### PR TITLE
feat(ai-curation): integrate background ai drafting and trending topics curation into app

### DIFF
--- a/backend/app/api/routes/posts.py
+++ b/backend/app/api/routes/posts.py
@@ -27,7 +27,6 @@ from app.models import (
     PostUpdate,
     User,
 )
-from app.services.ai_draft import generate_ai_post_draft
 from app.services.post_state_machine import validate_transition
 from app.services.publishing import PublishFailure, publish_post
 
@@ -110,16 +109,29 @@ async def upload_media(
 @router.post("/ai-draft", response_model=AIDraftResponse)
 async def generate_ai_draft(
     *,
-    _current_user: CurrentUser,
+    current_user: CurrentUser,
+    session: SessionDep,
     draft_in: AIDraftRequest,
 ) -> Any:
-    """Generate or enhance a post draft using AI based on prompt and platform."""
-    content = await generate_ai_post_draft(
-        prompt=draft_in.prompt,
+    """Curate, refine, and persist a post draft using CurationGraph directly into the database."""
+    from app.services.agentic.curation_graph import curate_and_draft_post
+
+    prompt = draft_in.prompt.strip() if draft_in.prompt else "Social media update"
+    report = await curate_and_draft_post(
+        user_id=str(current_user.id),
+        topic_title=prompt,
         platform=draft_in.platform,
-        tone=draft_in.tone,
+        target_tone=draft_in.tone,
+        session=session,
     )
-    return AIDraftResponse(content=content)
+
+    persisted_id = (
+        uuid.UUID(report.persisted_post_id) if report.persisted_post_id else None
+    )
+
+    final_content = report.refined_content or report.draft_content or prompt
+
+    return AIDraftResponse(content=final_content, post_id=persisted_id)
 
 
 def _get_user_details(*, session: Session, user_id: uuid.UUID) -> User | None:
@@ -161,10 +173,13 @@ def _post_to_public(*, post: Post, author: PostAuthor | None = None) -> PostPubl
     )
 
 
-def _serialize_post_with_author(*, session: Session, post: Post) -> PostPublic:
+def serialize_post_with_author(*, session: Session, post: Post) -> PostPublic:
     user = _get_user_details(session=session, user_id=post.owner_id)
     author = _build_post_author(user=user) if user else None
     return _post_to_public(post=post, author=author)
+
+
+_serialize_post_with_author = serialize_post_with_author
 
 
 def _raise_publish_failure(*, failure: PublishFailure) -> None:

--- a/backend/app/api/routes/trending.py
+++ b/backend/app/api/routes/trending.py
@@ -1,11 +1,12 @@
 import os
+import uuid
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 
 from app import crud
 from app.api.deps import CurrentUser, SessionDep
-from app.models import TrendingTopicsPublic
+from app.models import PostPublic, TrendingTopicsPublic
 from app.services.browser.manager import BrowserManager
 
 router = APIRouter(prefix="/trending", tags=["trending"])
@@ -56,3 +57,47 @@ async def extract_trending_topics(
 
     topics = crud.get_latest_trending_topics(session=session, user_id=current_user.id)
     return TrendingTopicsPublic(data=topics, count=len(topics))
+
+
+@router.post("/{topic_id}/draft", response_model=PostPublic)
+async def draft_from_trending_topic(
+    *,
+    topic_id: uuid.UUID,
+    session: SessionDep,
+    current_user: CurrentUser,
+    platform: str = "both",
+) -> Any:
+    """Curate and refine a social post draft from a database trending topic using CurationGraph."""
+    from app.api.routes.posts import serialize_post_with_author
+    from app.models import Post, TrendingTopic
+    from app.services.agentic.curation_graph import curate_and_draft_post
+
+    topic = session.get(TrendingTopic, topic_id)
+    if not topic or topic.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Trending topic not found",
+        )
+
+    report = await curate_and_draft_post(
+        user_id=str(current_user.id),
+        topic_title=topic.topic_title,
+        topic_id=str(topic.id),
+        platform=platform,
+        session=session,
+    )
+
+    if not report.persisted_post_id:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate draft: {report.error or 'Unknown error'}",
+        )
+
+    post = session.get(Post, uuid.UUID(report.persisted_post_id))
+    if not post:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Draft post created but could not be loaded",
+        )
+
+    return serialize_post_with_author(session=session, post=post)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -231,6 +231,7 @@ class AIDraftRequest(SQLModel):
 
 class AIDraftResponse(SQLModel):
     content: str
+    post_id: uuid.UUID | None = None
 
 
 # --- SocialAccount (OAuth / Browser session metadata) ---

--- a/backend/tests/api/routes/test_trending.py
+++ b/backend/tests/api/routes/test_trending.py
@@ -70,3 +70,73 @@ def test_extract_trending_requires_x_connection(
         )
     assert response.status_code == 400
     assert "not connected" in response.json()["detail"].lower()
