### PR TITLE
feat(x): X.com browser-based publishing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Captured from the app running locally (`bun run dev` in `frontend/`, dark theme)
 
 ---
 
+## Active TODOs (WIP)
+
+- **Frontend wiring for X.com publishing**: Expose the X.com platform selector in the UI so users can create and schedule posts.
+- **Docker stateless integration**: Make sure the backend folder is properly integrated so the application can run statelessly in production without losing browser session data.
+- **Writing social account in database**: Persist the X.com auth session to the `social_account` DB table upon successful connection.
+
+---
+
 ## Quick start
 
 ```bash

--- a/backend/app/api/main.py
+++ b/backend/app/api/main.py
@@ -13,6 +13,7 @@ from app.api.routes import (
     trending,
     users,
     utils,
+    x_auth,
 )
 from app.core.config import settings
 
@@ -28,6 +29,7 @@ api_router.include_router(personas.router)
 api_router.include_router(teams.router)
 api_router.include_router(admin.router)
 api_router.include_router(trending.router)
+api_router.include_router(x_auth.router)
 
 
 if settings.ENVIRONMENT == "local":

--- a/backend/app/api/routes/x_auth.py
+++ b/backend/app/api/routes/x_auth.py
@@ -1,0 +1,84 @@
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlmodel import Session
+
+from app.api.deps import CurrentUser, SessionDep
+from app.services.access import get_persona_role
+from app.services.browser.manager import BrowserManager
+
+router = APIRouter(prefix="/auth/x", tags=["auth"])
+
+
+class XStatusResponse(BaseModel):
+    status: str  # "connected" or "disconnected"
+
+
+def _require_persona_role(
+    *,
+    session: Session,
+    user_id: uuid.UUID,
+    persona_id: uuid.UUID,
+) -> str:
+    role = get_persona_role(
+        session=session,
+        persona_id=persona_id,
+        user_id=user_id,
+    )
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not enough permissions",
+        )
+    return role
+
+
+@router.get("/status", response_model=XStatusResponse)
+def x_status(
+    *,
+    session: SessionDep,
+    current_user: CurrentUser,
+    persona_id: uuid.UUID = Query(...),
+) -> Any:
+    """Check if the X account is connected for the persona."""
+    _require_persona_role(
+        session=session,
+        user_id=current_user.id,
+        persona_id=persona_id,
+    )
+
+    manager = BrowserManager(brand_id=str(persona_id))
+    is_connected = manager.session_exists("x")
+    return XStatusResponse(status="connected" if is_connected else "disconnected")
+
+
+@router.post("/connect")
+def x_connect(
+    *,
+    session: SessionDep,
+    current_user: CurrentUser,
+    persona_id: uuid.UUID = Query(...),
+    force: bool = Query(False),
+) -> Any:
+    """Launch the headed browser for manual X.com login.
+
+    This spins up a subprocess. Only members/admins of the persona can do this.
+    """
+    _require_persona_role(
+        session=session,
+        user_id=current_user.id,
+        persona_id=persona_id,
+    )
+
+    manager = BrowserManager(brand_id=str(persona_id))
+    try:
+        manager.start_login_subprocess(platform_name="x", force=force)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    return {"message": "X login browser launched successfully."}

--- a/backend/app/api/routes/x_auth.py
+++ b/backend/app/api/routes/x_auth.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlmodel import Session
 
 from app.api.deps import CurrentUser, SessionDep
-from app.services.access import get_persona_role
+from app.services.access import get_persona_role, has_min_role
 from app.services.browser.manager import BrowserManager
 
 router = APIRouter(prefix="/auth/x", tags=["auth"])
@@ -21,6 +21,7 @@ def _require_persona_role(
     session: Session,
     user_id: uuid.UUID,
     persona_id: uuid.UUID,
+    minimum: str | None = None,
 ) -> str:
     role = get_persona_role(
         session=session,
@@ -31,6 +32,11 @@ def _require_persona_role(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not enough permissions",
+        )
+    if minimum and not has_min_role(role=role, minimum=minimum):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Not enough permissions (requires {minimum} role)",
         )
     return role
 
@@ -70,6 +76,7 @@ def x_connect(
         session=session,
         user_id=current_user.id,
         persona_id=persona_id,
+        minimum="admin",
     )
 
     manager = BrowserManager(brand_id=str(persona_id))

--- a/backend/app/services/browser/actions.py
+++ b/backend/app/services/browser/actions.py
@@ -159,21 +159,8 @@ class EvasionMouse:
 
         try:
             async with self.lock:
-                await self.page.wait_for_selector(selector, state="visible")
-
-                # Find all matching locators and pick the first visible one
-                locators = await self.page.locator(selector).all()
-                locator = None
-                for loc in locators:
-                    if await loc.is_visible():
-                        locator = loc
-                        break
-
-                if not locator:
-                    logger.warning(
-                        f"human_click: No visible element found for {selector}, falling back to .first"
-                    )
-                    locator = self.page.locator(selector).first
+                await self.page.wait_for_selector(f"{selector} >> visible=true")
+                locator = self.page.locator(f"{selector} >> visible=true").first
 
                 await locator.scroll_into_view_if_needed()
                 box = await locator.bounding_box()

--- a/backend/app/services/browser/manager.py
+++ b/backend/app/services/browser/manager.py
@@ -27,6 +27,20 @@ class BrowserManager:
     def __init__(self, brand_id: str = "default"):
         self.brand_id = brand_id
 
+    def session_exists(self, platform_name: str) -> bool:
+        """Check if a persistent session directory exists and contains cookies."""
+        if platform_name not in PLATFORMS:
+            raise ValueError(f"Unknown platform: {platform_name}")
+        session_dir = get_session_dir(self.brand_id, platform_name)
+        if not session_dir.exists():
+            return False
+
+        # Playwright creates the folder and skeletal files as soon as it launches,
+        # so checking if the directory is empty is insufficient. We check for cookies.
+        cookies_path = session_dir / "Default" / "Cookies"
+        network_cookies_path = session_dir / "Default" / "Network" / "Cookies"
+        return cookies_path.exists() or network_cookies_path.exists()
+
     def start_login_subprocess(self, platform_name: str, force: bool = False) -> None:
         """Launch a vanilla Chrome window for manual user login.
 

--- a/backend/app/services/browser/selectors/x_selectors.json
+++ b/backend/app/services/browser/selectors/x_selectors.json
@@ -1,7 +1,7 @@
 {
   "compose": {
     "post_input": "[data-testid=\"tweetTextarea_0\"], .public-DraftEditor-content",
-    "post_button": "[data-testid=\"tweetButtonInline\"], div[role=\"button\"]:has-text(\"Post\")",
+    "post_button": "[data-testid=\"tweetButtonInline\"]",
     "reply_button": "[data-testid=\"reply\"]"
   },
   "navigation": {

--- a/backend/app/services/publishing.py
+++ b/backend/app/services/publishing.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, select
 from app.models import Post, PublishErrorResponse, SocialAccount
 from app.services.linkedin_posts import LinkedInPostClient, LinkedInPostError
 from app.services.post_state_machine import validate_transition
+from app.services.x_posts import XPostClient
 
 logger = logging.getLogger(__name__)
 
@@ -42,15 +43,61 @@ def _linkedin_account_for_persona(
     return session.exec(statement).first()
 
 
-def _as_failure(*, err: LinkedInPostError) -> PublishFailure:
+def _handle_publish_error(
+    *, session: Session, post: Post, user_id: uuid.UUID, err: Exception
+) -> PublishFailure:
+    validate_transition(current_status=post.status, target_status="failed")
+    post.status = "failed"
+
+    if hasattr(err, "code") and hasattr(err, "detail") and hasattr(err, "retryable"):
+        code = err.code
+        detail = str(err.detail)
+        retryable = err.retryable
+        details = getattr(err, "details", {})
+        trace_id = getattr(err, "trace_id", str(uuid.uuid4()))
+        status_code = getattr(err, "status_code", 500)
+    else:
+        code = "internal_error"
+        detail = f"Unexpected system error: {err}"
+        retryable = False
+        details = {}
+        trace_id = str(uuid.uuid4())
+        status_code = 500
+
+    post.error_code = code
+    post.error_message = detail
+
+    if retryable and post.retry_count < MAX_RETRIES:
+        post.retry_count += 1
+        post.last_retry_at = _now_utc()
+        post.next_retry_at = _next_retry_time(retry_count=post.retry_count)
+    else:
+        post.next_retry_at = None
+
+    post.updated_at = _now_utc()
+    session.add(post)
+    session.commit()
+    session.refresh(post)
+
+    logger.warning(
+        "publish_failed post_id=%s persona_id=%s user_id=%s status=%s trace_id=%s code=%s retryable=%s",
+        post.id,
+        post.persona_id,
+        user_id,
+        post.status,
+        trace_id,
+        code,
+        retryable,
+    )
+
     return PublishFailure(
-        status_code=err.status_code,
+        status_code=status_code,
         payload=PublishErrorResponse(
-            error=err.code,
-            message=str(err.detail),
-            retryable=err.retryable,
-            details=err.details,
-            trace_id=err.trace_id,
+            error=code,
+            message=detail,
+            retryable=retryable,
+            details=details,
+            trace_id=trace_id,
         ),
     )
 
@@ -69,7 +116,9 @@ async def publish_post(
             retryable=False,
             details={"platform": "linkedin"},
         )
-        return _as_failure(err=failure)
+        return _handle_publish_error(
+            session=session, post=post, user_id=user_id, err=failure
+        )
 
     if post.external_post_id:
         if post.status != "published":
@@ -93,61 +142,47 @@ async def publish_post(
     session.commit()
     session.refresh(post)
 
-    linkedin_account = _linkedin_account_for_persona(
-        session=session,
-        persona_id=post.persona_id,
-    )
-    if not linkedin_account or not linkedin_account.external_user_id:
-        err = LinkedInPostError(
-            status_code=400,
-            detail="LinkedIn account not connected for this persona",
-            code="linkedin_not_connected",
-            retryable=False,
-            details={"platform": "linkedin"},
+    if post.platform == "linkedin":
+        linkedin_account = _linkedin_account_for_persona(
+            session=session,
+            persona_id=post.persona_id,
         )
-        validate_transition(current_status=post.status, target_status="failed")
-        post.status = "failed"
-        post.error_code = err.code
-        post.error_message = str(err.detail)
-        post.updated_at = _now_utc()
-        session.add(post)
-        session.commit()
-        session.refresh(post)
-        return _as_failure(err=err)
+        if not linkedin_account or not linkedin_account.external_user_id:
+            err = LinkedInPostError(
+                status_code=400,
+                detail="LinkedIn account not connected for this persona",
+                code="linkedin_not_connected",
+                retryable=False,
+                details={"platform": "linkedin"},
+            )
+            return _handle_publish_error(
+                session=session, post=post, user_id=user_id, err=err
+            )
 
-    try:
-        client = LinkedInPostClient()
-        external_post_id = await client.create_text_post(
-            persona_id=str(post.persona_id),
-            linkedin_person_id=linkedin_account.external_user_id,
-            content=post.content,
-        )
-    except LinkedInPostError as err:
-        validate_transition(current_status=post.status, target_status="failed")
-        post.status = "failed"
-        post.error_code = err.code
-        post.error_message = str(err.detail)
-        if err.retryable and post.retry_count < MAX_RETRIES:
-            post.retry_count += 1
-            post.last_retry_at = _now_utc()
-            post.next_retry_at = _next_retry_time(retry_count=post.retry_count)
-        else:
-            post.next_retry_at = None
-        post.updated_at = _now_utc()
-        session.add(post)
-        session.commit()
-        session.refresh(post)
-        logger.warning(
-            "publish_failed post_id=%s persona_id=%s user_id=%s status=%s trace_id=%s code=%s retryable=%s",
-            post.id,
-            post.persona_id,
-            user_id,
-            post.status,
-            err.trace_id,
-            err.code,
-            err.retryable,
-        )
-        return _as_failure(err=err)
+        try:
+            client = LinkedInPostClient()
+            external_post_id = await client.create_text_post(
+                persona_id=str(post.persona_id),
+                linkedin_person_id=linkedin_account.external_user_id,
+                content=post.content,
+            )
+        except Exception as err:
+            return _handle_publish_error(
+                session=session, post=post, user_id=user_id, err=err
+            )
+    elif post.platform == "x":
+        try:
+            x_client = XPostClient()
+            external_post_id = await x_client.create_text_post(
+                persona_id=str(post.persona_id),
+                content=post.content,
+            )
+        except Exception as err:
+            return _handle_publish_error(
+                session=session, post=post, user_id=user_id, err=err
+            )
+    else:
+        raise ValueError(f"Unsupported platform: {post.platform}")
 
     validate_transition(current_status=post.status, target_status="published")
     post.status = "published"

--- a/backend/app/services/publishing.py
+++ b/backend/app/services/publishing.py
@@ -182,7 +182,10 @@ async def publish_post(
                 session=session, post=post, user_id=user_id, err=err
             )
     else:
-        raise ValueError(f"Unsupported platform: {post.platform}")
+        err = ValueError(f"Unsupported platform: {post.platform}")
+        return _handle_publish_error(
+            session=session, post=post, user_id=user_id, err=err
+        )
 
     validate_transition(current_status=post.status, target_status="published")
     post.status = "published"

--- a/backend/app/services/publishing.py
+++ b/backend/app/services/publishing.py
@@ -49,20 +49,15 @@ def _handle_publish_error(
     validate_transition(current_status=post.status, target_status="failed")
     post.status = "failed"
 
-    if hasattr(err, "code") and hasattr(err, "detail") and hasattr(err, "retryable"):
-        code = err.code
-        detail = str(err.detail)
-        retryable = err.retryable
-        details = getattr(err, "details", {})
-        trace_id = getattr(err, "trace_id", str(uuid.uuid4()))
-        status_code = getattr(err, "status_code", 500)
-    else:
-        code = "internal_error"
-        detail = f"Unexpected system error: {err}"
-        retryable = False
-        details = {}
-        trace_id = str(uuid.uuid4())
-        status_code = 500
+    # Use duck-typing to extract structured error fields if available
+    is_structured = hasattr(err, "code") and hasattr(err, "detail")
+    
+    code = getattr(err, "code", "internal_error") if is_structured else "internal_error"
+    detail = str(getattr(err, "detail", f"Unexpected system error: {err}"))
+    retryable = getattr(err, "retryable", False) if is_structured else False
+    details = getattr(err, "details", {}) if is_structured else {}
+    trace_id = getattr(err, "trace_id", str(uuid.uuid4()))
+    status_code = getattr(err, "status_code", 500) if is_structured else 500
 
     post.error_code = code
     post.error_message = detail
@@ -121,17 +116,19 @@ async def publish_post(
         )
 
     if post.external_post_id:
-        if post.status != "published":
-            validate_transition(current_status=post.status, target_status="published")
-            post.status = "published"
-            post.published_at = post.published_at or _now_utc()
-            post.error_code = None
-            post.error_message = None
-            post.next_retry_at = None
-            post.updated_at = _now_utc()
-            session.add(post)
-            session.commit()
-            session.refresh(post)
+        if post.status == "published":
+            return None
+            
+        validate_transition(current_status=post.status, target_status="published")
+        post.status = "published"
+        post.published_at = post.published_at or _now_utc()
+        post.error_code = None
+        post.error_message = None
+        post.next_retry_at = None
+        post.updated_at = _now_utc()
+        session.add(post)
+        session.commit()
+        session.refresh(post)
         return None
 
     validate_transition(current_status=post.status, target_status="publishing")

--- a/backend/app/services/publishing.py
+++ b/backend/app/services/publishing.py
@@ -97,48 +97,9 @@ def _handle_publish_error(
     )
 
 
-async def publish_post(
-    *,
-    session: Session,
-    post: Post,
-    user_id: uuid.UUID,
-) -> PublishFailure | None:
-    if post.persona_id is None:
-        failure = LinkedInPostError(
-            status_code=400,
-            detail="persona_id is required",
-            code="persona_required",
-            retryable=False,
-            details={"platform": "linkedin"},
-        )
-        return _handle_publish_error(
-            session=session, post=post, user_id=user_id, err=failure
-        )
-
-    if post.external_post_id:
-        if post.status == "published":
-            return None
-            
-        validate_transition(current_status=post.status, target_status="published")
-        post.status = "published"
-        post.published_at = post.published_at or _now_utc()
-        post.error_code = None
-        post.error_message = None
-        post.next_retry_at = None
-        post.updated_at = _now_utc()
-        session.add(post)
-        session.commit()
-        session.refresh(post)
-        return None
-
-    validate_transition(current_status=post.status, target_status="publishing")
-    post.status = "publishing"
-    post.publishing_started_at = _now_utc()
-    post.updated_at = _now_utc()
-    session.add(post)
-    session.commit()
-    session.refresh(post)
-
+async def _publish_to_platform(
+    session: Session, post: Post, user_id: uuid.UUID
+) -> str | PublishFailure:
     if post.platform == "linkedin":
         linkedin_account = _linkedin_account_for_persona(
             session=session,
@@ -158,7 +119,7 @@ async def publish_post(
 
         try:
             client = LinkedInPostClient()
-            external_post_id = await client.create_text_post(
+            return await client.create_text_post(
                 persona_id=str(post.persona_id),
                 linkedin_person_id=linkedin_account.external_user_id,
                 content=post.content,
@@ -170,7 +131,7 @@ async def publish_post(
     elif post.platform == "x":
         try:
             x_client = XPostClient()
-            external_post_id = await x_client.create_text_post(
+            return await x_client.create_text_post(
                 persona_id=str(post.persona_id),
                 content=post.content,
             )
@@ -184,10 +145,11 @@ async def publish_post(
             session=session, post=post, user_id=user_id, err=err
         )
 
+def _mark_as_published(session: Session, post: Post, external_post_id: str) -> None:
     validate_transition(current_status=post.status, target_status="published")
     post.status = "published"
     post.external_post_id = external_post_id
-    post.published_at = _now_utc()
+    post.published_at = post.published_at or _now_utc()
     post.error_code = None
     post.error_message = None
     post.next_retry_at = None
@@ -195,6 +157,45 @@ async def publish_post(
     session.add(post)
     session.commit()
     session.refresh(post)
+
+async def publish_post(
+    *,
+    session: Session,
+    post: Post,
+    user_id: uuid.UUID,
+) -> PublishFailure | None:
+    if post.persona_id is None:
+        # We default to LinkedInPostError for legacy reasons, but this catches all
+        failure = LinkedInPostError(
+            status_code=400,
+            detail="persona_id is required",
+            code="persona_required",
+            retryable=False,
+            details={"platform": post.platform},
+        )
+        return _handle_publish_error(
+            session=session, post=post, user_id=user_id, err=failure
+        )
+
+    if post.external_post_id:
+        if post.status == "published":
+            return None
+        _mark_as_published(session, post, post.external_post_id)
+        return None
+
+    validate_transition(current_status=post.status, target_status="publishing")
+    post.status = "publishing"
+    post.publishing_started_at = _now_utc()
+    post.updated_at = _now_utc()
+    session.add(post)
+    session.commit()
+    session.refresh(post)
+
+    result = await _publish_to_platform(session, post, user_id)
+    if isinstance(result, PublishFailure):
+        return result
+
+    _mark_as_published(session, post, result)
     logger.info(
         "publish_success post_id=%s persona_id=%s user_id=%s status=%s",
         post.id,

--- a/backend/app/services/publishing.py
+++ b/backend/app/services/publishing.py
@@ -97,53 +97,62 @@ def _handle_publish_error(
     )
 
 
+async def _publish_linkedin(session: Session, post: Post, user_id: uuid.UUID) -> str | PublishFailure:
+    linkedin_account = _linkedin_account_for_persona(
+        session=session,
+        persona_id=post.persona_id,
+    )
+    if not linkedin_account or not linkedin_account.external_user_id:
+        err = LinkedInPostError(
+            status_code=400,
+            detail="LinkedIn account not connected for this persona",
+            code="linkedin_not_connected",
+            retryable=False,
+            details={"platform": "linkedin"},
+        )
+        return _handle_publish_error(
+            session=session, post=post, user_id=user_id, err=err
+        )
+
+    try:
+        client = LinkedInPostClient()
+        return await client.create_text_post(
+            persona_id=str(post.persona_id),
+            linkedin_person_id=linkedin_account.external_user_id,
+            content=post.content,
+        )
+    except Exception as err:
+        return _handle_publish_error(
+            session=session, post=post, user_id=user_id, err=err
+        )
+
+async def _publish_x(session: Session, post: Post, user_id: uuid.UUID) -> str | PublishFailure:
+    try:
+        x_client = XPostClient()
+        return await x_client.create_text_post(
+            persona_id=str(post.persona_id),
+            content=post.content,
+        )
+    except Exception as err:
+        return _handle_publish_error(
+            session=session, post=post, user_id=user_id, err=err
+        )
+
+_PLATFORM_PUBLISHERS = {
+    "linkedin": _publish_linkedin,
+    "x": _publish_x,
+}
+
 async def _publish_to_platform(
     session: Session, post: Post, user_id: uuid.UUID
 ) -> str | PublishFailure:
-    if post.platform == "linkedin":
-        linkedin_account = _linkedin_account_for_persona(
-            session=session,
-            persona_id=post.persona_id,
-        )
-        if not linkedin_account or not linkedin_account.external_user_id:
-            err = LinkedInPostError(
-                status_code=400,
-                detail="LinkedIn account not connected for this persona",
-                code="linkedin_not_connected",
-                retryable=False,
-                details={"platform": "linkedin"},
-            )
-            return _handle_publish_error(
-                session=session, post=post, user_id=user_id, err=err
-            )
-
-        try:
-            client = LinkedInPostClient()
-            return await client.create_text_post(
-                persona_id=str(post.persona_id),
-                linkedin_person_id=linkedin_account.external_user_id,
-                content=post.content,
-            )
-        except Exception as err:
-            return _handle_publish_error(
-                session=session, post=post, user_id=user_id, err=err
-            )
-    elif post.platform == "x":
-        try:
-            x_client = XPostClient()
-            return await x_client.create_text_post(
-                persona_id=str(post.persona_id),
-                content=post.content,
-            )
-        except Exception as err:
-            return _handle_publish_error(
-                session=session, post=post, user_id=user_id, err=err
-            )
-    else:
+    publisher = _PLATFORM_PUBLISHERS.get(post.platform)
+    if not publisher:
         err = ValueError(f"Unsupported platform: {post.platform}")
         return _handle_publish_error(
             session=session, post=post, user_id=user_id, err=err
         )
+    return await publisher(session, post, user_id)
 
 def _mark_as_published(session: Session, post: Post, external_post_id: str) -> None:
     validate_transition(current_status=post.status, target_status="published")

--- a/backend/app/services/x_posts.py
+++ b/backend/app/services/x_posts.py
@@ -1,0 +1,256 @@
+import asyncio
+import json
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException, status
+from rebrowser_playwright.async_api import Error as PlaywrightError
+from rebrowser_playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+from app.services.browser.actions import (
+    EvasionMouse,
+    PostButtonDisabledError,
+    random_delay,
+)
+from app.services.browser.manager import BrowserManager
+
+logger = logging.getLogger(__name__)
+
+
+class XPostError(HTTPException):
+    """Specialized error for X.com post operations."""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        detail: str,
+        code: str = "x_publish_failed",
+        retryable: bool = False,
+        details: dict[str, Any] | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        self.code = code
+        self.retryable = retryable
+        self.details = details or {}
+        self.trace_id = trace_id or str(uuid.uuid4())
+        super().__init__(status_code=status_code, detail=detail)
+
+
+class XPostClient:
+    """Client for posting to X.com using browser automation."""
+
+    def __init__(self) -> None:
+        self.selectors_path = (
+            Path(__file__).parent / "browser" / "selectors" / "x_selectors.json"
+        )
+        if not self.selectors_path.exists():
+            raise RuntimeError(f"Missing X selectors at {self.selectors_path}")
+
+        with open(self.selectors_path) as f:
+            self.selectors = json.load(f)
+
+    async def create_text_post(
+        self,
+        *,
+        persona_id: str,
+        content: str,
+    ) -> str:
+        """Create a text-only post on X.com using Playwright.
+
+        Returns the X.com tweet ID (rest_id).
+        """
+        if len(content) > 280:
+            raise XPostError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Post content exceeds X.com's 280 character limit.",
+                code="x_content_too_long",
+                retryable=False,
+                details={"platform": "x", "length": len(content)},
+            )
+
+        manager = BrowserManager(brand_id=persona_id)
+
+        if not manager.session_exists("x"):
+            raise XPostError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="X session not found. Please connect X account.",
+                code="x_not_connected",
+                retryable=False,
+                details={"platform": "x"},
+            )
+
+        post_input_selector = self.selectors["compose"]["post_input"]
+        post_button_selector = self.selectors["compose"]["post_button"]
+
+        try:
+            async with manager.get_context(
+                "x", headless=(os.environ.get("PLAYWRIGHT_HEADLESS", "1") == "1")
+            ) as context:
+                page = context.pages[0] if context.pages else await context.new_page()
+                mouse = EvasionMouse(page)
+                asyncio.create_task(mouse.start_idle())
+
+                logger.info("Navigating to https://x.com/home")
+                await page.goto("https://x.com/home", wait_until="domcontentloaded")
+
+                # Sentinel Check: Wait for the URL to stabilize to either /home or a checkpoint
+                try:
+                    await page.wait_for_url(
+                        lambda url: "home" in url
+                        or "checkpoint" in url
+                        or "login" in url,
+                        timeout=10000,
+                    )
+                except PlaywrightTimeoutError:
+                    pass  # If it times out, we'll just check current_url next anyway
+
+                current_url = page.url
+                if "/home" not in current_url:
+                    await mouse.stop_idle()
+                    body = await page.inner_text("body")
+                    if (
+                        "Help us keep Twitter safe" in body
+                        or "Confirm your phone number" in body
+                        or "checkpoint" in current_url
+                    ):
+                        raise XPostError(
+                            status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="X session flagged by security checkpoint. Please re-login.",
+                            code="x_session_flagged",
+                            retryable=False,
+                            details={"platform": "x", "url": current_url},
+                        )
+                    raise XPostError(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="X session expired or invalid. Please re-login.",
+                        code="x_session_expired",
+                        retryable=False,
+                        details={"platform": "x", "url": current_url},
+                    )
+
+                logger.info(
+                    "Sentinel check passed (URL routing confirmed), proceeding with post."
+                )
+                await random_delay(min_sec=2.0, max_sec=4.0)
+
+                logger.info(
+                    f"Targeting post input box using selector: {post_input_selector}"
+                )
+                await mouse.human_click(selector=post_input_selector)
+
+                logger.info("Typing draft post")
+                await mouse.human_type(
+                    selector=post_input_selector, text=content, wpm=90.0
+                )
+
+                await random_delay(min_sec=1.0, max_sec=2.0)
+
+                logger.info(
+                    "Setting up network interceptor for CreateTweet GraphQL endpoint..."
+                )
+                try:
+                    async with page.expect_response(
+                        lambda response: "graphql" in response.url
+                        and "CreateTweet" in response.url
+                        and response.request.method == "POST",
+                        timeout=15000,
+                    ) as response_info:
+                        await mouse.human_click(selector=post_button_selector)
+
+                    response = await response_info.value
+
+                    if response.status != 200:
+                        raise XPostError(
+                            status_code=status.HTTP_502_BAD_GATEWAY,
+                            detail=f"X.com returned HTTP {response.status}",
+                            code="x_network_error",
+                            retryable=True,
+                            details={"platform": "x"},
+                        )
+
+                    response_json = await response.json()
+                    if "errors" in response_json:
+                        logger.error(
+                            f"GraphQL returned errors: {json.dumps(response_json['errors'])}"
+                        )
+                        raise XPostError(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="GraphQL application-level error during post.",
+                            code="x_graphql_error",
+                            retryable=False,
+                            details={
+                                "platform": "x",
+                                "errors": response_json["errors"],
+                            },
+                        )
+
+                    rest_id = None
+                    try:
+                        rest_id = response_json["data"]["create_tweet"][
+                            "tweet_results"
+                        ]["result"]["rest_id"]
+                    except (KeyError, TypeError):
+                        pass
+
+                    if not rest_id:
+                        raise XPostError(
+                            status_code=status.HTTP_502_BAD_GATEWAY,
+                            detail="X.com did not return a tweet ID.",
+                            code="x_missing_post_id",
+                            retryable=True,
+                            details={"platform": "x"},
+                        )
+
+                    await mouse.stop_idle()
+                    logger.info(f"✅ SUCCESSFULLY POSTED TO X (rest_id: {rest_id})")
+                    return str(rest_id)
+
+                except PostButtonDisabledError:
+                    await mouse.stop_idle()
+                    raise XPostError(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="The Post button remained disabled. Content may be too long or invalid.",
+                        code="x_button_disabled",
+                        retryable=False,
+                        details={"platform": "x"},
+                    )
+                except PlaywrightTimeoutError:
+                    await mouse.stop_idle()
+                    raise XPostError(
+                        status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                        detail="Timeout waiting for CreateTweet network response.",
+                        code="x_timeout",
+                        retryable=True,
+                        details={"platform": "x"},
+                    )
+
+        except XPostError:
+            raise
+        except PlaywrightError as e:
+            if "closed" in str(e).lower():
+                raise XPostError(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Browser window was closed manually.",
+                    code="x_browser_closed",
+                    retryable=False,
+                    details={"platform": "x"},
+                )
+            raise XPostError(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Browser automation error: {e}",
+                code="x_automation_error",
+                retryable=True,
+                details={"platform": "x"},
+            )
+        except Exception as e:
+            raise XPostError(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Unexpected error: {e}",
+                code="x_internal_error",
+                retryable=False,
+                details={"platform": "x"},
+            )

--- a/backend/app/services/x_posts.py
+++ b/backend/app/services/x_posts.py
@@ -51,16 +51,13 @@ class XPostClient:
         with open(self.selectors_path) as f:
             self.selectors = json.load(f)
 
-    async def create_text_post(
-        self,
-        *,
-        persona_id: str,
-        content: str,
-    ) -> str:
-        """Create a text-only post on X.com using Playwright.
+    async def create_text_post(self, *, persona_id: str, content: str) -> str:
+        """Create a text-only post on X.com using Playwright."""
+        self._validate_content(content)
+        manager = self._get_manager(persona_id)
+        return await self._execute_post_flow(manager, content)
 
-        Returns the X.com tweet ID (rest_id).
-        """
+    def _validate_content(self, content: str) -> None:
         normalized_content = normalize_post_text(content)
         if len(normalized_content) > 280:
             raise XPostError(
@@ -71,8 +68,8 @@ class XPostClient:
                 details={"platform": "x", "length": len(content)},
             )
 
+    def _get_manager(self, persona_id: str) -> BrowserManager:
         manager = BrowserManager(brand_id=persona_id)
-
         if not manager.session_exists("x"):
             raise XPostError(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -81,7 +78,9 @@ class XPostClient:
                 retryable=False,
                 details={"platform": "x"},
             )
+        return manager
 
+    async def _execute_post_flow(self, manager: BrowserManager, content: str) -> str:
         try:
             async with manager.get_context(
                 "x", headless=(os.environ.get("PLAYWRIGHT_HEADLESS", "1") == "1")
@@ -91,52 +90,64 @@ class XPostClient:
                 asyncio.create_task(mouse.start_idle())
 
                 await self._perform_sentinel_check(page, mouse)
-                rest_id = await self._type_and_publish(page, mouse, content)
-                return rest_id
+                return await self._type_and_publish(page, mouse, content)
 
         except XPostError:
             raise
         except PlaywrightError as e:
-            if "closed" in str(e).lower():
-                raise XPostError(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="Browser window was closed manually.",
-                    code="x_browser_closed",
-                    retryable=False,
-                    details={"platform": "x"},
-                )
-            raise XPostError(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Browser automation error: {e}",
-                code="x_automation_error",
-                retryable=True,
-                details={"platform": "x"},
-            )
+            self._handle_playwright_error(e)
+            return ""
         except Exception as e:
+            self._handle_unexpected_error(e)
+            return ""
+
+    def _handle_playwright_error(self, e: PlaywrightError) -> None:
+        if "closed" in str(e).lower():
             raise XPostError(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Unexpected error: {e}",
-                code="x_internal_error",
+                detail="Browser window was closed manually.",
+                code="x_browser_closed",
                 retryable=False,
                 details={"platform": "x"},
             )
+        raise XPostError(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Browser automation error: {e}",
+            code="x_automation_error",
+            retryable=True,
+            details={"platform": "x"},
+        )
+
+    def _handle_unexpected_error(self, e: Exception) -> None:
+        raise XPostError(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {e}",
+            code="x_internal_error",
+            retryable=False,
+            details={"platform": "x"},
+        )
 
     async def _perform_sentinel_check(self, page: Any, mouse: EvasionMouse) -> None:
+        await self._navigate_to_home(page)
+        body = await page.inner_text("body")
+        await self._verify_valid_url(page.url, body, mouse)
+        logger.info("Sentinel check passed (URL routing confirmed), proceeding with post.")
+        await random_delay(min_sec=2.0, max_sec=4.0)
+
+    async def _navigate_to_home(self, page: Any) -> None:
         logger.info("Navigating to https://x.com/home")
         await page.goto("https://x.com/home", wait_until="domcontentloaded")
-
         try:
             await page.wait_for_url(
                 lambda url: "home" in url or "checkpoint" in url or "login" in url,
                 timeout=10000,
             )
         except PlaywrightTimeoutError:
-            pass  # Fallback to checking current_url directly
+            pass
 
-        current_url = page.url
+    async def _verify_valid_url(self, current_url: str, body: str, mouse: EvasionMouse) -> None:
         if "/home" not in current_url:
             await mouse.stop_idle()
-            body = await page.inner_text("body")
             if (
                 "Help us keep Twitter safe" in body
                 or "Confirm your phone number" in body
@@ -156,22 +167,22 @@ class XPostClient:
                 retryable=False,
                 details={"platform": "x", "url": current_url},
             )
-        
-        logger.info("Sentinel check passed (URL routing confirmed), proceeding with post.")
-        await random_delay(min_sec=2.0, max_sec=4.0)
 
     async def _type_and_publish(self, page: Any, mouse: EvasionMouse, content: str) -> str:
-        post_input_selector = self.selectors["compose"]["post_input"]
-        post_button_selector = self.selectors["compose"]["post_button"]
+        await self._fill_post_content(mouse, content)
+        return await self._click_publish_and_wait(page, mouse)
 
+    async def _fill_post_content(self, mouse: EvasionMouse, content: str) -> None:
+        post_input_selector = self.selectors["compose"]["post_input"]
         logger.info(f"Targeting post input box using selector: {post_input_selector}")
         await mouse.human_click(selector=post_input_selector)
 
         logger.info("Typing draft post")
         await mouse.human_type(selector=post_input_selector, text=content, wpm=90.0)
-
         await random_delay(min_sec=1.0, max_sec=2.0)
 
+    async def _click_publish_and_wait(self, page: Any, mouse: EvasionMouse) -> str:
+        post_button_selector = self.selectors["compose"]["post_button"]
         logger.info("Setting up network interceptor for CreateTweet GraphQL endpoint...")
         try:
             async with page.expect_response(

--- a/backend/app/services/x_posts.py
+++ b/backend/app/services/x_posts.py
@@ -82,9 +82,6 @@ class XPostClient:
                 details={"platform": "x"},
             )
 
-        post_input_selector = self.selectors["compose"]["post_input"]
-        post_button_selector = self.selectors["compose"]["post_button"]
-
         try:
             async with manager.get_context(
                 "x", headless=(os.environ.get("PLAYWRIGHT_HEADLESS", "1") == "1")
@@ -93,139 +90,9 @@ class XPostClient:
                 mouse = EvasionMouse(page)
                 asyncio.create_task(mouse.start_idle())
 
-                logger.info("Navigating to https://x.com/home")
-                await page.goto("https://x.com/home", wait_until="domcontentloaded")
-
-                # Sentinel Check: Wait for the URL to stabilize to either /home or a checkpoint
-                try:
-                    await page.wait_for_url(
-                        lambda url: "home" in url
-                        or "checkpoint" in url
-                        or "login" in url,
-                        timeout=10000,
-                    )
-                except PlaywrightTimeoutError:
-                    pass  # If it times out, we'll just check current_url next anyway
-
-                current_url = page.url
-                if "/home" not in current_url:
-                    await mouse.stop_idle()
-                    body = await page.inner_text("body")
-                    if (
-                        "Help us keep Twitter safe" in body
-                        or "Confirm your phone number" in body
-                        or "checkpoint" in current_url
-                    ):
-                        raise XPostError(
-                            status_code=status.HTTP_401_UNAUTHORIZED,
-                            detail="X session flagged by security checkpoint. Please re-login.",
-                            code="x_session_flagged",
-                            retryable=False,
-                            details={"platform": "x", "url": current_url},
-                        )
-                    raise XPostError(
-                        status_code=status.HTTP_401_UNAUTHORIZED,
-                        detail="X session expired or invalid. Please re-login.",
-                        code="x_session_expired",
-                        retryable=False,
-                        details={"platform": "x", "url": current_url},
-                    )
-
-                logger.info(
-                    "Sentinel check passed (URL routing confirmed), proceeding with post."
-                )
-                await random_delay(min_sec=2.0, max_sec=4.0)
-
-                logger.info(
-                    f"Targeting post input box using selector: {post_input_selector}"
-                )
-                await mouse.human_click(selector=post_input_selector)
-
-                logger.info("Typing draft post")
-                await mouse.human_type(
-                    selector=post_input_selector, text=content, wpm=90.0
-                )
-
-                await random_delay(min_sec=1.0, max_sec=2.0)
-
-                logger.info(
-                    "Setting up network interceptor for CreateTweet GraphQL endpoint..."
-                )
-                try:
-                    async with page.expect_response(
-                        lambda response: "graphql" in response.url
-                        and "CreateTweet" in response.url
-                        and response.request.method == "POST",
-                        timeout=15000,
-                    ) as response_info:
-                        await mouse.human_click(selector=post_button_selector)
-
-                    response = await response_info.value
-
-                    if response.status != 200:
-                        raise XPostError(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail=f"X.com returned HTTP {response.status}",
-                            code="x_network_error",
-                            retryable=True,
-                            details={"platform": "x"},
-                        )
-
-                    response_json = await response.json()
-                    if "errors" in response_json:
-                        logger.error(
-                            f"GraphQL returned errors: {json.dumps(response_json['errors'])}"
-                        )
-                        raise XPostError(
-                            status_code=status.HTTP_400_BAD_REQUEST,
-                            detail="GraphQL application-level error during post.",
-                            code="x_graphql_error",
-                            retryable=False,
-                            details={
-                                "platform": "x",
-                                "errors": response_json["errors"],
-                            },
-                        )
-
-                    rest_id = None
-                    try:
-                        rest_id = response_json["data"]["create_tweet"][
-                            "tweet_results"
-                        ]["result"]["rest_id"]
-                    except (KeyError, TypeError):
-                        pass
-
-                    if not rest_id:
-                        raise XPostError(
-                            status_code=status.HTTP_502_BAD_GATEWAY,
-                            detail="X.com did not return a tweet ID.",
-                            code="x_missing_post_id",
-                            retryable=True,
-                            details={"platform": "x"},
-                        )
-
-                    await mouse.stop_idle()
-                    logger.info(f"✅ SUCCESSFULLY POSTED TO X (rest_id: {rest_id})")
-                    return str(rest_id)
-
-                except PostButtonDisabledError:
-                    await mouse.stop_idle()
-                    raise XPostError(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail="The Post button remained disabled. Content may be too long or invalid.",
-                        code="x_button_disabled",
-                        retryable=False,
-                        details={"platform": "x"},
-                    )
-                except PlaywrightTimeoutError:
-                    await mouse.stop_idle()
-                    raise XPostError(
-                        status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-                        detail="Timeout waiting for CreateTweet network response.",
-                        code="x_timeout",
-                        retryable=True,
-                        details={"platform": "x"},
-                    )
+                await self._perform_sentinel_check(page, mouse)
+                rest_id = await self._type_and_publish(page, mouse, content)
+                return rest_id
 
         except XPostError:
             raise
@@ -253,3 +120,126 @@ class XPostClient:
                 retryable=False,
                 details={"platform": "x"},
             )
+
+    async def _perform_sentinel_check(self, page: Any, mouse: EvasionMouse) -> None:
+        logger.info("Navigating to https://x.com/home")
+        await page.goto("https://x.com/home", wait_until="domcontentloaded")
+
+        try:
+            await page.wait_for_url(
+                lambda url: "home" in url or "checkpoint" in url or "login" in url,
+                timeout=10000,
+            )
+        except PlaywrightTimeoutError:
+            pass  # Fallback to checking current_url directly
+
+        current_url = page.url
+        if "/home" not in current_url:
+            await mouse.stop_idle()
+            body = await page.inner_text("body")
+            if (
+                "Help us keep Twitter safe" in body
+                or "Confirm your phone number" in body
+                or "checkpoint" in current_url
+            ):
+                raise XPostError(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="X session flagged by security checkpoint. Please re-login.",
+                    code="x_session_flagged",
+                    retryable=False,
+                    details={"platform": "x", "url": current_url},
+                )
+            raise XPostError(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="X session expired or invalid. Please re-login.",
+                code="x_session_expired",
+                retryable=False,
+                details={"platform": "x", "url": current_url},
+            )
+        
+        logger.info("Sentinel check passed (URL routing confirmed), proceeding with post.")
+        await random_delay(min_sec=2.0, max_sec=4.0)
+
+    async def _type_and_publish(self, page: Any, mouse: EvasionMouse, content: str) -> str:
+        post_input_selector = self.selectors["compose"]["post_input"]
+        post_button_selector = self.selectors["compose"]["post_button"]
+
+        logger.info(f"Targeting post input box using selector: {post_input_selector}")
+        await mouse.human_click(selector=post_input_selector)
+
+        logger.info("Typing draft post")
+        await mouse.human_type(selector=post_input_selector, text=content, wpm=90.0)
+
+        await random_delay(min_sec=1.0, max_sec=2.0)
+
+        logger.info("Setting up network interceptor for CreateTweet GraphQL endpoint...")
+        try:
+            async with page.expect_response(
+                lambda response: "graphql" in response.url
+                and "CreateTweet" in response.url
+                and response.request.method == "POST",
+                timeout=15000,
+            ) as response_info:
+                await mouse.human_click(selector=post_button_selector)
+
+            response = await response_info.value
+            return await self._parse_graphql_response(response, mouse)
+
+        except PostButtonDisabledError:
+            await mouse.stop_idle()
+            raise XPostError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="The Post button remained disabled. Content may be too long or invalid.",
+                code="x_button_disabled",
+                retryable=False,
+                details={"platform": "x"},
+            )
+        except PlaywrightTimeoutError:
+            await mouse.stop_idle()
+            raise XPostError(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="Timeout waiting for CreateTweet network response.",
+                code="x_timeout",
+                retryable=True,
+                details={"platform": "x"},
+            )
+
+    async def _parse_graphql_response(self, response: Any, mouse: EvasionMouse) -> str:
+        if response.status != 200:
+            raise XPostError(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"X.com returned HTTP {response.status}",
+                code="x_network_error",
+                retryable=True,
+                details={"platform": "x"},
+            )
+
+        response_json = await response.json()
+        if "errors" in response_json:
+            logger.error(f"GraphQL returned errors: {json.dumps(response_json['errors'])}")
+            raise XPostError(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="GraphQL application-level error during post.",
+                code="x_graphql_error",
+                retryable=False,
+                details={"platform": "x", "errors": response_json["errors"]},
+            )
+
+        rest_id = None
+        try:
+            rest_id = response_json["data"]["create_tweet"]["tweet_results"]["result"]["rest_id"]
+        except (KeyError, TypeError):
+            pass
+
+        if not rest_id:
+            raise XPostError(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="X.com did not return a tweet ID.",
+                code="x_missing_post_id",
+                retryable=True,
+                details={"platform": "x"},
+            )
+
+        await mouse.stop_idle()
+        logger.info(f"✅ SUCCESSFULLY POSTED TO X (rest_id: {rest_id})")
+        return str(rest_id)

--- a/backend/app/services/x_posts.py
+++ b/backend/app/services/x_posts.py
@@ -29,15 +29,12 @@ class XPostError(HTTPException):
         *,
         status_code: int,
         detail: str,
-        code: str = "x_publish_failed",
-        retryable: bool = False,
-        details: dict[str, Any] | None = None,
-        trace_id: str | None = None,
+        **kwargs: Any,
     ) -> None:
-        self.code = code
-        self.retryable = retryable
-        self.details = details or {}
-        self.trace_id = trace_id or str(uuid.uuid4())
+        self.code = kwargs.get("code", "x_publish_failed")
+        self.retryable = kwargs.get("retryable", False)
+        self.details = kwargs.get("details", {})
+        self.trace_id = kwargs.get("trace_id", str(uuid.uuid4()))
         super().__init__(status_code=status_code, detail=detail)
 
 

--- a/backend/app/services/x_posts.py
+++ b/backend/app/services/x_posts.py
@@ -145,28 +145,35 @@ class XPostClient:
         except PlaywrightTimeoutError:
             pass
 
+    def _is_security_checkpoint(self, current_url: str, body: str) -> bool:
+        if "checkpoint" in current_url:
+            return True
+        if "Help us keep Twitter safe" in body:
+            return True
+        if "Confirm your phone number" in body:
+            return True
+        return False
+
     async def _verify_valid_url(self, current_url: str, body: str, mouse: EvasionMouse) -> None:
-        if "/home" not in current_url:
-            await mouse.stop_idle()
-            if (
-                "Help us keep Twitter safe" in body
-                or "Confirm your phone number" in body
-                or "checkpoint" in current_url
-            ):
-                raise XPostError(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="X session flagged by security checkpoint. Please re-login.",
-                    code="x_session_flagged",
-                    retryable=False,
-                    details={"platform": "x", "url": current_url},
-                )
+        if "/home" in current_url:
+            return
+
+        await mouse.stop_idle()
+        if self._is_security_checkpoint(current_url, body):
             raise XPostError(
                 status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="X session expired or invalid. Please re-login.",
-                code="x_session_expired",
+                detail="X session flagged by security checkpoint. Please re-login.",
+                code="x_session_flagged",
                 retryable=False,
                 details={"platform": "x", "url": current_url},
             )
+        raise XPostError(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="X session expired or invalid. Please re-login.",
+            code="x_session_expired",
+            retryable=False,
+            details={"platform": "x", "url": current_url},
+        )
 
     async def _type_and_publish(self, page: Any, mouse: EvasionMouse, content: str) -> str:
         await self._fill_post_content(mouse, content)

--- a/backend/app/services/x_posts.py
+++ b/backend/app/services/x_posts.py
@@ -13,6 +13,7 @@ from rebrowser_playwright.async_api import TimeoutError as PlaywrightTimeoutErro
 from app.services.browser.actions import (
     EvasionMouse,
     PostButtonDisabledError,
+    normalize_post_text,
     random_delay,
 )
 from app.services.browser.manager import BrowserManager
@@ -63,7 +64,8 @@ class XPostClient:
 
         Returns the X.com tweet ID (rest_id).
         """
-        if len(content) > 280:
+        normalized_content = normalize_post_text(content)
+        if len(normalized_content) > 280:
             raise XPostError(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Post content exceeds X.com's 280 character limit.",

--- a/backend/scripts/diagnose_uuid.py
+++ b/backend/scripts/diagnose_uuid.py
@@ -1,0 +1,25 @@
+import asyncio
+import os
+from app.services.browser.manager import BrowserManager
+
+async def main():
+    manager = BrowserManager(brand_id="989cb0e8-93ab-4763-9dc9-bf48a232e683")
+    headless = os.environ.get("PLAYWRIGHT_HEADLESS", "1") == "1"
+    
+    async with manager.get_context("x", headless=headless) as context:
+        page = context.pages[0] if context.pages else await context.new_page()
+        print("Navigating to https://x.com/home")
+        await page.goto("https://x.com/home", wait_until="domcontentloaded")
+        
+        await page.wait_for_timeout(5000)
+        
+        print(f"Final URL: {page.url}")
+        
+        count = await page.locator("[data-testid='AppTabBar_Home_Link']").count()
+        print(f"Found home links: {count}")
+        
+        body = await page.inner_text("body")
+        print(f"Body snippet: {body[:200]}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/diagnose_x.py
+++ b/backend/scripts/diagnose_x.py
@@ -1,0 +1,41 @@
+import asyncio
+import os
+from app.services.browser.manager import BrowserManager
+
+async def main():
+    manager = BrowserManager(brand_id="default")
+    headless = os.environ.get("PLAYWRIGHT_HEADLESS", "1") == "1"
+    
+    async with manager.get_context("x", headless=headless) as context:
+        page = context.pages[0] if context.pages else await context.new_page()
+        
+        print("Navigating to https://x.com/home")
+        await page.goto("https://x.com/home", wait_until="domcontentloaded")
+        
+        # Wait a few seconds for the app to initialize
+        await page.wait_for_timeout(5000)
+        
+        # Take a screenshot
+        await page.screenshot(path="x_diagnostics.png")
+        print("Screenshot saved to backend/x_diagnostics.png")
+        
+        # Check some common selectors
+        selectors = [
+            "nav[aria-label='Primary navigation']",
+            "[data-testid='AppTabBar_Home_Link']",
+            "[data-testid='tweetTextarea_0']",
+            "a[href='/home']"
+        ]
+        
+        for sel in selectors:
+            elements = await page.locator(sel).count()
+            print(f"Selector '{sel}': found {elements} elements")
+            
+        # Get the body text to see if we're on a login/error page
+        text = await page.inner_text("body")
+        print("\n--- BODY TEXT START ---")
+        print(text[:500] + ("..." if len(text) > 500 else ""))
+        print("--- BODY TEXT END ---")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/diagnose_x_sentinel.py
+++ b/backend/scripts/diagnose_x_sentinel.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+from app.services.browser.manager import BrowserManager
+
+async def main():
+    manager = BrowserManager(brand_id="default")
+    headless = os.environ.get("PLAYWRIGHT_HEADLESS", "1") == "1"
+    
+    async with manager.get_context("x", headless=headless) as context:
+        page = context.pages[0] if context.pages else await context.new_page()
+        
+        print("Navigating to https://x.com/home")
+        await page.goto("https://x.com/home", wait_until="domcontentloaded")
+        
+        # Wait 5s to load
+        await page.wait_for_timeout(5000)
+        
+        print("Checking selectors...")
+        
+        selectors = [
+            "nav[aria-label='Primary navigation']",
+            "[data-testid='AppTabBar_Home_Link']",
+            "a[href='/home']",
+            "nav"
+        ]
+        
+        for sel in selectors:
+            try:
+                count = await page.locator(sel).count()
+                print(f"Selector '{sel}': found {count} elements")
+                if count > 0 and sel == "nav":
+                    # print aria-labels of navs
+                    for i in range(count):
+                        label = await page.locator(sel).nth(i).get_attribute("aria-label")
+                        print(f"  nav[{i}] aria-label = {label}")
+            except Exception as e:
+                print(f"Error checking {sel}: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/test_db_e2e.py
+++ b/backend/scripts/test_db_e2e.py
@@ -1,15 +1,16 @@
 import asyncio
-import uuid
+import sys
 from sqlmodel import Session, select
 from app.core.db import engine
-from app.models import Post, PostCreate, Persona
+from app.models import Post, Persona
 from app.services.publishing import publish_post
 
 async def main():
+    persona_name = sys.argv[1] if len(sys.argv) > 1 else "Ashwath N"
     with Session(engine) as session:
-        persona = session.exec(select(Persona).where(Persona.name == "Ashwath N")).first()
+        persona = session.exec(select(Persona).where(Persona.name == persona_name)).first()
         if not persona:
-            print("Persona not found!")
+            print(f"Persona '{persona_name}' not found!")
             return
             
         print(f"Using persona: {persona.name} ({persona.id})")

--- a/backend/scripts/test_db_e2e.py
+++ b/backend/scripts/test_db_e2e.py
@@ -1,0 +1,51 @@
+import asyncio
+import uuid
+from sqlmodel import Session, select
+from app.core.db import engine
+from app.models import Post, PostCreate, Persona
+from app.services.publishing import publish_post
+
+async def main():
+    with Session(engine) as session:
+        persona = session.exec(select(Persona).where(Persona.name == "Ashwath N")).first()
+        if not persona:
+            print("Persona not found!")
+            return
+            
+        print(f"Using persona: {persona.name} ({persona.id})")
+        
+        # Create a post record
+        content = "The new Apex Legends season is actually looking incredibly solid. The weapon sandbox changes are exactly what the game needed to feel fresh again. Time to grind some ranked! 🎮🔥 #ApexLegends #Gaming"
+        
+        post = Post(
+            content=content,
+            platform="x",
+            status="draft",
+            persona_id=persona.id,
+            owner_id=persona.user_id
+        )
+        session.add(post)
+        session.commit()
+        session.refresh(post)
+        
+        print(f"Created Post in DB: ID={post.id}, status={post.status}")
+        
+        try:
+            # Run the publishing state machine
+            await publish_post(session=session, post=post, user_id=persona.user_id)
+            
+            # Refresh to show updated status
+            session.refresh(post)
+            print("========================================")
+            print(f"Final Post Status: {post.status}")
+            print(f"External Post ID: {post.external_post_id}")
+            print(f"Error Message: {post.error_message}")
+            print("========================================")
+        except Exception as e:
+            print(f"Publishing failed: {e}")
+            session.refresh(post)
+            print(f"Post status is now: {post.status}")
+            print(f"Error: {post.error_message}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/test_db_e2e.py
+++ b/backend/scripts/test_db_e2e.py
@@ -16,7 +16,7 @@ async def main():
         print(f"Using persona: {persona.name} ({persona.id})")
         
         # Create a post record
-        content = "The new Apex Legends season is actually looking incredibly solid. The weapon sandbox changes are exactly what the game needed to feel fresh again. Time to grind some ranked! 🎮🔥 #ApexLegends #Gaming"
+        content = sys.argv[2] if len(sys.argv) > 2 else "The new Apex Legends season is actually looking incredibly solid. The weapon sandbox changes are exactly what the game needed to feel fresh again. Time to grind some ranked! 🎮🔥 #ApexLegends #Gaming"
         
         post = Post(
             content=content,

--- a/backend/scripts/test_x_post_e2e.py
+++ b/backend/scripts/test_x_post_e2e.py
@@ -1,0 +1,32 @@
+import asyncio
+import logging
+import sys
+
+from app.services.x_posts import XPostClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+
+async def main():
+    post_content = "Just hit Immortal in Valorant! 🎮 The grind was real but the aim training finally paid off. Reyna diff all day! Who wants to queue? #Valorant #RiotGames #Gaming"
+    
+    print("========================================")
+    print(f"Attempting to post: '{post_content}'")
+    print("Using persona_id: 'default'")
+    print("========================================\n")
+    
+    try:
+        client = XPostClient()
+        post_id = await client.create_text_post(
+            persona_id="default",
+            content=post_content
+        )
+        print(f"\n✅ Success! Tweet ID: {post_id}")
+    except Exception as e:
+        print(f"\n❌ Failed to post: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/test_x_post_e2e.py
+++ b/backend/scripts/test_x_post_e2e.py
@@ -11,17 +11,18 @@ logging.basicConfig(
 )
 
 async def main():
-    post_content = "Just hit Immortal in Valorant! 🎮 The grind was real but the aim training finally paid off. Reyna diff all day! Who wants to queue? #Valorant #RiotGames #Gaming"
+    persona_id = sys.argv[1] if len(sys.argv) > 1 else "default"
+    post_content = sys.argv[2] if len(sys.argv) > 2 else "Just hit Immortal in Valorant! 🎮 The grind was real but the aim training finally paid off. Reyna diff all day! Who wants to queue? #Valorant #RiotGames #Gaming"
     
     print("========================================")
     print(f"Attempting to post: '{post_content}'")
-    print("Using persona_id: 'default'")
+    print(f"Using persona_id: '{persona_id}'")
     print("========================================\n")
     
     try:
         client = XPostClient()
         post_id = await client.create_text_post(
-            persona_id="default",
+            persona_id=persona_id,
             content=post_content
         )
         print(f"\n✅ Success! Tweet ID: {post_id}")


### PR DESCRIPTION
## Summary

Implements end-to-end X.com posting via Playwright browser automation. This PR wires X.com publishing into the existing platform-agnostic pipeline alongside LinkedIn.

---

## What ships

### `x_posts.py` — Core publishing client
- `XPostClient.create_text_post()` drives a Playwright browser to post on X.com
- **Sentinel check** navigates to `x.com/home` and uses `page.wait_for_url()` to wait for URL stabilization — distinguishes logged-in, session-expired, and security-checkpoint states without fragile DOM inspection or hardcoded timeouts
- **Strict GraphQL interceptor** filters on `response.request.method == 'POST'` to prevent preflight OPTIONS responses from crashing the worker with a `JSONDecodeError`
- **Pre-validation** rejects content > 280 chars before launching the browser
- **EvasionMouse** for human-like Bezier-curve mouse movement, randomized click offsets, and realistic typing via `humantyping`
- Structured error codes: `x_session_expired`, `x_session_flagged`, `x_timeout`, `x_graphql_error`, `x_missing_post_id`, `x_button_disabled`

### `x_auth.py` — Auth API endpoints
- `GET /api/v1/auth/x/status?persona_id=` — checks session file on disk
- `POST /api/v1/auth/x/connect?persona_id=` — launches headed Chrome subprocess for manual login; enforces persona-level access via `get_persona_role()`

### `publishing.py` — Platform routing + DRY errors
- `publish_post()` dispatches to LinkedIn or X based on `post.platform`
- Extracted `_handle_publish_error()` centralizes DB state transitions, exponential backoff retry scheduling, and structured logging — removes ~50 lines of duplicated code
- Generic `except Exception` catch-all prevents unexpected errors (JSON parse failures, Playwright crashes) from leaving posts permanently stuck in `publishing` state

### Browser layer hardening
- `session_exists()` now checks for the Chromium `Default/Cookies` file instead of `any(dir.iterdir())` — prevents false-positives from aborted logins
- `human_click()` uses `>> visible=true` pseudo-class instead of iterating all locators — removes unnecessary CDP round-trips
- `x_selectors.json`: narrowed `post_button` to `[data-testid=tweetButtonInline]` only — fixes automation clicking the wrong sidebar Post button

---

## Testing

Verified with `scripts/test_db_e2e.py` against a live X.com session:
- Post record created in DB with `status=draft`
- `publish_post()` transitions: `draft → publishing → published`
- `external_post_id` (X.com `rest_id`) captured and saved in DB

---

## Out of scope (follow-up)

- Frontend unlock for X.com platform selector
- Writing a `SocialAccount` DB row on X connect (session is currently file-only)
- Docker volume mount for stateless deploys