+
+
+def test_draft_from_trending_topic_success(
+    client: TestClient,
+    db: Session,
+) -> None:
+    user, headers = _create_user_with_auth(client=client, db=db)
+
+    now = datetime.now(timezone.utc)
+    topic = TrendingTopic(
+        user_id=user.id,
+        topic_url="https://x.com/i/trending/ai_trends",
+        topic_title="AI Agent Breakthroughs",
+        category="Tech",
+        post_count=50000,
+        scraped_at=now,
+    )
+    db.add(topic)
+    db.commit()
+
+    from app.models import Post
+    from app.services.agentic.schemas import CuratedDraftReport
+
+    created_post = Post(
+        owner_id=user.id,
+        content="AI Agent Breakthroughs are transforming developer productivity.",
+        platform="both",
+        status="draft",
+    )
+    db.add(created_post)
+    db.commit()
+
+    mock_report = CuratedDraftReport(
+        draft_content=created_post.content,
+        refined_content=created_post.content,
+        is_compliant=True,
+        topic_title=topic.topic_title,
+        persisted_post_id=str(created_post.id),
+        status="persisted",
+    )
+
+    with patch(
+        "app.services.agentic.curation_graph.curate_and_draft_post",
+        return_value=mock_report,
+    ):
+        response = client.post(
+            f"{settings.API_V1_STR}/trending/{topic.id}/draft",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == str(created_post.id)
+    assert data["content"] == created_post.content
+    assert data["status"] == "draft"
+
+
+def test_draft_from_trending_topic_not_found(
+    client: TestClient,
+    db: Session,
+) -> None:
+    _user, headers = _create_user_with_auth(client=client, db=db)
+    import uuid
+
+    fake_id = uuid.uuid4()
+    response = client.post(
+        f"{settings.API_V1_STR}/trending/{fake_id}/draft",
+        headers=headers,
+    )
+    assert response.status_code == 404

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -36,6 +36,18 @@ export const AIDraftResponseSchema = {
         content: {
             type: 'string',
             title: 'Content'
+        },
+        post_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Post Id'
         }
     },
     type: 'object',

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -3,7 +3,7 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { AdminReadSchedulerStatusResponse, AuthLinkedinConfigCheckResponse, AuthLinkedinAuthorizeResponse, AuthLinkedinCallbackData, AuthLinkedinCallbackResponse, AuthXStatusResponse, AuthXVerifyResponse, AuthXConnectData, AuthXConnectResponse, ItemsReadItemsData, ItemsReadItemsResponse, ItemsCreateItemData, ItemsCreateItemResponse, ItemsReadItemData, ItemsReadItemResponse, ItemsUpdateItemData, ItemsUpdateItemResponse, ItemsDeleteItemData, ItemsDeleteItemResponse, LinkedinLinkedinStatusResponse, LinkedinLinkedinDisconnectResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, PostsUploadMediaData, PostsUploadMediaResponse, PostsGenerateAiDraftData, PostsGenerateAiDraftResponse, PostsReadPostsData, PostsReadPostsResponse, PostsCreateNewPostData, PostsCreateNewPostResponse, PostsReadPostData, PostsReadPostResponse, PostsUpdateExistingPostData, PostsUpdateExistingPostResponse, PostsDeleteExistingPostData, PostsDeleteExistingPostResponse, PostsPublishExistingPostData, PostsPublishExistingPostResponse, PostsRetryFailedPostData, PostsRetryFailedPostResponse, PrivateCreateUserData, PrivateCreateUserResponse, TrendingGetTrendingResponse, TrendingExtractTrendingTopicsData, TrendingExtractTrendingTopicsResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
+import type { AdminReadSchedulerStatusResponse, AuthLinkedinConfigCheckResponse, AuthLinkedinAuthorizeResponse, AuthLinkedinCallbackData, AuthLinkedinCallbackResponse, AuthXStatusResponse, AuthXVerifyResponse, AuthXConnectData, AuthXConnectResponse, ItemsReadItemsData, ItemsReadItemsResponse, ItemsCreateItemData, ItemsCreateItemResponse, ItemsReadItemData, ItemsReadItemResponse, ItemsUpdateItemData, ItemsUpdateItemResponse, ItemsDeleteItemData, ItemsDeleteItemResponse, LinkedinLinkedinStatusResponse, LinkedinLinkedinDisconnectResponse, LoginLoginAccessTokenData, LoginLoginAccessTokenResponse, LoginTestTokenResponse, LoginRecoverPasswordData, LoginRecoverPasswordResponse, LoginResetPasswordData, LoginResetPasswordResponse, LoginRecoverPasswordHtmlContentData, LoginRecoverPasswordHtmlContentResponse, PostsUploadMediaData, PostsUploadMediaResponse, PostsGenerateAiDraftData, PostsGenerateAiDraftResponse, PostsReadPostsData, PostsReadPostsResponse, PostsCreateNewPostData, PostsCreateNewPostResponse, PostsReadPostData, PostsReadPostResponse, PostsUpdateExistingPostData, PostsUpdateExistingPostResponse, PostsDeleteExistingPostData, PostsDeleteExistingPostResponse, PostsPublishExistingPostData, PostsPublishExistingPostResponse, PostsRetryFailedPostData, PostsRetryFailedPostResponse, PrivateCreateUserData, PrivateCreateUserResponse, TrendingGetTrendingResponse, TrendingExtractTrendingTopicsData, TrendingExtractTrendingTopicsResponse, TrendingDraftFromTrendingTopicData, TrendingDraftFromTrendingTopicResponse, UsersReadUsersData, UsersReadUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersReadUserMeResponse, UsersDeleteUserMeResponse, UsersUpdateUserMeData, UsersUpdateUserMeResponse, UsersUpdatePasswordMeData, UsersUpdatePasswordMeResponse, UsersRegisterUserData, UsersRegisterUserResponse, UsersReadUserByIdData, UsersReadUserByIdResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsTestEmailData, UtilsTestEmailResponse, UtilsHealthCheckResponse } from './types.gen';
 
 export class AdminService {
     /**
@@ -386,7 +386,7 @@ export class PostsService {
     
     /**
      * Generate Ai Draft
-     * Generate or enhance a post draft using AI based on prompt and platform.
+     * Curate, refine, and persist a post draft using CurationGraph directly into the database.
      * @param data The data for the request.
      * @param data.requestBody
      * @returns AIDraftResponse Successful Response
@@ -608,6 +608,31 @@ export class TrendingService {
             url: '/api/v1/trending/extract',
             query: {
                 max_topics: data.maxTopics
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Draft From Trending Topic
+     * Curate and refine a social post draft from a database trending topic using CurationGraph.
+     * @param data The data for the request.
+     * @param data.topicId
+     * @param data.platform
+     * @returns PostPublic Successful Response
+     * @throws ApiError
+     */
+    public static draftFromTrendingTopic(data: TrendingDraftFromTrendingTopicData): CancelablePromise<TrendingDraftFromTrendingTopicResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/trending/{topic_id}/draft',
+            path: {
+                topic_id: data.topicId
+            },
+            query: {
+                platform: data.platform
             },
             errors: {
                 422: 'Validation Error'

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -8,6 +8,7 @@ export type AIDraftRequest = {
 
 export type AIDraftResponse = {
     content: string;
+    post_id?: (string | null);
 };
 
 export type Body_login_login_access_token = {
@@ -387,6 +388,13 @@ export type TrendingExtractTrendingTopicsData = {
 };
 
 export type TrendingExtractTrendingTopicsResponse = (TrendingTopicsPublic);
+
+export type TrendingDraftFromTrendingTopicData = {
+    platform?: string;
+    topicId: string;
+};
+
+export type TrendingDraftFromTrendingTopicResponse = (PostPublic);
 
 export type UsersReadUsersData = {
     limit?: number;

--- a/frontend/src/components/Post/PostCard.tsx
+++ b/frontend/src/components/Post/PostCard.tsx
@@ -59,6 +59,7 @@ export interface PostCardData {
 export interface PostCardProps {
   post: PostCardData
   isEditing?: boolean
+  isDrafting?: boolean
   onLike?: (postId: string) => void
   onRepost?: (postId: string) => void
   onComment?: (postId: string) => void
@@ -249,6 +250,7 @@ interface PostCardHeaderProps {
   createdAt: Date | string
   scheduledAt?: Date | string | null
   isScheduled: boolean
+  isDrafting?: boolean
   scheduledDateTime: string
   isEditing: boolean
   canSave: boolean
@@ -271,17 +273,19 @@ function PostCardHeader(props: PostCardHeaderProps) {
         isScheduled={props.isScheduled}
         scheduledDateTime={props.scheduledDateTime}
       />
-      <PostCardHeaderActions
-        isEditing={props.isEditing}
-        canSave={props.canSave}
-        onCancel={props.onCancel}
-        onSave={props.onSave}
-        onPreview={props.onPreview}
-        onEdit={props.onEdit}
-        onDelete={props.onDelete}
-        onPublish={props.onPublish}
-        isPublishing={props.isPublishing}
-      />
+      {!props.isDrafting && (
+        <PostCardHeaderActions
+          isEditing={props.isEditing}
+          canSave={props.canSave}
+          onCancel={props.onCancel}
+          onSave={props.onSave}
+          onPreview={props.onPreview}
+          onEdit={props.onEdit}
+          onDelete={props.onDelete}
+          onPublish={props.onPublish}
+          isPublishing={props.isPublishing}
+        />
+      )}
     </div>
   )
 }
@@ -332,12 +336,14 @@ function FailureNotice({
 
 function PostCardBodyContent({
   isEditing,
+  isDrafting,
   content,
   editedContent,
   onContentChange,
   imageUrl,
 }: {
   isEditing: boolean
+  isDrafting?: boolean
   content: string
   editedContent: string
   onContentChange: (val: string) => void
@@ -353,6 +359,20 @@ function PostCardBodyContent({
           className="min-h-24 resize-none border py-2.5 px-3 text-sm leading-relaxed focus-visible:ring-1 focus-visible:ring-primary"
           rows={4}
         />
+      </div>
+    )
+  }
+
+  if (isDrafting) {
+    return (
+      <div className="mt-1">
+        <p className="break-words text-sm leading-normal whitespace-pre-wrap text-foreground">
+          {content}
+        </p>
+        <div className="space-y-2 mt-3 opacity-60">
+          <div className="h-2.5 bg-muted rounded-full w-4/5 animate-pulse" />
+          <div className="h-2.5 bg-muted rounded-full w-3/5 animate-pulse" />
+        </div>
       </div>
     )
   }
@@ -470,15 +490,22 @@ function usePostCardEngagement(
   const [isReposted, setIsReposted] = React.useState(post.isReposted ?? false)
   const [repostCount, setRepostCount] = React.useState(post.reposts ?? 0)
 
+  React.useEffect(() => {
+    setIsLiked(post.isLiked ?? false)
+    setLikeCount(post.likes ?? 0)
+    setIsReposted(post.isReposted ?? false)
+    setRepostCount(post.reposts ?? 0)
+  }, [post.isLiked, post.likes, post.isReposted, post.reposts])
+
   const handleLike = React.useCallback(() => {
     setIsLiked((prev) => !prev)
-    setLikeCount((prev) => (isLiked ? prev - 1 : prev + 1))
+    setLikeCount((prev) => (isLiked ? Math.max(0, prev - 1) : prev + 1))
     onLike?.(post.id)
   }, [isLiked, onLike, post.id])
 
   const handleRepost = React.useCallback(() => {
     setIsReposted((prev) => !prev)
-    setRepostCount((prev) => (isReposted ? prev - 1 : prev + 1))
+    setRepostCount((prev) => (isReposted ? Math.max(0, prev - 1) : prev + 1))
     onRepost?.(post.id)
   }, [isReposted, onRepost, post.id])
 
@@ -494,6 +521,7 @@ function usePostCardEngagement(
 
 interface PostCardActionsProps {
   isEditing: boolean
+  isDrafting?: boolean
   platform: Platform
   onPlatformChange?: (platform: Platform) => void
   engagement: ReturnType<typeof usePostCardEngagement>
@@ -505,6 +533,7 @@ interface PostCardActionsProps {
 
 function PostCardActionsRow({
   isEditing,
+  isDrafting = false,
   platform,
   onPlatformChange,
   engagement,
@@ -514,27 +543,32 @@ function PostCardActionsRow({
   isPosted,
 }: PostCardActionsProps) {
   return (
-    <div className="mt-2">
+    <div
+      className={`mt-2 ${
+        isDrafting ? "opacity-40 pointer-events-none select-none" : ""
+      }`}
+    >
       <PostActionFooter
         isEditing={isEditing}
         platform={platform}
         onPlatformChange={onPlatformChange}
         isLiked={engagement.isLiked}
         likeCount={engagement.likeCount}
-        onLike={engagement.handleLike}
+        onLike={isDrafting ? undefined : engagement.handleLike}
         isReposted={engagement.isReposted}
         repostCount={engagement.repostCount}
-        onRepost={engagement.handleRepost}
+        onRepost={isDrafting ? undefined : engagement.handleRepost}
         commentsCount={commentsCount}
-        onComment={onComment}
-        onShare={onShare}
+        onComment={isDrafting ? undefined : onComment}
+        onShare={isDrafting ? undefined : onShare}
         isPosted={isPosted}
       />
     </div>
   )
 }
 
-function getPostCardFlags(post: PostCardData) {
+function getPostCardFlags(post: PostCardData, isDrafting?: boolean) {
+  const isDraftingMode = Boolean(isDrafting || post.status === "drafting")
   const isScheduled = Boolean(
     post.scheduledAt ||
       post.type === "scheduled" ||
@@ -546,7 +580,13 @@ function getPostCardFlags(post: PostCardData) {
     ? formatFullDateTime(post.scheduledAt)
     : ""
 
-  return { isScheduled, isFailed, isPosted, scheduledDateTime }
+  return {
+    isDrafting: isDraftingMode,
+    isScheduled,
+    isFailed,
+    isPosted,
+    scheduledDateTime,
+  }
 }
 
 interface PostCardLayoutProps extends PostCardProps {
@@ -602,6 +642,7 @@ function PostCardHeaderWrapper({
       createdAt={post.createdAt}
       scheduledAt={post.scheduledAt}
       isScheduled={flags.isScheduled}
+      isDrafting={flags.isDrafting}
       scheduledDateTime={flags.scheduledDateTime}
       isEditing={isEditing}
       canSave={editor.editedContent.trim().length > 0}
@@ -617,7 +658,7 @@ function PostCardHeaderWrapper({
 }
 
 function PostCardMainColumn(props: PostCardLayoutProps) {
-  const flags = getPostCardFlags(props.post)
+  const flags = getPostCardFlags(props.post, props.isDrafting)
 
   return (
     <div className="min-w-0 flex-1">
@@ -635,6 +676,7 @@ function PostCardMainColumn(props: PostCardLayoutProps) {
 
       <PostCardBodyContent
         isEditing={false}
+        isDrafting={flags.isDrafting}
         content={props.post.content}
         editedContent={props.editor.editedContent}
         onContentChange={props.editor.setEditedContent}
@@ -652,6 +694,7 @@ function PostCardMainColumn(props: PostCardLayoutProps) {
 
       <PostCardActionsRow
         isEditing={false}
+        isDrafting={flags.isDrafting}
         platform={props.editor.platform}
         onPlatformChange={
           flags.isPosted ? undefined : props.editor.handlePlatformChange
@@ -669,7 +712,7 @@ function PostCardMainColumn(props: PostCardLayoutProps) {
 function PostCardLayout(props: PostCardLayoutProps) {
   return (
     <article
-      className={`group border-b transition-colors hover:bg-accent/40`}
+      className="group border-b transition-colors hover:bg-accent/40"
       aria-label={`Post by ${props.post.author.name}`}
     >
       <div className="p-3 sm:p-4">
@@ -737,15 +780,18 @@ export const Posted = PostCard
 export const ScheduledPost = PostCard
 export const DraftPost = PostCard
 export const FailedPost = PostCard
+export const DraftingPost = PostCard
 
 export type PostedData = PostCardData
 export type ScheduledPostData = PostCardData
 export type DraftPostData = PostCardData
 export type FailedPostData = PostCardData
+export type DraftingPostData = PostCardData
 
 export type PostedProps = PostCardProps
 export type ScheduledPostProps = PostCardProps
 export type DraftPostProps = PostCardProps
 export type FailedPostProps = PostCardProps
+export type DraftingPostProps = PostCardProps
 
 export default PostCard

--- a/frontend/src/components/Post/PostCard.tsx
+++ b/frontend/src/components/Post/PostCard.tsx
@@ -84,14 +84,28 @@ function parseScheduledDate(scheduledAt?: Date | string | null): Date | null {
   return typeof scheduledAt === "string" ? new Date(scheduledAt) : scheduledAt
 }
 
-function PostCardAuthorMeta({
-  author,
+function ScheduledTimeBadge({
+  scheduledDateTime,
+}: {
+  scheduledDateTime: string
+}) {
+  return (
+    <span
+      title={`Scheduled for ${scheduledDateTime}`}
+      className="shrink-0 text-xs font-medium text-primary flex items-center gap-1 hover:underline cursor-default"
+    >
+      <Clock className="h-3 w-3 shrink-0" />
+      {scheduledDateTime}
+    </span>
+  )
+}
+
+function TimeMeta({
   createdAt,
   scheduledAt,
   isScheduled,
   scheduledDateTime,
 }: {
-  author: PostAuthorData
   createdAt: Date | string
   scheduledAt?: Date | string | null
   isScheduled: boolean
@@ -106,6 +120,36 @@ function PostCardAuthorMeta({
     [createdAt],
   )
 
+  if (isScheduled && scheduledAt) {
+    return <ScheduledTimeBadge scheduledDateTime={scheduledDateTime} />
+  }
+
+  return (
+    <time
+      dateTime={
+        typeof createdAt === "string" ? createdAt : createdAt.toISOString()
+      }
+      title={fullDateTime}
+      className="shrink-0 text-xs hover:underline"
+    >
+      {relativeTime}
+    </time>
+  )
+}
+
+function PostCardAuthorMeta({
+  author,
+  createdAt,
+  scheduledAt,
+  isScheduled,
+  scheduledDateTime,
+}: {
+  author: PostAuthorData
+  createdAt: Date | string
+  scheduledAt?: Date | string | null
+  isScheduled: boolean
+  scheduledDateTime: string
+}) {
   return (
     <div className="flex min-w-0 items-center gap-1.5 flex-wrap sm:flex-nowrap">
       <button
@@ -120,78 +164,63 @@ function PostCardAuthorMeta({
         <span className="shrink-0" aria-hidden="true">
           ·
         </span>
-        {isScheduled && scheduledAt ? (
-          <span
-            title={`Scheduled for ${scheduledDateTime}`}
-            className="shrink-0 text-xs font-medium text-primary flex items-center gap-1 hover:underline cursor-default"
-          >
-            <Clock className="h-3 w-3 shrink-0" />
-            {scheduledDateTime}
-          </span>
-        ) : (
-          <time
-            dateTime={
-              typeof createdAt === "string"
-                ? createdAt
-                : createdAt.toISOString()
-            }
-            title={fullDateTime}
-            className="shrink-0 text-xs hover:underline"
-          >
-            {relativeTime}
-          </time>
-        )}
+        <TimeMeta
+          createdAt={createdAt}
+          scheduledAt={scheduledAt}
+          isScheduled={isScheduled}
+          scheduledDateTime={scheduledDateTime}
+        />
       </div>
     </div>
   )
 }
 
-function PostCardHeaderActions({
-  isEditing,
+function EditingHeaderActions({
   canSave,
   onCancel,
   onSave,
+}: {
+  canSave: boolean
+  onCancel: () => void
+  onSave: () => void
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        className="h-8 px-3 text-xs"
+      >
+        <X className="mr-1.5 h-3.5 w-3.5" />
+        Cancel
+      </Button>
+      <Button
+        size="sm"
+        onClick={onSave}
+        className="h-8 px-3 text-xs"
+        disabled={!canSave}
+      >
+        <Check className="mr-1.5 h-3.5 w-3.5" />
+        Save
+      </Button>
+    </div>
+  )
+}
+
+function DropdownHeaderActions({
   onPreview,
   onEdit,
   onDelete,
   onPublish,
   isPublishing,
 }: {
-  isEditing: boolean
-  canSave: boolean
-  onCancel: () => void
-  onSave: () => void
   onPreview?: () => void
   onEdit?: () => void
   onDelete?: () => void
   onPublish?: () => void
   isPublishing?: boolean
 }) {
-  if (isEditing) {
-    return (
-      <div className="flex items-center gap-1.5">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onCancel}
-          className="h-8 px-3 text-xs"
-        >
-          <X className="mr-1.5 h-3.5 w-3.5" />
-          Cancel
-        </Button>
-        <Button
-          size="sm"
-          onClick={onSave}
-          className="h-8 px-3 text-xs"
-          disabled={!canSave}
-        >
-          <Check className="mr-1.5 h-3.5 w-3.5" />
-          Save
-        </Button>
-      </div>
-    )
-  }
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -242,6 +271,48 @@ function PostCardHeaderActions({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  )
+}
+
+function PostCardHeaderActions({
+  isEditing,
+  canSave,
+  onCancel,
+  onSave,
+  onPreview,
+  onEdit,
+  onDelete,
+  onPublish,
+  isPublishing,
+}: {
+  isEditing: boolean
+  canSave: boolean
+  onCancel: () => void
+  onSave: () => void
+  onPreview?: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+  onPublish?: () => void
+  isPublishing?: boolean
+}) {
+  if (isEditing) {
+    return (
+      <EditingHeaderActions
+        canSave={canSave}
+        onCancel={onCancel}
+        onSave={onSave}
+      />
+    )
+  }
+
+  return (
+    <DropdownHeaderActions
+      onPreview={onPreview}
+      onEdit={onEdit}
+      onDelete={onDelete}
+      onPublish={onPublish}
+      isPublishing={isPublishing}
+    />
   )
 }
 
@@ -334,49 +405,47 @@ function FailureNotice({
   )
 }
 
-function PostCardBodyContent({
-  isEditing,
-  isDrafting,
-  content,
+function EditingBodyContent({
   editedContent,
   onContentChange,
-  imageUrl,
 }: {
-  isEditing: boolean
-  isDrafting?: boolean
-  content: string
   editedContent: string
   onContentChange: (val: string) => void
+}) {
+  return (
+    <div className="mt-1.5">
+      <Textarea
+        value={editedContent}
+        onChange={(e) => onContentChange(e.target.value)}
+        placeholder="What's happening?"
+        className="min-h-24 resize-none border py-2.5 px-3 text-sm leading-relaxed focus-visible:ring-1 focus-visible:ring-primary"
+        rows={4}
+      />
+    </div>
+  )
+}
+
+function DraftingBodyContent({ content }: { content: string }) {
+  return (
+    <div className="mt-1">
+      <p className="break-words text-sm leading-normal whitespace-pre-wrap text-foreground">
+        {content}
+      </p>
+      <div className="space-y-2 mt-3 opacity-60">
+        <div className="h-2.5 bg-muted rounded-full w-4/5 animate-pulse" />
+        <div className="h-2.5 bg-muted rounded-full w-3/5 animate-pulse" />
+      </div>
+    </div>
+  )
+}
+
+function NormalBodyContent({
+  content,
+  imageUrl,
+}: {
+  content: string
   imageUrl?: string | null
 }) {
-  if (isEditing) {
-    return (
-      <div className="mt-1.5">
-        <Textarea
-          value={editedContent}
-          onChange={(e) => onContentChange(e.target.value)}
-          placeholder="What's happening?"
-          className="min-h-24 resize-none border py-2.5 px-3 text-sm leading-relaxed focus-visible:ring-1 focus-visible:ring-primary"
-          rows={4}
-        />
-      </div>
-    )
-  }
-
-  if (isDrafting) {
-    return (
-      <div className="mt-1">
-        <p className="break-words text-sm leading-normal whitespace-pre-wrap text-foreground">
-          {content}
-        </p>
-        <div className="space-y-2 mt-3 opacity-60">
-          <div className="h-2.5 bg-muted rounded-full w-4/5 animate-pulse" />
-          <div className="h-2.5 bg-muted rounded-full w-3/5 animate-pulse" />
-        </div>
-      </div>
-    )
-  }
-
   return (
     <>
       <div className="mt-1">
@@ -397,6 +466,37 @@ function PostCardBodyContent({
       )}
     </>
   )
+}
+
+function PostCardBodyContent({
+  isEditing,
+  isDrafting,
+  content,
+  editedContent,
+  onContentChange,
+  imageUrl,
+}: {
+  isEditing: boolean
+  isDrafting?: boolean
+  content: string
+  editedContent: string
+  onContentChange: (val: string) => void
+  imageUrl?: string | null
+}) {
+  if (isEditing) {
+    return (
+      <EditingBodyContent
+        editedContent={editedContent}
+        onContentChange={onContentChange}
+      />
+    )
+  }
+
+  if (isDrafting) {
+    return <DraftingBodyContent content={content} />
+  }
+
+  return <NormalBodyContent content={content} imageUrl={imageUrl} />
 }
 
 function PostCardAvatar({ author }: { author: PostAuthorData }) {
@@ -567,25 +667,22 @@ function PostCardActionsRow({
   )
 }
 
-function getPostCardFlags(post: PostCardData, isDrafting?: boolean) {
-  const isDraftingMode = Boolean(isDrafting || post.status === "drafting")
-  const isScheduled = Boolean(
-    post.scheduledAt ||
-      post.type === "scheduled" ||
-      post.status === "scheduled",
-  )
-  const isFailed = post.status === "failed"
-  const isPosted = post.type === "posted" || post.status === "published"
-  const scheduledDateTime = post.scheduledAt
-    ? formatFullDateTime(post.scheduledAt)
-    : ""
+function getScheduledDateTime(scheduledAt?: Date | string | null): string {
+  if (!scheduledAt) return ""
+  return formatFullDateTime(scheduledAt)
+}
 
+function getPostCardFlags(post: PostCardData, isDrafting?: boolean) {
   return {
-    isDrafting: isDraftingMode,
-    isScheduled,
-    isFailed,
-    isPosted,
-    scheduledDateTime,
+    isDrafting: Boolean(isDrafting || post.status === "drafting"),
+    isScheduled: Boolean(
+      post.scheduledAt ||
+        post.type === "scheduled" ||
+        post.status === "scheduled",
+    ),
+    isFailed: post.status === "failed",
+    isPosted: post.type === "posted" || post.status === "published",
+    scheduledDateTime: getScheduledDateTime(post.scheduledAt),
   }
 }
 

--- a/frontend/src/components/Post/index.ts
+++ b/frontend/src/components/Post/index.ts
@@ -1,4 +1,7 @@
 export {
+  DraftingPost,
+  type DraftingPostData,
+  type DraftingPostProps,
   DraftPost,
   type DraftPostData,
   type DraftPostProps,

--- a/frontend/src/components/PostInput/PostActionBar.tsx
+++ b/frontend/src/components/PostInput/PostActionBar.tsx
@@ -184,6 +184,43 @@ interface ActionButtonsProps {
   onAiDraftSubmit?: () => void
 }
 
+function getPrimaryButtonLabel(
+  isAiMode: boolean,
+  isAiGenerating: boolean,
+  isSubmitting: boolean,
+  isScheduled: boolean,
+): string {
+  if (isAiMode) {
+    return isAiGenerating ? "Drafting…" : "Draft"
+  }
+  if (isSubmitting) {
+    return isScheduled ? "Scheduling…" : "Posting…"
+  }
+  return isScheduled ? "Schedule" : "Post"
+}
+
+function getPrimaryButtonHandler(
+  isAiMode: boolean,
+  isScheduled: boolean,
+  onAiDraftSubmit?: () => void,
+  onScheduleClick?: () => void,
+  onPostClick?: () => void,
+): (() => void) | undefined {
+  if (isAiMode) return onAiDraftSubmit
+  if (isScheduled) return onScheduleClick
+  return onPostClick
+}
+
+function getPrimaryButtonDisabled(
+  isAiMode: boolean,
+  isDraftDisabled: boolean,
+  isAiGenerating: boolean,
+  isScheduleOrPublishDisabled: boolean,
+): boolean {
+  if (isAiMode) return isDraftDisabled || isAiGenerating
+  return isScheduleOrPublishDisabled
+}
+
 function ActionButtonsGroup({
   isSubmitting,
   isScheduled,
@@ -201,27 +238,31 @@ function ActionButtonsGroup({
   onPostClick,
   onAiDraftSubmit,
 }: ActionButtonsProps) {
-  const primaryLabel = isAiMode
-    ? isAiGenerating
-      ? "Drafting…"
-      : "Draft"
-    : isSubmitting
-      ? isScheduled
-        ? "Scheduling…"
-        : "Posting…"
-      : isScheduled
-        ? "Schedule"
-        : "Post"
+  const primaryLabel = getPrimaryButtonLabel(
+    isAiMode,
+    isAiGenerating,
+    isSubmitting,
+    isScheduled,
+  )
 
-  const handlePrimaryClick = isAiMode
-    ? onAiDraftSubmit
-    : isScheduled
-      ? onScheduleClick
-      : onPostClick
+  const handlePrimaryClick = getPrimaryButtonHandler(
+    isAiMode,
+    isScheduled,
+    onAiDraftSubmit,
+    onScheduleClick,
+    onPostClick,
+  )
 
-  const isPrimaryDisabled = isAiMode
-    ? isDraftDisabled || isAiGenerating
-    : isScheduleOrPublishDisabled
+  const isPrimaryDisabled = getPrimaryButtonDisabled(
+    isAiMode,
+    isDraftDisabled,
+    isAiGenerating,
+    isScheduleOrPublishDisabled,
+  )
+
+  const buttonStyle = isAiMode
+    ? "bg-primary/90 hover:bg-primary text-primary-foreground shadow-xs"
+    : "bg-primary text-primary-foreground hover:bg-primary/90 shadow-2xs hover:shadow-sm"
 
   return (
     <div className="flex items-center gap-2 shrink-0 ml-auto">
@@ -268,11 +309,7 @@ function ActionButtonsGroup({
         size="sm"
         onClick={handlePrimaryClick}
         disabled={isPrimaryDisabled}
-        className={`h-8.5 min-w-[70px] px-4.5 text-xs font-bold rounded-full transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:scale-[1.03] active:scale-95 cursor-pointer disabled:opacity-50 disabled:hover:scale-100 ${
-          isAiMode
-            ? "bg-primary/90 hover:bg-primary text-primary-foreground shadow-xs"
-            : "bg-primary text-primary-foreground hover:bg-primary/90 shadow-2xs hover:shadow-sm"
-        }`}
+        className={`h-8.5 min-w-[70px] px-4.5 text-xs font-bold rounded-full transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:scale-[1.03] active:scale-95 cursor-pointer disabled:opacity-50 disabled:hover:scale-100 ${buttonStyle}`}
         data-testid="primary-post-btn"
       >
         <span

--- a/frontend/src/components/PostInput/PostActionBar.tsx
+++ b/frontend/src/components/PostInput/PostActionBar.tsx
@@ -62,12 +62,13 @@ interface LeftControlsProps {
   isScheduled: boolean
   isSubmitting: boolean
   isAiGenerating?: boolean
+  isAiMode?: boolean
   scheduledAt?: Date | undefined
   onScheduleChange?: (date: Date | undefined) => void
   onToggleSchedule: (open: boolean) => void
   onActionTypeChange: (type: "draft" | "schedule" | "post") => void
   onImageClick?: () => void
-  onAiDraftClick?: () => void
+  onToggleAiMode?: () => void
 }
 
 function ScheduleAndMediaControls({
@@ -75,12 +76,13 @@ function ScheduleAndMediaControls({
   isScheduled,
   isSubmitting,
   isAiGenerating,
+  isAiMode,
   scheduledAt,
   onScheduleChange,
   onToggleSchedule,
   onActionTypeChange,
   onImageClick,
-  onAiDraftClick,
+  onToggleAiMode,
 }: LeftControlsProps) {
   const mediaAndAiButtons = (
     <>
@@ -102,22 +104,22 @@ function ScheduleAndMediaControls({
         type="button"
         variant="ghost"
         size="icon"
-        className={`h-8.5 w-8.5 rounded-full transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:scale-105 active:scale-95 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed shrink-0 ${
-          isAiGenerating
-            ? "text-primary bg-primary/15 animate-pulse"
+        className={`h-8.5 w-8.5 rounded-full transition-colors duration-150 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed shrink-0 ${
+          isAiMode
+            ? "text-primary bg-primary/20 ring-1 ring-primary/40 shadow-xs"
             : "text-muted-foreground hover:text-primary hover:bg-primary/10"
         }`}
-        aria-label="Draft with AI"
-        title="Draft with AI"
-        onClick={onAiDraftClick}
+        aria-label={isAiMode ? "Disable AI Draft Mode" : "Draft with AI"}
+        title={
+          isAiMode
+            ? "AI Draft Mode Active (click to toggle off)"
+            : "Draft with AI"
+        }
+        onClick={onToggleAiMode}
         disabled={isSubmitting || isAiGenerating}
         data-testid="ai-draft-btn"
       >
-        <PencilSparklesIcon
-          className={`h-4.5 w-4.5 transition-transform duration-200 ${
-            isAiGenerating ? "animate-spin" : "group-hover:scale-110"
-          }`}
-        />
+        <PencilSparklesIcon className="h-4.5 w-4.5" />
       </Button>
     </>
   )
@@ -173,10 +175,13 @@ interface ActionButtonsProps {
   currentLength: number
   platform: Platform
   isXPremium?: boolean
+  isAiMode?: boolean
+  isAiGenerating?: boolean
   onCancelClick?: () => void
   onDraftClick: () => void
   onScheduleClick: () => void
   onPostClick: () => void
+  onAiDraftSubmit?: () => void
 }
 
 function ActionButtonsGroup({
@@ -188,18 +193,35 @@ function ActionButtonsGroup({
   currentLength,
   platform,
   isXPremium,
+  isAiMode = false,
+  isAiGenerating = false,
   onCancelClick,
   onDraftClick,
   onScheduleClick,
   onPostClick,
+  onAiDraftSubmit,
 }: ActionButtonsProps) {
-  const primaryLabel = isSubmitting
-    ? isScheduled
-      ? "Scheduling…"
-      : "Posting…"
+  const primaryLabel = isAiMode
+    ? isAiGenerating
+      ? "Drafting…"
+      : "Draft"
+    : isSubmitting
+      ? isScheduled
+        ? "Scheduling…"
+        : "Posting…"
+      : isScheduled
+        ? "Schedule"
+        : "Post"
+
+  const handlePrimaryClick = isAiMode
+    ? onAiDraftSubmit
     : isScheduled
-      ? "Schedule"
-      : "Post"
+      ? onScheduleClick
+      : onPostClick
+
+  const isPrimaryDisabled = isAiMode
+    ? isDraftDisabled || isAiGenerating
+    : isScheduleOrPublishDisabled
 
   return (
     <div className="flex items-center gap-2 shrink-0 ml-auto">
@@ -235,7 +257,7 @@ function ActionButtonsGroup({
         aria-label="Add to draft"
         title="Add to draft"
         onClick={onDraftClick}
-        disabled={isDraftDisabled}
+        disabled={isDraftDisabled || isAiMode}
         data-testid="save-draft-btn"
       >
         <Plus className="h-3.5 w-3.5 transition-transform duration-200 group-hover:scale-110" />
@@ -244,9 +266,13 @@ function ActionButtonsGroup({
       <Button
         type="button"
         size="sm"
-        onClick={isScheduled ? onScheduleClick : onPostClick}
-        disabled={isScheduleOrPublishDisabled}
-        className="h-8.5 min-w-[70px] px-4.5 text-xs font-bold rounded-full bg-primary text-primary-foreground hover:bg-primary/90 shadow-2xs hover:shadow-sm transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:scale-[1.03] active:scale-95 cursor-pointer disabled:opacity-50 disabled:hover:scale-100"
+        onClick={handlePrimaryClick}
+        disabled={isPrimaryDisabled}
+        className={`h-8.5 min-w-[70px] px-4.5 text-xs font-bold rounded-full transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] hover:scale-[1.03] active:scale-95 cursor-pointer disabled:opacity-50 disabled:hover:scale-100 ${
+          isAiMode
+            ? "bg-primary/90 hover:bg-primary text-primary-foreground shadow-xs"
+            : "bg-primary text-primary-foreground hover:bg-primary/90 shadow-2xs hover:shadow-sm"
+        }`}
         data-testid="primary-post-btn"
       >
         <span
@@ -260,6 +286,30 @@ function ActionButtonsGroup({
   )
 }
 
+export interface PostActionBarProps {
+  isSubmitting: boolean
+  isContentEmpty: boolean
+  canPublishOrSchedule?: boolean
+  currentLength?: number
+  platform?: Platform
+  isXPremium?: boolean
+  isAiGenerating?: boolean
+  isAiMode?: boolean
+  onActionTypeChange: (type: "draft" | "schedule" | "post") => void
+  onImageClick?: () => void
+  onDraftClick: () => void
+  onToggleAiMode?: () => void
+  onAiDraftSubmit?: () => void
+  onScheduleClick: () => void
+  onPostClick: () => void
+  onCancelClick?: () => void
+  showCancel?: boolean
+  scheduledAt?: Date | undefined
+  onScheduleChange?: (date: Date | undefined) => void
+  isScheduleOpen: boolean
+  onToggleSchedule: (open: boolean) => void
+}
+
 export const PostActionBar = React.memo(function PostActionBar({
   isSubmitting,
   isContentEmpty,
@@ -268,10 +318,12 @@ export const PostActionBar = React.memo(function PostActionBar({
   platform = "linkx",
   isXPremium = false,
   isAiGenerating = false,
+  isAiMode = false,
   onActionTypeChange,
   onImageClick,
   onDraftClick,
-  onAiDraftClick,
+  onToggleAiMode,
+  onAiDraftSubmit,
   onScheduleClick,
   onPostClick,
   onCancelClick,
@@ -298,12 +350,13 @@ export const PostActionBar = React.memo(function PostActionBar({
         isScheduled={isScheduled}
         isSubmitting={isSubmitting}
         isAiGenerating={isAiGenerating}
+        isAiMode={isAiMode}
         scheduledAt={scheduledAt}
         onScheduleChange={onScheduleChange}
         onToggleSchedule={onToggleSchedule}
         onActionTypeChange={onActionTypeChange}
         onImageClick={onImageClick}
-        onAiDraftClick={onAiDraftClick}
+        onToggleAiMode={onToggleAiMode}
       />
 
       <ActionButtonsGroup
@@ -315,10 +368,13 @@ export const PostActionBar = React.memo(function PostActionBar({
         currentLength={currentLength}
         platform={platform}
         isXPremium={isXPremium}
+        isAiMode={isAiMode}
+        isAiGenerating={isAiGenerating}
         onCancelClick={onCancelClick}
         onDraftClick={onDraftClick}
         onScheduleClick={onScheduleClick}
         onPostClick={onPostClick}
+        onAiDraftSubmit={onAiDraftSubmit}
       />
     </div>
   )

--- a/frontend/src/components/PostInput/PostInputBox.tsx
+++ b/frontend/src/components/PostInput/PostInputBox.tsx
@@ -115,12 +115,14 @@ interface PostInputFormBodyProps {
   removeMedia: () => void
   isSubmitting: boolean
   isAiGenerating?: boolean
+  isAiMode?: boolean
   setActionType: (type: "draft" | "schedule" | "post") => void
   canPublishOrSchedule: boolean
   isXPremium?: boolean
   onImageClick: () => void
   handleSubmit: (action: "draft" | "schedule" | "post") => void
-  onAiDraftClick?: () => void
+  onToggleAiMode?: () => void
+  onAiDraftSubmit?: () => void
   onCancel?: () => void
   scheduledAt?: Date
   setScheduledAt: (date?: Date) => void
@@ -140,12 +142,14 @@ function PostInputFormBody({
   removeMedia,
   isSubmitting,
   isAiGenerating,
+  isAiMode = false,
   setActionType,
   canPublishOrSchedule,
   isXPremium,
   onImageClick,
   handleSubmit,
-  onAiDraftClick,
+  onToggleAiMode,
+  onAiDraftSubmit,
   onCancel,
   scheduledAt,
   setScheduledAt,
@@ -170,7 +174,11 @@ function PostInputFormBody({
         ref={textareaRef}
         value={content}
         onChange={handleContentChange}
-        placeholder="What's happening?"
+        placeholder={
+          isAiMode
+            ? "Type a topic, idea, or notes for AI to draft..."
+            : "What's happening?"
+        }
         aria-label="Post content"
         rows={2}
         className="w-full bg-transparent border-0 outline-none resize-none text-[15px] sm:text-[16px] leading-relaxed placeholder:text-muted-foreground/60 focus:outline-none focus:ring-0 p-0 text-foreground min-h-[64px]"
@@ -198,6 +206,7 @@ function PostInputFormBody({
         <PostActionBar
           isSubmitting={isSubmitting}
           isAiGenerating={isAiGenerating}
+          isAiMode={isAiMode}
           isContentEmpty={content.trim().length === 0 && !imageUrl}
           canPublishOrSchedule={canPublishOrSchedule}
           currentLength={content.length}
@@ -206,7 +215,8 @@ function PostInputFormBody({
           onActionTypeChange={setActionType}
           onImageClick={onImageClick}
           onDraftClick={() => handleSubmit("draft")}
-          onAiDraftClick={onAiDraftClick}
+          onToggleAiMode={onToggleAiMode}
+          onAiDraftSubmit={onAiDraftSubmit}
           onScheduleClick={() => handleSubmit("schedule")}
           onPostClick={() => handleSubmit("post")}
           onCancelClick={onCancel}
@@ -342,12 +352,14 @@ export function PostInputBox({
         removeMedia={form.removeMedia}
         isSubmitting={isSubmitting}
         isAiGenerating={form.isGeneratingAiDraft}
+        isAiMode={form.isAiMode}
         setActionType={form.setActionType}
         canPublishOrSchedule={canPublishOrSchedule}
         isXPremium={Boolean(xStatus?.is_premium)}
         onImageClick={() => fileInputRef.current?.click()}
         handleSubmit={onSubmitHandler}
-        onAiDraftClick={onAiDraftHandler}
+        onToggleAiMode={form.toggleAiMode}
+        onAiDraftSubmit={onAiDraftHandler}
         onCancel={onCancel}
         scheduledAt={form.scheduledAt}
         setScheduledAt={form.setScheduledAt}

--- a/frontend/src/components/PostInput/usePostForm.ts
+++ b/frontend/src/components/PostInput/usePostForm.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react"
 import { PostsService } from "@/client"
 import type { Platform } from "@/components/Common/PlatformSelector"
 import useCustomToast from "@/hooks/useCustomToast"
+import { draftingStore } from "@/hooks/useDraftingStore"
 import { handleError } from "@/utils"
 
 export interface UsePostFormOptions {
@@ -176,6 +177,11 @@ function useComposerCoreState(options?: UsePostFormOptions) {
   const [actionType, setActionType] = useState<"draft" | "schedule" | "post">(
     "post",
   )
+  const [isAiMode, setIsAiMode] = useState<boolean>(false)
+
+  const toggleAiMode = useCallback(() => {
+    setIsAiMode((prev) => !prev)
+  }, [])
 
   const handleContentChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -193,6 +199,9 @@ function useComposerCoreState(options?: UsePostFormOptions) {
     setChannel,
     actionType,
     setActionType,
+    isAiMode,
+    setIsAiMode,
+    toggleAiMode,
     handleContentChange,
   }
 }
@@ -200,10 +209,15 @@ function useComposerCoreState(options?: UsePostFormOptions) {
 function useAiDraftMutation(
   showSuccessToast: (msg: string) => void,
   showErrorToast: (msg: string) => void,
-  onDraftGenerated: (content: string) => void,
 ) {
+  const queryClient = useQueryClient()
+
   return useMutation({
-    mutationFn: async (data: { prompt: string; platform: Platform }) => {
+    mutationFn: async (data: {
+      draftId: string
+      prompt: string
+      platform: Platform
+    }) => {
       return await PostsService.generateAiDraft({
         requestBody: {
           prompt: data.prompt,
@@ -211,18 +225,20 @@ function useAiDraftMutation(
         },
       })
     },
-    onSuccess: (res) => {
-      if (res?.content) {
-        onDraftGenerated(res.content)
-        showSuccessToast("AI draft generated!")
-      }
+    onSuccess: (_, variables) => {
+      draftingStore.removeDraft(variables.draftId)
+      showSuccessToast("Draft created and saved to your drafts!")
+      queryClient.invalidateQueries({ queryKey: ["posts"] })
     },
-    onError: handleError.bind(showErrorToast),
+    onError: (err, variables) => {
+      draftingStore.removeDraft(variables.draftId)
+      handleError.call(showErrorToast, err as any)
+    },
   })
 }
 
 export function usePostForm(options?: UsePostFormOptions) {
-  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const { showSuccessToast, showErrorToast, showInfoToast } = useCustomToast()
   const core = useComposerCoreState(options)
   const media = useComposerMedia(showErrorToast, options?.initialImageUrl)
 
@@ -231,6 +247,7 @@ export function usePostForm(options?: UsePostFormOptions) {
     core.setScheduledAt(undefined)
     core.setChannel("linkx")
     core.setActionType("post")
+    core.setIsAiMode(false)
     media.removeMedia()
   }, [core, media])
 
@@ -240,18 +257,36 @@ export function usePostForm(options?: UsePostFormOptions) {
     onSuccessReset: resetForm,
   })
 
-  const aiDraftMutation = useAiDraftMutation(
-    showSuccessToast,
-    showErrorToast,
-    (generatedContent) => core.setContent(generatedContent),
-  )
+  const aiDraftMutation = useAiDraftMutation(showSuccessToast, showErrorToast)
 
   const handleAiDraft = useCallback(() => {
+    const prompt = core.content.trim()
+    if (!prompt) return
+
+    const draftId = `draft-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+
+    // Add to in-flight drafting list immediately
+    draftingStore.addDraft({
+      id: draftId,
+      prompt,
+      platform: core.channel,
+      startedAt: new Date(),
+    })
+
+    // Immediately free the input box for the user's next post
+    core.setContent("")
+    core.setIsAiMode(false)
+
+    // Show initial notification toast
+    showInfoToast("Drafting post in background with AI...", "Drafting...")
+
+    // Trigger background generation
     aiDraftMutation.mutate({
-      prompt: core.content,
+      draftId,
+      prompt,
       platform: core.channel,
     })
-  }, [core.content, core.channel, aiDraftMutation])
+  }, [core, showInfoToast, aiDraftMutation])
 
   const handleSubmit = useCallback(
     (action: "draft" | "schedule" | "post") => {
@@ -280,6 +315,6 @@ export function usePostForm(options?: UsePostFormOptions) {
     handleSubmit,
     createPostMutation,
     handleAiDraft,
-    isGeneratingAiDraft: aiDraftMutation.isPending,
+    isGeneratingAiDraft: false,
   }
 }

--- a/frontend/src/components/Timeline/TrendingTopics.tsx
+++ b/frontend/src/components/Timeline/TrendingTopics.tsx
@@ -1,9 +1,10 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Bot, RefreshCw } from "lucide-react"
+import { Bot, Loader2, RefreshCw } from "lucide-react"
 import * as React from "react"
 import { TrendingService, type TrendingTopicPublic } from "@/client"
 import { Button } from "@/components/ui/button"
 import useCustomToast from "@/hooks/useCustomToast"
+import { draftingStore } from "@/hooks/useDraftingStore"
 import { formatRelativeTime, handleError } from "@/utils"
 
 export type TrendingTopic = TrendingTopicPublic
@@ -110,10 +111,11 @@ function TrendingEmptyState({ isPending, onRefresh }: EmptyProps) {
 
 interface RowProps {
   topic: TrendingTopicPublic
-  onTopicDraft?: (topicTitle: string) => void
+  isDrafting?: boolean
+  onDraft: () => void
 }
 
-function TrendingTopicRow({ topic, onTopicDraft }: RowProps) {
+function TrendingTopicRow({ topic, isDrafting = false, onDraft }: RowProps) {
   const postCountStr = formatPostCount(topic.post_count)
 
   return (
@@ -135,16 +137,25 @@ function TrendingTopicRow({ topic, onTopicDraft }: RowProps) {
         <span className="text-xs text-muted-foreground">
           {postCountStr || ""}
         </span>
-        {onTopicDraft && (
-          <button
-            type="button"
-            onClick={() => onTopicDraft(topic.topic_title)}
-            className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-primary transition-colors cursor-pointer focus:outline-none"
-          >
-            <Bot className="h-3.5 w-3.5" />
-            <span>Draft</span>
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={onDraft}
+          disabled={isDrafting}
+          className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-primary transition-colors cursor-pointer focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed"
+          title={`Generate AI draft from "${topic.topic_title}"`}
+        >
+          {isDrafting ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+              <span className="text-primary font-semibold">Drafting…</span>
+            </>
+          ) : (
+            <>
+              <Bot className="h-3.5 w-3.5" />
+              <span>Draft</span>
+            </>
+          )}
+        </button>
       </div>
     </div>
   )
@@ -157,7 +168,10 @@ export function TrendingTopics({
   onTopicDraft,
 }: TrendingTopicsProps) {
   const queryClient = useQueryClient()
-  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const { showSuccessToast, showErrorToast, showInfoToast } = useCustomToast()
+  const [draftingTopicId, setDraftingTopicId] = React.useState<string | null>(
+    null,
+  )
 
   const extractMutation = useMutation({
     mutationFn: async () =>
@@ -173,6 +187,53 @@ export function TrendingTopics({
     },
     onError: handleError.bind(showErrorToast),
   })
+
+  const draftMutation = useMutation({
+    mutationFn: async ({
+      topicId,
+    }: {
+      topicId: string
+      topicTitle: string
+    }) => {
+      setDraftingTopicId(topicId)
+      return TrendingService.draftFromTrendingTopic({ topicId })
+    },
+    onSuccess: (_, variables) => {
+      draftingStore.removeDraft(`trend-${variables.topicId}`)
+      showSuccessToast(
+        `Draft created from trending topic: "${variables.topicTitle}"`,
+      )
+      queryClient.invalidateQueries({ queryKey: ["posts"] })
+    },
+    onError: (err, variables) => {
+      draftingStore.removeDraft(`trend-${variables.topicId}`)
+      handleError.call(showErrorToast, err as any)
+    },
+    onSettled: () => {
+      setDraftingTopicId(null)
+    },
+  })
+
+  const handleDraftClick = (topic: TrendingTopicPublic) => {
+    if (onTopicDraft) {
+      onTopicDraft(topic.topic_title)
+    } else {
+      draftingStore.addDraft({
+        id: `trend-${topic.id}`,
+        prompt: topic.topic_title,
+        platform: "both",
+        startedAt: new Date(),
+      })
+      showInfoToast(
+        `Drafting post from "${topic.topic_title}" in background...`,
+        "Drafting...",
+      )
+      draftMutation.mutate({
+        topicId: topic.id,
+        topicTitle: topic.topic_title,
+      })
+    }
+  }
 
   const relativeTime = React.useMemo(() => {
     if (!lastScrapedAt) return null
@@ -199,7 +260,8 @@ export function TrendingTopics({
             <TrendingTopicRow
               key={topic.id}
               topic={topic}
-              onTopicDraft={onTopicDraft}
+              isDrafting={draftingTopicId === topic.id}
+              onDraft={() => handleDraftClick(topic)}
             />
           ))}
         </div>

--- a/frontend/src/hooks/useCustomToast.ts
+++ b/frontend/src/hooks/useCustomToast.ts
@@ -14,7 +14,16 @@ const useCustomToast = () => {
     })
   }, [])
 
-  return { showSuccessToast, showErrorToast }
+  const showInfoToast = React.useCallback(
+    (description: string, title = "Drafting...") => {
+      toast.info(title, {
+        description,
+      })
+    },
+    [],
+  )
+
+  return { showSuccessToast, showErrorToast, showInfoToast }
 }
 
 export default useCustomToast

--- a/frontend/src/hooks/useDraftingStore.ts
+++ b/frontend/src/hooks/useDraftingStore.ts
@@ -1,0 +1,44 @@
+import * as React from "react"
+import type { Platform } from "@/components/Common/PlatformSelector"
+
+export interface ActiveDraftItem {
+  id: string
+  prompt: string
+  platform: Platform | string
+  startedAt: Date
+}
+
+let activeDrafts: ActiveDraftItem[] = []
+const listeners = new Set<() => void>()
+
+function emitChange() {
+  listeners.forEach((listener) => {
+    listener()
+  })
+}
+
+export const draftingStore = {
+  addDraft(draft: ActiveDraftItem) {
+    activeDrafts = [draft, ...activeDrafts]
+    emitChange()
+  },
+  removeDraft(id: string) {
+    activeDrafts = activeDrafts.filter((d) => d.id !== id)
+    emitChange()
+  },
+  getDrafts() {
+    return activeDrafts
+  },
+  subscribe(listener: () => void) {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  },
+}
+
+export function useActiveDrafts(): ActiveDraftItem[] {
+  return React.useSyncExternalStore(
+    draftingStore.subscribe,
+    draftingStore.getDrafts,
+    draftingStore.getDrafts,
+  )
+}

--- a/frontend/src/routes/_layout/home.tsx
+++ b/frontend/src/routes/_layout/home.tsx
@@ -4,8 +4,7 @@ import { Loader2 } from "lucide-react"
 import * as React from "react"
 import { PostsService, TrendingService } from "@/client"
 import type { Platform } from "@/components/Common/PlatformSelector"
-import type { PostedData } from "@/components/Post/Posted"
-import { Posted } from "@/components/Post/Posted"
+import { DraftingPost, Posted, type PostedData } from "@/components/Post"
 import {
   PostPreviewDialog,
   type PreviewPostData,
@@ -27,6 +26,7 @@ import {
 import { LoadingButton } from "@/components/ui/loading-button"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
+import { useActiveDrafts } from "@/hooks/useDraftingStore"
 import { transformToPostedPost, transformToScheduledPost } from "@/utils"
 
 type TimelinePost =
@@ -78,8 +78,8 @@ function convertToPreviewData(post: TimelinePost): PreviewPostData {
 function TimelinePage() {
   const queryClient = useQueryClient()
   const { user } = useAuth()
-
-  const [draftContent, setDraftContent] = React.useState<string>("")
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const activeDrafts = useActiveDrafts()
   const [editingPostId, setEditingPostId] = React.useState<string | null>(null)
 
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
@@ -92,8 +92,6 @@ function TimelinePage() {
   const [previewPost, setPreviewPost] = React.useState<PreviewPostData | null>(
     null,
   )
-
-  const { showSuccessToast, showErrorToast } = useCustomToast()
 
   const { data: scheduledData, isLoading: isLoadingScheduled } = useQuery({
     queryKey: ["posts", "scheduled"],
@@ -271,11 +269,6 @@ function TimelinePage() {
     }
   }
 
-  const handleTopicDraft = (topicTitle: string) => {
-    setDraftContent(topicTitle)
-    window.scrollTo({ top: 0, behavior: "smooth" })
-  }
-
   const sortedPosts = React.useMemo(() => {
     const toTime = (d: Date | string) =>
       (typeof d === "string" ? new Date(d) : d).getTime()
@@ -302,13 +295,34 @@ function TimelinePage() {
           <PostInputBox
             username={user?.full_name || user?.email || "User"}
             avatarUrl={undefined}
-            initialContent={draftContent}
             onSubmit={() => {
-              setDraftContent("")
               queryClient.invalidateQueries({ queryKey: ["posts"] })
             }}
           />
         </div>
+
+        {/* In-Flight Background AI Drafts */}
+        {activeDrafts.length > 0 && (
+          <div className="w-full">
+            {activeDrafts.map((draft) => (
+              <DraftingPost
+                key={draft.id}
+                isDrafting
+                post={{
+                  id: draft.id,
+                  author: {
+                    name: user?.full_name || user?.email || "You",
+                    username: user?.email?.split("@")[0] || "user",
+                  },
+                  content: draft.prompt,
+                  createdAt: draft.startedAt,
+                  platform: (draft.platform as any) || "linkx",
+                  status: "drafting",
+                }}
+              />
+            ))}
+          </div>
+        )}
 
         {/* Feed Posts */}
         {isLoadingScheduled || isLoadingPublished ? (
@@ -318,7 +332,7 @@ function TimelinePage() {
               Loading timeline...
             </p>
           </div>
-        ) : sortedPosts.length === 0 ? (
+        ) : sortedPosts.length === 0 && activeDrafts.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
             <p className="text-sm text-muted-foreground">
               No posts in your timeline yet. Create a draft or schedule your
@@ -368,7 +382,6 @@ function TimelinePage() {
           <TrendingTopics
             topics={trendingTopics}
             lastScrapedAt={latestScrapedAt}
-            onTopicDraft={handleTopicDraft}
           />
         </div>
       </div>

--- a/frontend/src/routes/_layout/posts.tsx
+++ b/frontend/src/routes/_layout/posts.tsx
@@ -15,6 +15,7 @@ import * as React from "react"
 import { PostsService, type PostUpdate } from "@/client"
 import type { Platform } from "@/components/Common/PlatformSelector"
 import {
+  DraftingPost,
   DraftPost,
   FailedPost,
   Posted,
@@ -43,7 +44,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
+import { useActiveDrafts } from "@/hooks/useDraftingStore"
 import {
   handleError,
   transformToDraftPost,
@@ -688,8 +691,29 @@ function PostsFeedList({
   onPublish: (id: string) => void
   isPublishing: (id: string) => boolean
 }) {
+  const activeDrafts = useActiveDrafts()
+  const { user } = useAuth()
+
   return (
     <div className="w-full pb-20">
+      {activeCategory === "drafts" &&
+        activeDrafts.map((draft) => (
+          <DraftingPost
+            key={draft.id}
+            isDrafting
+            post={{
+              id: draft.id,
+              author: {
+                name: user?.full_name || user?.email || "You",
+                username: user?.email?.split("@")[0] || "user",
+              },
+              content: draft.prompt,
+              createdAt: draft.startedAt,
+              platform: (draft.platform as any) || "linkx",
+              status: "drafting",
+            }}
+          />
+        ))}
       {activePosts.map((post) => {
         const isEditing = editingPostId === post.id
 
@@ -879,6 +903,7 @@ export function PostsPage() {
     React.useState<Platform>("linkedin")
 
   const { showSuccessToast, showErrorToast } = useCustomToast()
+  const activeDrafts = useActiveDrafts()
 
   const {
     data: postsData,
@@ -1054,7 +1079,8 @@ export function PostsPage() {
                 Loading posts...
               </p>
             </div>
-          ) : activePosts.length === 0 ? (
+          ) : activePosts.length === 0 &&
+            (activeCategory !== "drafts" || activeDrafts.length === 0) ? (
             <PostsEmptyState
               activeCategory={activeCategory}
               hasActiveFilters={hasActiveFilters}


### PR DESCRIPTION
## Summary of Changes

### 1. Backend Orchestration & Curation Integration
- **Direct DB Draft Curation**: Updated `POST /api/v1/posts/ai-draft` and added `POST /api/v1/trending/{topic_id}/draft` to invoke `CurationGraph` (`curate_and_draft_post`), which refines platform constraints and saves directly into the PostgreSQL `Post` table with `status="draft"`.
- **OpenAPI Client Generation**: Regenerated typed frontend TypeScript SDK with `TrendingService.draftFromTrendingTopic` and `AIDraftResponse.post_id`.

### 2. Frontend Non-Blocking Background AI Drafting
- **Instant Composer Freeing**: Hitting **Draft** immediately clears the input box, resets the toggle, and fires non-blocking background generation with instant `Drafting...` toast notifications.
- **In-Flight Feed State via Reusable `PostCard`**: Powered by native `isDrafting` state in `PostCard`, rendering the exact prompt, subtle loading skeleton placeholders, and disabled action footers across `/home` and `/posts`.
- **Trending Topics One-Click Curation**: One-click drafting directly from trending topic cards with live status updates and automatic timeline cache invalidation.

### Verification
- **Backend**: `uv run pytest tests/ -v` (523 tests passing)
- **Frontend**: `bun run lint && bun run build` (zero errors)