### PR TITLE
feat(ai): hover copy actions, voice input, live markdown, and scroll stability (#113)

### DIFF
--- a/backend/app/services/ai_chat_runner.py
+++ b/backend/app/services/ai_chat_runner.py
@@ -48,15 +48,35 @@ def _extract_text_from_parts(parts: list[dict[str, Any]]) -> str:
     return "\n".join(text_chunks).strip()
 
 
+def _extract_thought_from_parts(parts: list[dict[str, Any]]) -> str:
+    """Extract concatenated thought content from message parts."""
+    thoughts = [
+        str(part.get("content", ""))
+        for part in parts
+        if part.get("type") == "thought" and part.get("content")
+    ]
+    return "\n".join(thoughts).strip()
+
+
+def _build_assistant_history_content(thought: str, text: str) -> str:
+    if thought and text:
+        return f"<thought>{thought}</thought>\n\n{text}"
+    if thought:
+        return f"<thought>{thought}</thought>"
+    return text
+
+
 def _convert_transcript_item(item: dict[str, Any]) -> BaseMessage | None:
     role = item.get("role")
-    text = _extract_text_from_parts(item.get("parts", []))
-    if not text:
+    parts = item.get("parts", [])
+    text = _extract_text_from_parts(parts)
+    thought = _extract_thought_from_parts(parts)
+    if not text and not thought:
         return None
     if role == "user":
         return HumanMessage(content=text)
     if role == "assistant":
-        return AIMessage(content=text)
+        return AIMessage(content=_build_assistant_history_content(thought, text))
     return None
 
 
@@ -100,7 +120,7 @@ async def default_chat_stream_runner(
     *,
     message: str,
     transcript: dict[str, Any] | None = None,
-    smooth_delay: float = 0.015,
+    smooth_delay: float = 0.0,
     model: str | None = None,
 ) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
     """Stream AI chat conversation tokens and thinking thoughts word-by-word."""

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "react-hook-form": "^7.80.0",
         "react-icons": "^5.7.0",
         "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
@@ -868,6 +869,8 @@
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -1027,6 +1030,8 @@
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "react-hook-form": "^7.80.0",
     "react-icons": "^5.7.0",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/frontend/src/components/Chat/AIChatFeed.tsx
+++ b/frontend/src/components/Chat/AIChatFeed.tsx
@@ -62,11 +62,7 @@ export function AIChatFeed({
         <MessageScrollerViewport>
           <MessageScrollerContent className="mx-auto flex w-full max-w-2xl flex-col gap-6 px-4 py-6">
             {localMessages.map((message, index) => (
-              <MessageScrollerItem
-                key={message.id}
-                messageId={message.id}
-                scrollAnchor={message.role === "user"}
-              >
+              <MessageScrollerItem key={message.id} messageId={message.id}>
                 <ChatMessage
                   message={message}
                   isStreaming={

--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -1,3 +1,4 @@
+import { ChatMessageActions } from "@/components/Chat/ChatMessageActions"
 import { DraftArtifactCard } from "@/components/Chat/DraftArtifactCard"
 import { TextPart } from "@/components/Chat/parts/TextPart"
 import { ThoughtPart } from "@/components/Chat/parts/ThoughtPart"
@@ -12,22 +13,43 @@ export interface ChatMessageProps {
   isStreaming?: boolean
 }
 
+function extractTextParts(parts: ChatUIMessage["parts"]): string {
+  return parts
+    .filter(
+      (p): p is { type: "text"; text: string } =>
+        p.type === "text" && Boolean(p.text),
+    )
+    .map((p) => p.text)
+    .join("\n\n")
+    .trim()
+}
+
+function getMessageTimestamp(message: ChatUIMessage): string | undefined {
+  return message.createdAt || (message as { created_at?: string }).created_at
+}
+
 function UserMessageBubble({ message }: { message: ChatUIMessage }) {
-  const text = message.parts
-    .filter((part) => part.type === "text")
-    .map((part) => part.text)
-    .join("")
+  const text = extractTextParts(message.parts)
+  const createdAt = getMessageTimestamp(message)
 
   return (
-    <Message align="end">
-      <MessageContent>
-        <Bubble align="end" variant="outline">
-          <BubbleContent className="rounded-3xl border border-border bg-background text-foreground font-normal px-5 py-3 leading-relaxed shadow-none">
-            {text}
-          </BubbleContent>
-        </Bubble>
-      </MessageContent>
-    </Message>
+    <div className="group relative flex flex-col items-end w-full">
+      <Message align="end">
+        <MessageContent>
+          <Bubble align="end" variant="outline">
+            <BubbleContent className="rounded-3xl border border-border bg-background text-foreground font-normal px-5 py-3 leading-relaxed shadow-none">
+              {text}
+            </BubbleContent>
+          </Bubble>
+        </MessageContent>
+      </Message>
+      <ChatMessageActions
+        textToCopy={text}
+        createdAt={createdAt}
+        align="end"
+        className="pr-2 pt-0.5"
+      />
+    </div>
   )
 }
 
@@ -105,24 +127,45 @@ export function ChatMessage({
     (part): part is SourceUrlPart => part.type === "source-url",
   )
 
+  const hasThoughtPart = message.parts.some((p) => p.type === "thought")
   const hasResponseStarted = message.parts.some(
     (p) => p.type === "text" && Boolean(p.text?.trim()),
   )
+  const assistantText = extractTextParts(message.parts)
+  const createdAt = getMessageTimestamp(message)
 
   return (
-    <Message align="start">
-      <MessageContent>
-        {message.parts.map((part, index) => (
-          <AssistantPartRenderer
-            key={index}
-            part={part}
-            index={index}
-            isStreaming={isStreaming}
-            hasResponseStarted={hasResponseStarted}
-            sources={sources}
-          />
-        ))}
-      </MessageContent>
-    </Message>
+    <div className="group relative flex flex-col items-start w-full">
+      <Message align="start">
+        <MessageContent>
+          {isStreaming && !hasThoughtPart && !hasResponseStarted && (
+            <ThoughtPart
+              part={{ type: "thought", content: "" }}
+              isStreaming={true}
+              hasResponseStarted={false}
+            />
+          )}
+
+          {message.parts.map((part, index) => (
+            <AssistantPartRenderer
+              key={index}
+              part={part}
+              index={index}
+              isStreaming={isStreaming}
+              hasResponseStarted={hasResponseStarted}
+              sources={sources}
+            />
+          ))}
+        </MessageContent>
+      </Message>
+      {!isStreaming && assistantText && (
+        <ChatMessageActions
+          textToCopy={assistantText}
+          createdAt={createdAt}
+          align="start"
+          className="pl-2 pt-0.5"
+        />
+      )}
+    </div>
   )
 }

--- a/frontend/src/components/Chat/ChatMessageActions.tsx
+++ b/frontend/src/components/Chat/ChatMessageActions.tsx
@@ -1,0 +1,92 @@
+import { Check, Copy } from "lucide-react"
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface ChatMessageActionsProps {
+  textToCopy: string
+  createdAt?: string
+  align?: "start" | "end"
+  className?: string
+}
+
+function formatMessageTime(createdAt?: string): string {
+  if (!createdAt) return ""
+  try {
+    const date = new Date(createdAt)
+    if (Number.isNaN(date.getTime())) return ""
+    return new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(date)
+  } catch {
+    return ""
+  }
+}
+
+export function ChatMessageActions({
+  textToCopy,
+  createdAt,
+  align = "start",
+  className,
+}: ChatMessageActionsProps) {
+  const [copied, setCopied] = React.useState(false)
+  const timeString = React.useMemo(
+    () => formatMessageTime(createdAt),
+    [createdAt],
+  )
+
+  const handleCopy = React.useCallback(async () => {
+    if (!textToCopy) return
+    try {
+      await navigator.clipboard.writeText(textToCopy)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // ignore clipboard error
+    }
+  }, [textToCopy])
+
+  const copyButton = textToCopy ? (
+    <button
+      type="button"
+      aria-label={copied ? "Copied to clipboard" : "Copy message"}
+      onClick={handleCopy}
+      className="flex size-6 items-center justify-center rounded-md text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground transition-colors cursor-pointer"
+    >
+      {copied ? (
+        <Check className="size-3 text-emerald-500" />
+      ) : (
+        <Copy className="size-3" />
+      )}
+    </button>
+  ) : null
+
+  const timeBadge = timeString ? (
+    <span className="text-[11px] text-muted-foreground/70 font-normal px-1">
+      {timeString}
+    </span>
+  ) : null
+
+  return (
+    <div
+      data-slot="message-actions"
+      className={cn(
+        "flex items-center gap-1.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity duration-150 select-none py-1 text-xs text-muted-foreground",
+        align === "end" ? "justify-end" : "justify-start",
+        className,
+      )}
+    >
+      {align === "start" ? (
+        <>
+          {copyButton}
+          {timeBadge}
+        </>
+      ) : (
+        <>
+          {timeBadge}
+          {copyButton}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Chat/PromptForm.tsx
+++ b/frontend/src/components/Chat/PromptForm.tsx
@@ -1,22 +1,19 @@
 import { Plus } from "lucide-react"
-import * as React from "react"
+import type * as React from "react"
 
-import {
-  type AttachmentImage,
-  AttachmentPreviewStrip,
-} from "@/components/Chat/AttachmentPreviewStrip"
+import { AttachmentPreviewStrip } from "@/components/Chat/AttachmentPreviewStrip"
 import {
   type AIModelOption,
   ModelSelectorPill,
 } from "@/components/Chat/ModelSelectorPill"
 import { PromptSubmitButton } from "@/components/Chat/PromptSubmitButton"
+import { usePromptFormState } from "@/components/Chat/usePromptFormState"
 import { VoiceInputButton } from "@/components/Chat/VoiceInputButton"
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupTextarea,
 } from "@/components/ui/input-group"
-import { useSpeechRecognition } from "@/hooks/useSpeechRecognition"
 
 export type { AIModelOption }
 
@@ -36,127 +33,6 @@ export interface PromptFormProps {
   onValueChange?: (value: string) => void
 }
 
-const FALLBACK_MODELS: AIModelOption[] = [
-  { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash", provider: "Google" },
-  { id: "claude-sonnet-4-6", name: "Claude 3.7 Sonnet", provider: "Anthropic" },
-  { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "OpenAI" },
-  { id: "gpt-5.4", name: "GPT-5.4", provider: "OpenAI" },
-  { id: "gpt-oss-120b-medium", name: "DeepSeek R1", provider: "OpenSource" },
-]
-
-function normalizeModels(models?: (AIModelOption | string)[]): AIModelOption[] {
-  if (!models || models.length === 0) return FALLBACK_MODELS
-  return models.map((m) => (typeof m === "string" ? { id: m, name: m } : m))
-}
-
-function useImageAttachments() {
-  const [selectedImages, setSelectedImages] = React.useState<AttachmentImage[]>(
-    [],
-  )
-  const fileInputRef = React.useRef<HTMLInputElement>(null)
-
-  function handleImageSelect(e: React.ChangeEvent<HTMLInputElement>) {
-    const files = e.target.files
-    if (!files || files.length === 0) return
-
-    const newImages = Array.from(files).map((file) => ({
-      file,
-      preview: URL.createObjectURL(file),
-    }))
-
-    setSelectedImages((prev) => [...prev, ...newImages])
-    if (fileInputRef.current) {
-      fileInputRef.current.value = ""
-    }
-  }
-
-  function handleRemoveImage(index: number) {
-    setSelectedImages((prev) => {
-      const target = prev[index]
-      if (target) {
-        URL.revokeObjectURL(target.preview)
-      }
-      return prev.filter((_, i) => i !== index)
-    })
-  }
-
-  function clearImages() {
-    setSelectedImages([])
-  }
-
-  return {
-    selectedImages,
-    fileInputRef,
-    handleImageSelect,
-    handleRemoveImage,
-    clearImages,
-  }
-}
-
-function usePromptVoiceInput({
-  input,
-  updateInput,
-}: {
-  input: string
-  updateInput: (val: string) => void
-}) {
-  const baseInputRef = React.useRef(input)
-
-  const handleTranscriptChange = React.useCallback(
-    ({ transcript: voiceText }: { transcript: string }) => {
-      if (!voiceText) return
-      const base = baseInputRef.current.trim()
-      const separator = base && voiceText ? " " : ""
-      const fullText = base + separator + voiceText
-      updateInput(fullText)
-    },
-    [updateInput],
-  )
-
-  const {
-    isListening: isVoiceListening,
-    isSupported: isVoiceSupported,
-    startListening,
-    stopListening: stopVoiceListening,
-    resetTranscript,
-    error: voiceError,
-  } = useSpeechRecognition({
-    onTranscriptChange: handleTranscriptChange,
-  })
-
-  const handleToggleVoice = React.useCallback(() => {
-    baseInputRef.current = input
-    resetTranscript()
-    if (isVoiceListening) {
-      stopVoiceListening()
-    } else {
-      startListening()
-    }
-  }, [
-    isVoiceListening,
-    stopVoiceListening,
-    startListening,
-    resetTranscript,
-    input,
-  ])
-
-  function stopAndReset() {
-    if (isVoiceListening) {
-      stopVoiceListening()
-    }
-    resetTranscript()
-    baseInputRef.current = ""
-  }
-
-  return {
-    isVoiceListening,
-    isVoiceSupported,
-    voiceError,
-    handleToggleVoice,
-    stopAndReset,
-  }
-}
-
 export function PromptForm({
   onSubmit,
   onStop,
@@ -172,82 +48,35 @@ export function PromptForm({
   initialValue = "",
   onValueChange,
 }: PromptFormProps) {
-  const [input, setInput] = React.useState(initialValue)
-  const [localModelId, setLocalModelId] = React.useState(
-    selectedModelId || "gemini-3.6-flash-high",
-  )
-
-  const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
-  const effectiveInputRef = inputRef || internalInputRef
-  const onValueChangeRef = React.useRef(onValueChange)
-
   const {
-    selectedImages,
+    input,
+    updateInput,
+    effectiveInputRef,
     fileInputRef,
+    selectedImages,
     handleImageSelect,
     handleRemoveImage,
-    clearImages,
-  } = useImageAttachments()
-
-  React.useEffect(() => {
-    onValueChangeRef.current = onValueChange
-  })
-
-  const updateInput = React.useCallback((val: string) => {
-    setInput(val)
-    onValueChangeRef.current?.(val)
-  }, [])
-
-  const {
+    activeModelId,
+    normalizedModels,
+    handleSelectModel,
     isVoiceListening,
     isVoiceSupported,
     voiceError,
     handleToggleVoice,
-    stopAndReset,
-  } = usePromptVoiceInput({ input, updateInput })
-
-  const activeModelId = selectedModelId || localModelId
-  const normalizedModels = React.useMemo(
-    () => normalizeModels(models),
-    [models],
-  )
-
-  React.useEffect(() => {
-    if (autoFocus) {
-      effectiveInputRef.current?.focus()
-    }
-  }, [autoFocus, effectiveInputRef])
-
-  function handleSubmit(event?: React.FormEvent) {
-    event?.preventDefault()
-    stopAndReset()
-    const text = input.trim()
-    if ((!text && selectedImages.length === 0) || isBusy) return
-
-    if (selectedImages.length > 0) {
-      onSubmit(
-        text,
-        selectedImages.map((img) => img.file),
-      )
-    } else {
-      onSubmit(text)
-    }
-    updateInput("")
-    clearImages()
-  }
-
-  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (
-      event.key === "Enter" &&
-      !event.shiftKey &&
-      !event.nativeEvent.isComposing
-    ) {
-      event.preventDefault()
-      handleSubmit()
-    }
-  }
-
-  const hasContent = input.trim().length > 0 || selectedImages.length > 0
+    handleSubmit,
+    handleKeyDown,
+    hasContent,
+  } = usePromptFormState({
+    initialValue,
+    selectedModelId,
+    models,
+    onSelectModel,
+    onValueChange,
+    onSubmit,
+    isBusy,
+    autoFocus,
+    inputRef,
+  })
 
   return (
     <form onSubmit={handleSubmit} className={className}>
@@ -293,10 +122,7 @@ export function PromptForm({
             <ModelSelectorPill
               selectedModelId={activeModelId}
               models={normalizedModels}
-              onSelectModel={(mId) => {
-                setLocalModelId(mId)
-                onSelectModel?.(mId)
-              }}
+              onSelectModel={handleSelectModel}
             />
 
             <VoiceInputButton

--- a/frontend/src/components/Chat/PromptForm.tsx
+++ b/frontend/src/components/Chat/PromptForm.tsx
@@ -93,54 +93,14 @@ function useImageAttachments() {
   }
 }
 
-export function PromptForm({
-  onSubmit,
-  onStop,
-  isBusy = false,
-  placeholder = "Ask anything",
-  selectedModelId,
-  models,
-  onSelectModel,
-  inputRef,
-  autoFocus = false,
-  actions,
-  className,
-  initialValue = "",
-  onValueChange,
-}: PromptFormProps) {
-  const [input, setInput] = React.useState(initialValue)
-  const [localModelId, setLocalModelId] = React.useState(
-    selectedModelId || "gemini-3.6-flash-high",
-  )
-
-  const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
-  const effectiveInputRef = inputRef || internalInputRef
-  const baseInputRef = React.useRef(initialValue)
-  const onValueChangeRef = React.useRef(onValueChange)
-
-  const {
-    selectedImages,
-    fileInputRef,
-    handleImageSelect,
-    handleRemoveImage,
-    clearImages,
-  } = useImageAttachments()
-
-  React.useEffect(() => {
-    onValueChangeRef.current = onValueChange
-  })
-
-  const updateInput = React.useCallback((val: string) => {
-    setInput(val)
-    baseInputRef.current = val
-    onValueChangeRef.current?.(val)
-  }, [])
-
-  const activeModelId = selectedModelId || localModelId
-  const normalizedModels = React.useMemo(
-    () => normalizeModels(models),
-    [models],
-  )
+function usePromptVoiceInput({
+  input,
+  updateInput,
+}: {
+  input: string
+  updateInput: (val: string) => void
+}) {
+  const baseInputRef = React.useRef(input)
 
   const handleTranscriptChange = React.useCallback(
     ({ transcript: voiceText }: { transcript: string }) => {
@@ -148,10 +108,9 @@ export function PromptForm({
       const base = baseInputRef.current.trim()
       const separator = base && voiceText ? " " : ""
       const fullText = base + separator + voiceText
-      setInput(fullText)
-      onValueChangeRef.current?.(fullText)
+      updateInput(fullText)
     },
-    [],
+    [updateInput],
   )
 
   const {
@@ -181,24 +140,87 @@ export function PromptForm({
     input,
   ])
 
+  function stopAndReset() {
+    if (isVoiceListening) {
+      stopVoiceListening()
+    }
+    resetTranscript()
+    baseInputRef.current = ""
+  }
+
+  return {
+    isVoiceListening,
+    isVoiceSupported,
+    voiceError,
+    handleToggleVoice,
+    stopAndReset,
+  }
+}
+
+export function PromptForm({
+  onSubmit,
+  onStop,
+  isBusy = false,
+  placeholder = "Ask anything",
+  selectedModelId,
+  models,
+  onSelectModel,
+  inputRef,
+  autoFocus = false,
+  actions,
+  className,
+  initialValue = "",
+  onValueChange,
+}: PromptFormProps) {
+  const [input, setInput] = React.useState(initialValue)
+  const [localModelId, setLocalModelId] = React.useState(
+    selectedModelId || "gemini-3.6-flash-high",
+  )
+
+  const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
+  const effectiveInputRef = inputRef || internalInputRef
+  const onValueChangeRef = React.useRef(onValueChange)
+
+  const {
+    selectedImages,
+    fileInputRef,
+    handleImageSelect,
+    handleRemoveImage,
+    clearImages,
+  } = useImageAttachments()
+
+  React.useEffect(() => {
+    onValueChangeRef.current = onValueChange
+  })
+
+  const updateInput = React.useCallback((val: string) => {
+    setInput(val)
+    onValueChangeRef.current?.(val)
+  }, [])
+
+  const {
+    isVoiceListening,
+    isVoiceSupported,
+    voiceError,
+    handleToggleVoice,
+    stopAndReset,
+  } = usePromptVoiceInput({ input, updateInput })
+
+  const activeModelId = selectedModelId || localModelId
+  const normalizedModels = React.useMemo(
+    () => normalizeModels(models),
+    [models],
+  )
+
   React.useEffect(() => {
     if (autoFocus) {
       effectiveInputRef.current?.focus()
     }
   }, [autoFocus, effectiveInputRef])
 
-  function handleSelectModel(mId: string) {
-    setLocalModelId(mId)
-    onSelectModel?.(mId)
-  }
-
   function handleSubmit(event?: React.FormEvent) {
     event?.preventDefault()
-    if (isVoiceListening) {
-      stopVoiceListening()
-    }
-    resetTranscript()
-    baseInputRef.current = ""
+    stopAndReset()
     const text = input.trim()
     if ((!text && selectedImages.length === 0) || isBusy) return
 
@@ -271,7 +293,10 @@ export function PromptForm({
             <ModelSelectorPill
               selectedModelId={activeModelId}
               models={normalizedModels}
-              onSelectModel={handleSelectModel}
+              onSelectModel={(mId) => {
+                setLocalModelId(mId)
+                onSelectModel?.(mId)
+              }}
             />
 
             <VoiceInputButton

--- a/frontend/src/components/Chat/PromptForm.tsx
+++ b/frontend/src/components/Chat/PromptForm.tsx
@@ -44,103 +44,16 @@ const FALLBACK_MODELS: AIModelOption[] = [
   { id: "gpt-oss-120b-medium", name: "DeepSeek R1", provider: "OpenSource" },
 ]
 
-export function PromptForm({
-  onSubmit,
-  onStop,
-  isBusy = false,
-  placeholder = "Ask anything",
-  selectedModelId,
-  models,
-  onSelectModel,
-  inputRef,
-  autoFocus = false,
-  actions,
-  className,
-  initialValue = "",
-  onValueChange,
-}: PromptFormProps) {
-  const [input, setInput] = React.useState(initialValue)
-  const [localModelId, setLocalModelId] = React.useState(
-    selectedModelId || "gemini-3.6-flash-high",
-  )
+function normalizeModels(models?: (AIModelOption | string)[]): AIModelOption[] {
+  if (!models || models.length === 0) return FALLBACK_MODELS
+  return models.map((m) => (typeof m === "string" ? { id: m, name: m } : m))
+}
+
+function useImageAttachments() {
   const [selectedImages, setSelectedImages] = React.useState<AttachmentImage[]>(
     [],
   )
-
-  const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
-  const effectiveInputRef = inputRef || internalInputRef
   const fileInputRef = React.useRef<HTMLInputElement>(null)
-  const baseInputRef = React.useRef(initialValue)
-  const onValueChangeRef = React.useRef(onValueChange)
-
-  React.useEffect(() => {
-    onValueChangeRef.current = onValueChange
-  })
-
-  const updateInput = React.useCallback((val: string) => {
-    setInput(val)
-    baseInputRef.current = val
-    onValueChangeRef.current?.(val)
-  }, [])
-
-  const activeModelId = selectedModelId || localModelId
-
-  const normalizedModels: AIModelOption[] = React.useMemo(() => {
-    if (!models || models.length === 0) return FALLBACK_MODELS
-    return models.map((m) => (typeof m === "string" ? { id: m, name: m } : m))
-  }, [models])
-
-  const handleTranscriptChange = React.useCallback(
-    ({ transcript: voiceText }: { transcript: string }) => {
-      if (!voiceText) return
-      const base = baseInputRef.current.trim()
-      const separator = base && voiceText ? " " : ""
-      const fullText = base + separator + voiceText
-      setInput(fullText)
-      onValueChangeRef.current?.(fullText)
-    },
-    [],
-  )
-
-  const {
-    isListening: isVoiceListening,
-    isSupported: isVoiceSupported,
-    startListening,
-    stopListening: stopVoiceListening,
-    resetTranscript,
-    error: voiceError,
-  } = useSpeechRecognition({
-    onTranscriptChange: handleTranscriptChange,
-  })
-
-  const handleToggleVoice = React.useCallback(() => {
-    if (isVoiceListening) {
-      stopVoiceListening()
-      baseInputRef.current = input
-      resetTranscript()
-    } else {
-      baseInputRef.current = input
-      resetTranscript()
-      startListening()
-    }
-  }, [
-    isVoiceListening,
-    stopVoiceListening,
-    startListening,
-    resetTranscript,
-    input,
-  ])
-
-  React.useEffect(() => {
-    if (autoFocus) {
-      effectiveInputRef.current?.focus()
-    }
-  }, [autoFocus, effectiveInputRef])
-
-  function handleSelectModel(mId: string) {
-    setLocalModelId(mId)
-    onSelectModel?.(mId)
-  }
 
   function handleImageSelect(e: React.ChangeEvent<HTMLInputElement>) {
     const files = e.target.files
@@ -167,6 +80,118 @@ export function PromptForm({
     })
   }
 
+  function clearImages() {
+    setSelectedImages([])
+  }
+
+  return {
+    selectedImages,
+    fileInputRef,
+    handleImageSelect,
+    handleRemoveImage,
+    clearImages,
+  }
+}
+
+export function PromptForm({
+  onSubmit,
+  onStop,
+  isBusy = false,
+  placeholder = "Ask anything",
+  selectedModelId,
+  models,
+  onSelectModel,
+  inputRef,
+  autoFocus = false,
+  actions,
+  className,
+  initialValue = "",
+  onValueChange,
+}: PromptFormProps) {
+  const [input, setInput] = React.useState(initialValue)
+  const [localModelId, setLocalModelId] = React.useState(
+    selectedModelId || "gemini-3.6-flash-high",
+  )
+
+  const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
+  const effectiveInputRef = inputRef || internalInputRef
+  const baseInputRef = React.useRef(initialValue)
+  const onValueChangeRef = React.useRef(onValueChange)
+
+  const {
+    selectedImages,
+    fileInputRef,
+    handleImageSelect,
+    handleRemoveImage,
+    clearImages,
+  } = useImageAttachments()
+
+  React.useEffect(() => {
+    onValueChangeRef.current = onValueChange
+  })
+
+  const updateInput = React.useCallback((val: string) => {
+    setInput(val)
+    baseInputRef.current = val
+    onValueChangeRef.current?.(val)
+  }, [])
+
+  const activeModelId = selectedModelId || localModelId
+  const normalizedModels = React.useMemo(
+    () => normalizeModels(models),
+    [models],
+  )
+
+  const handleTranscriptChange = React.useCallback(
+    ({ transcript: voiceText }: { transcript: string }) => {
+      if (!voiceText) return
+      const base = baseInputRef.current.trim()
+      const separator = base && voiceText ? " " : ""
+      const fullText = base + separator + voiceText
+      setInput(fullText)
+      onValueChangeRef.current?.(fullText)
+    },
+    [],
+  )
+
+  const {
+    isListening: isVoiceListening,
+    isSupported: isVoiceSupported,
+    startListening,
+    stopListening: stopVoiceListening,
+    resetTranscript,
+    error: voiceError,
+  } = useSpeechRecognition({
+    onTranscriptChange: handleTranscriptChange,
+  })
+
+  const handleToggleVoice = React.useCallback(() => {
+    baseInputRef.current = input
+    resetTranscript()
+    if (isVoiceListening) {
+      stopVoiceListening()
+    } else {
+      startListening()
+    }
+  }, [
+    isVoiceListening,
+    stopVoiceListening,
+    startListening,
+    resetTranscript,
+    input,
+  ])
+
+  React.useEffect(() => {
+    if (autoFocus) {
+      effectiveInputRef.current?.focus()
+    }
+  }, [autoFocus, effectiveInputRef])
+
+  function handleSelectModel(mId: string) {
+    setLocalModelId(mId)
+    onSelectModel?.(mId)
+  }
+
   function handleSubmit(event?: React.FormEvent) {
     event?.preventDefault()
     if (isVoiceListening) {
@@ -176,6 +201,7 @@ export function PromptForm({
     baseInputRef.current = ""
     const text = input.trim()
     if ((!text && selectedImages.length === 0) || isBusy) return
+
     if (selectedImages.length > 0) {
       onSubmit(
         text,
@@ -185,7 +211,18 @@ export function PromptForm({
       onSubmit(text)
     }
     updateInput("")
-    setSelectedImages([])
+    clearImages()
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault()
+      handleSubmit()
+    }
   }
 
   const hasContent = input.trim().length > 0 || selectedImages.length > 0
@@ -213,16 +250,7 @@ export function PromptForm({
           value={input}
           onChange={(event) => updateInput(event.target.value)}
           className="min-h-[56px] px-3.5 pt-3 text-sm text-foreground placeholder:text-muted-foreground/80 leading-relaxed"
-          onKeyDown={(event) => {
-            if (
-              event.key === "Enter" &&
-              !event.shiftKey &&
-              !event.nativeEvent.isComposing
-            ) {
-              event.preventDefault()
-              handleSubmit()
-            }
-          }}
+          onKeyDown={handleKeyDown}
         />
 
         <InputGroupAddon align="block-end" className="px-2 pb-1.5 pt-1">

--- a/frontend/src/components/Chat/PromptForm.tsx
+++ b/frontend/src/components/Chat/PromptForm.tsx
@@ -1,4 +1,4 @@
-import { Mic, Plus } from "lucide-react"
+import { Plus } from "lucide-react"
 import * as React from "react"
 
 import {
@@ -10,11 +10,13 @@ import {
   ModelSelectorPill,
 } from "@/components/Chat/ModelSelectorPill"
 import { PromptSubmitButton } from "@/components/Chat/PromptSubmitButton"
+import { VoiceInputButton } from "@/components/Chat/VoiceInputButton"
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupTextarea,
 } from "@/components/ui/input-group"
+import { useSpeechRecognition } from "@/hooks/useSpeechRecognition"
 
 export type { AIModelOption }
 
@@ -30,6 +32,8 @@ export interface PromptFormProps {
   autoFocus?: boolean
   actions?: React.ReactNode
   className?: string
+  initialValue?: string
+  onValueChange?: (value: string) => void
 }
 
 const FALLBACK_MODELS: AIModelOption[] = [
@@ -52,8 +56,10 @@ export function PromptForm({
   autoFocus = false,
   actions,
   className,
+  initialValue = "",
+  onValueChange,
 }: PromptFormProps) {
-  const [input, setInput] = React.useState("")
+  const [input, setInput] = React.useState(initialValue)
   const [localModelId, setLocalModelId] = React.useState(
     selectedModelId || "gemini-3.6-flash-high",
   )
@@ -64,6 +70,18 @@ export function PromptForm({
   const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
   const effectiveInputRef = inputRef || internalInputRef
   const fileInputRef = React.useRef<HTMLInputElement>(null)
+  const baseInputRef = React.useRef(initialValue)
+  const onValueChangeRef = React.useRef(onValueChange)
+
+  React.useEffect(() => {
+    onValueChangeRef.current = onValueChange
+  })
+
+  const updateInput = React.useCallback((val: string) => {
+    setInput(val)
+    baseInputRef.current = val
+    onValueChangeRef.current?.(val)
+  }, [])
 
   const activeModelId = selectedModelId || localModelId
 
@@ -71,6 +89,47 @@ export function PromptForm({
     if (!models || models.length === 0) return FALLBACK_MODELS
     return models.map((m) => (typeof m === "string" ? { id: m, name: m } : m))
   }, [models])
+
+  const handleTranscriptChange = React.useCallback(
+    ({ transcript: voiceText }: { transcript: string }) => {
+      if (!voiceText) return
+      const base = baseInputRef.current.trim()
+      const separator = base && voiceText ? " " : ""
+      const fullText = base + separator + voiceText
+      setInput(fullText)
+      onValueChangeRef.current?.(fullText)
+    },
+    [],
+  )
+
+  const {
+    isListening: isVoiceListening,
+    isSupported: isVoiceSupported,
+    startListening,
+    stopListening: stopVoiceListening,
+    resetTranscript,
+    error: voiceError,
+  } = useSpeechRecognition({
+    onTranscriptChange: handleTranscriptChange,
+  })
+
+  const handleToggleVoice = React.useCallback(() => {
+    if (isVoiceListening) {
+      stopVoiceListening()
+      baseInputRef.current = input
+      resetTranscript()
+    } else {
+      baseInputRef.current = input
+      resetTranscript()
+      startListening()
+    }
+  }, [
+    isVoiceListening,
+    stopVoiceListening,
+    startListening,
+    resetTranscript,
+    input,
+  ])
 
   React.useEffect(() => {
     if (autoFocus) {
@@ -110,6 +169,11 @@ export function PromptForm({
 
   function handleSubmit(event?: React.FormEvent) {
     event?.preventDefault()
+    if (isVoiceListening) {
+      stopVoiceListening()
+    }
+    resetTranscript()
+    baseInputRef.current = ""
     const text = input.trim()
     if ((!text && selectedImages.length === 0) || isBusy) return
     if (selectedImages.length > 0) {
@@ -120,7 +184,7 @@ export function PromptForm({
     } else {
       onSubmit(text)
     }
-    setInput("")
+    updateInput("")
     setSelectedImages([])
   }
 
@@ -128,7 +192,7 @@ export function PromptForm({
 
   return (
     <form onSubmit={handleSubmit} className={className}>
-      <InputGroup className="rounded-3xl border border-border/80 bg-[#121214]/95 backdrop-blur-md p-1.5 shadow-lg transition-all focus-within:border-border">
+      <InputGroup className="rounded-3xl border border-border/70 bg-[#121214]/95 backdrop-blur-md p-1.5 shadow-lg transition-all focus-within:border-border/70 focus-within:ring-0 focus-within:ring-offset-0 focus-within:outline-none focus:outline-none focus:ring-0 focus-within:!ring-0 focus-within:!border-border/70">
         <input
           type="file"
           ref={fileInputRef}
@@ -147,7 +211,7 @@ export function PromptForm({
           ref={effectiveInputRef}
           placeholder={placeholder}
           value={input}
-          onChange={(event) => setInput(event.target.value)}
+          onChange={(event) => updateInput(event.target.value)}
           className="min-h-[56px] px-3.5 pt-3 text-sm text-foreground placeholder:text-muted-foreground/80 leading-relaxed"
           onKeyDown={(event) => {
             if (
@@ -182,13 +246,13 @@ export function PromptForm({
               onSelectModel={handleSelectModel}
             />
 
-            <button
-              type="button"
-              aria-label="Voice input"
-              className="flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors cursor-pointer"
-            >
-              <Mic className="size-3.5" />
-            </button>
+            <VoiceInputButton
+              isListening={isVoiceListening}
+              isSupported={isVoiceSupported}
+              onToggle={handleToggleVoice}
+              error={voiceError}
+              disabled={isBusy}
+            />
 
             <PromptSubmitButton
               isBusy={isBusy}

--- a/frontend/src/components/Chat/VoiceInputButton.tsx
+++ b/frontend/src/components/Chat/VoiceInputButton.tsx
@@ -1,0 +1,65 @@
+import { Mic } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export interface VoiceInputButtonProps {
+  isListening: boolean
+  isSupported: boolean
+  onToggle: () => void
+  disabled?: boolean
+  error?: string | null
+  className?: string
+}
+
+export function VoiceInputButton({
+  isListening,
+  isSupported,
+  onToggle,
+  disabled = false,
+  error,
+  className,
+}: VoiceInputButtonProps) {
+  if (!isSupported) {
+    return (
+      <button
+        type="button"
+        disabled
+        aria-label="Voice input not supported in this browser"
+        title="Voice input is not supported in this browser (available on Chrome/Edge/Safari)"
+        className={cn(
+          "flex size-7 items-center justify-center rounded-full text-muted-foreground/40 cursor-not-allowed opacity-50",
+          className,
+        )}
+      >
+        <Mic className="size-3.5" />
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      aria-label={isListening ? "Stop voice input" : "Start voice input"}
+      title={
+        error
+          ? error
+          : isListening
+            ? "Listening… Click to stop"
+            : "Voice input (Click to speak)"
+      }
+      className={cn(
+        "flex size-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted/40 hover:text-foreground transition-colors cursor-pointer",
+        disabled && "opacity-50 cursor-not-allowed",
+        className,
+      )}
+    >
+      <Mic
+        className={cn(
+          "size-3.5 transition-colors duration-200",
+          isListening ? "text-red-500" : "text-muted-foreground",
+        )}
+      />
+    </button>
+  )
+}

--- a/frontend/src/components/Chat/__tests__/ChatMessageActions.test.tsx
+++ b/frontend/src/components/Chat/__tests__/ChatMessageActions.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+import { ChatMessageActions } from "@/components/Chat/ChatMessageActions"
+
+describe("ChatMessageActions", () => {
+  it("renders formatted time when valid createdAt is provided", () => {
+    render(
+      <ChatMessageActions
+        textToCopy="Hello world"
+        createdAt="2026-09-02T12:30:00Z"
+      />,
+    )
+
+    const copyBtn = screen.getByRole("button", { name: /copy message/i })
+    expect(copyBtn).toBeDefined()
+  })
+
+  it("renders copy button before timestamp when align is start (assistant response)", () => {
+    const { container } = render(
+      <ChatMessageActions
+        textToCopy="Response text"
+        createdAt="2026-09-02T12:30:00Z"
+        align="start"
+      />,
+    )
+
+    const root = container.querySelector('[data-slot="message-actions"]')
+    expect(root).toBeDefined()
+    const firstChild = root?.firstElementChild
+    expect(firstChild?.tagName.toLowerCase()).toBe("button")
+  })
+
+  it("renders timestamp before copy button when align is end (user request)", () => {
+    const { container } = render(
+      <ChatMessageActions
+        textToCopy="User prompt"
+        createdAt="2026-09-02T12:30:00Z"
+        align="end"
+      />,
+    )
+
+    const root = container.querySelector('[data-slot="message-actions"]')
+    expect(root).toBeDefined()
+    const firstChild = root?.firstElementChild
+    expect(firstChild?.tagName.toLowerCase()).toBe("span")
+  })
+
+  it("copies text to clipboard when copy button is clicked", async () => {
+    const user = userEvent.setup()
+    render(
+      <ChatMessageActions
+        textToCopy="Copy this prompt"
+        createdAt="2026-09-02T12:30:00Z"
+      />,
+    )
+
+    const copyBtn = screen.getByRole("button", { name: /copy message/i })
+    await user.click(copyBtn)
+
+    const copiedText = await navigator.clipboard.readText()
+    expect(copiedText).toBe("Copy this prompt")
+    expect(
+      screen.getByRole("button", { name: /copied to clipboard/i }),
+    ).toBeDefined()
+  })
+})

--- a/frontend/src/components/Chat/__tests__/ThoughtPart.test.tsx
+++ b/frontend/src/components/Chat/__tests__/ThoughtPart.test.tsx
@@ -42,4 +42,21 @@ describe("ThoughtPart component", () => {
       screen.queryByText(/Selected LinkedIn hook pattern/),
     ).not.toBeInTheDocument()
   })
+
+  it("renders markdown formatting inside expanded thought content", () => {
+    const { container } = render(
+      <ThoughtPart
+        part={{
+          type: "thought",
+          content: "Here is **critical reasoning** step.",
+        }}
+        isStreaming={true}
+        hasResponseStarted={false}
+      />,
+    )
+
+    const strongEl = container.querySelector("strong")
+    expect(strongEl).toBeDefined()
+    expect(strongEl?.textContent).toBe("critical reasoning")
+  })
 })

--- a/frontend/src/components/Chat/__tests__/VoiceInputButton.test.tsx
+++ b/frontend/src/components/Chat/__tests__/VoiceInputButton.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { VoiceInputButton } from "@/components/Chat/VoiceInputButton"
+
+describe("VoiceInputButton", () => {
+  it("renders disabled state when speech recognition is unsupported", () => {
+    render(
+      <VoiceInputButton
+        isListening={false}
+        isSupported={false}
+        onToggle={vi.fn()}
+      />,
+    )
+
+    const btn = screen.getByRole("button", {
+      name: /voice input not supported in this browser/i,
+    })
+    expect(btn).toBeDefined()
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("calls onToggle when clicked while supported", async () => {
+    const user = userEvent.setup()
+    const handleToggle = vi.fn()
+
+    render(
+      <VoiceInputButton
+        isListening={false}
+        isSupported={true}
+        onToggle={handleToggle}
+      />,
+    )
+
+    const btn = screen.getByRole("button", { name: /start voice input/i })
+    await user.click(btn)
+
+    expect(handleToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders red mic icon when isListening is true", () => {
+    const { container } = render(
+      <VoiceInputButton
+        isListening={true}
+        isSupported={true}
+        onToggle={vi.fn()}
+      />,
+    )
+
+    const btn = screen.getByRole("button", { name: /stop voice input/i })
+    expect(btn).toBeDefined()
+
+    const micIcon = container.querySelector("svg")
+    expect(micIcon?.getAttribute("class")).toContain("text-red-500")
+  })
+})

--- a/frontend/src/components/Chat/parts/TextPart.tsx
+++ b/frontend/src/components/Chat/parts/TextPart.tsx
@@ -1,16 +1,26 @@
+import * as React from "react"
 import ReactMarkdown from "react-markdown"
+import remarkBreaks from "remark-breaks"
 import remarkGfm from "remark-gfm"
 
 import type { TextMessagePart } from "@/components/Chat/types"
+import { completeStreamingMarkdown } from "@/lib/markdown-stream"
 
 export function TextPart({ part }: { part: TextMessagePart }) {
+  const formattedText = React.useMemo(
+    () => completeStreamingMarkdown(part.text),
+    [part.text],
+  )
+
   if (!part.text.trim()) {
     return null
   }
 
   return (
-    <div className="typeset px-1 leading-relaxed text-sm text-foreground">
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{part.text}</ReactMarkdown>
+    <div className="typeset px-1 leading-relaxed text-sm text-foreground w-full min-w-0 max-w-full break-words [overflow-wrap:anywhere]">
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+        {formattedText}
+      </ReactMarkdown>
     </div>
   )
 }

--- a/frontend/src/components/Chat/parts/ThoughtPart.tsx
+++ b/frontend/src/components/Chat/parts/ThoughtPart.tsx
@@ -1,7 +1,11 @@
 import { ChevronDown, Loader2 } from "lucide-react"
 import * as React from "react"
+import ReactMarkdown from "react-markdown"
+import remarkBreaks from "remark-breaks"
+import remarkGfm from "remark-gfm"
 
 import type { ThoughtPart as ThoughtPartType } from "@/components/Chat/types"
+import { completeStreamingMarkdown } from "@/lib/markdown-stream"
 import { cn } from "@/lib/utils"
 
 export interface ThoughtPartProps {
@@ -30,9 +34,12 @@ function ThoughtContent({ content }: { content?: string }) {
       </span>
     )
   }
+  const formattedContent = completeStreamingMarkdown(content)
   return (
-    <div className="text-xs text-muted-foreground/80 font-normal leading-relaxed whitespace-pre-wrap">
-      {content}
+    <div className="text-xs text-muted-foreground/80 font-normal leading-relaxed [&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:list-decimal [&_ol]:pl-4 [&_li]:my-0.5 [&_code]:bg-muted/60 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_strong]:font-medium [&_strong]:text-foreground/90">
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+        {formattedContent}
+      </ReactMarkdown>
     </div>
   )
 }

--- a/frontend/src/components/Chat/usePromptFormState.ts
+++ b/frontend/src/components/Chat/usePromptFormState.ts
@@ -16,6 +16,15 @@ function normalizeModels(models?: (AIModelOption | string)[]): AIModelOption[] {
   return models.map((m) => (typeof m === "string" ? { id: m, name: m } : m))
 }
 
+function isPlainEnterPress(
+  event: React.KeyboardEvent<HTMLTextAreaElement>,
+): boolean {
+  if (event.key !== "Enter") return false
+  if (event.shiftKey) return false
+  if (event.nativeEvent.isComposing) return false
+  return true
+}
+
 export function useImageAttachments() {
   const [selectedImages, setSelectedImages] = React.useState<AttachmentImage[]>(
     [],
@@ -217,11 +226,7 @@ export function usePromptFormState({
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (
-      event.key === "Enter" &&
-      !event.shiftKey &&
-      !event.nativeEvent.isComposing
-    ) {
+    if (isPlainEnterPress(event)) {
       event.preventDefault()
       handleSubmit()
     }

--- a/frontend/src/components/Chat/usePromptFormState.ts
+++ b/frontend/src/components/Chat/usePromptFormState.ts
@@ -1,0 +1,251 @@
+import * as React from "react"
+import type { AttachmentImage } from "@/components/Chat/AttachmentPreviewStrip"
+import type { AIModelOption } from "@/components/Chat/ModelSelectorPill"
+import { useSpeechRecognition } from "@/hooks/useSpeechRecognition"
+
+const FALLBACK_MODELS: AIModelOption[] = [
+  { id: "gemini-3.6-flash-high", name: "Gemini 3.6 Flash", provider: "Google" },
+  { id: "claude-sonnet-4-6", name: "Claude 3.7 Sonnet", provider: "Anthropic" },
+  { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "OpenAI" },
+  { id: "gpt-5.4", name: "GPT-5.4", provider: "OpenAI" },
+  { id: "gpt-oss-120b-medium", name: "DeepSeek R1", provider: "OpenSource" },
+]
+
+function normalizeModels(models?: (AIModelOption | string)[]): AIModelOption[] {
+  if (!models || models.length === 0) return FALLBACK_MODELS
+  return models.map((m) => (typeof m === "string" ? { id: m, name: m } : m))
+}
+
+export function useImageAttachments() {
+  const [selectedImages, setSelectedImages] = React.useState<AttachmentImage[]>(
+    [],
+  )
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
+
+  function handleImageSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files
+    if (!files || files.length === 0) return
+
+    const newImages = Array.from(files).map((file) => ({
+      file,
+      preview: URL.createObjectURL(file),
+    }))
+
+    setSelectedImages((prev) => [...prev, ...newImages])
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""
+    }
+  }
+
+  function handleRemoveImage(index: number) {
+    setSelectedImages((prev) => {
+      const target = prev[index]
+      if (target) {
+        URL.revokeObjectURL(target.preview)
+      }
+      return prev.filter((_, i) => i !== index)
+    })
+  }
+
+  function clearImages() {
+    setSelectedImages([])
+  }
+
+  return {
+    selectedImages,
+    fileInputRef,
+    handleImageSelect,
+    handleRemoveImage,
+    clearImages,
+  }
+}
+
+export function usePromptVoiceInput({
+  input,
+  updateInput,
+}: {
+  input: string
+  updateInput: (val: string) => void
+}) {
+  const baseInputRef = React.useRef(input)
+
+  const handleTranscriptChange = React.useCallback(
+    ({ transcript: voiceText }: { transcript: string }) => {
+      if (!voiceText) return
+      const base = baseInputRef.current.trim()
+      const separator = base && voiceText ? " " : ""
+      const fullText = base + separator + voiceText
+      updateInput(fullText)
+    },
+    [updateInput],
+  )
+
+  const {
+    isListening: isVoiceListening,
+    isSupported: isVoiceSupported,
+    startListening,
+    stopListening: stopVoiceListening,
+    resetTranscript,
+    error: voiceError,
+  } = useSpeechRecognition({
+    onTranscriptChange: handleTranscriptChange,
+  })
+
+  const handleToggleVoice = React.useCallback(() => {
+    baseInputRef.current = input
+    resetTranscript()
+    if (isVoiceListening) {
+      stopVoiceListening()
+    } else {
+      startListening()
+    }
+  }, [
+    isVoiceListening,
+    stopVoiceListening,
+    startListening,
+    resetTranscript,
+    input,
+  ])
+
+  function stopAndReset() {
+    if (isVoiceListening) {
+      stopVoiceListening()
+    }
+    resetTranscript()
+    baseInputRef.current = ""
+  }
+
+  return {
+    isVoiceListening,
+    isVoiceSupported,
+    voiceError,
+    handleToggleVoice,
+    stopAndReset,
+  }
+}
+
+export interface UsePromptFormStateProps {
+  initialValue?: string
+  selectedModelId?: string
+  models?: (AIModelOption | string)[]
+  onSelectModel?: (modelId: string) => void
+  onValueChange?: (value: string) => void
+  onSubmit: (text: string, images?: File[]) => void
+  isBusy?: boolean
+  autoFocus?: boolean
+  inputRef?: React.RefObject<HTMLTextAreaElement | null>
+}
+
+export function usePromptFormState({
+  initialValue = "",
+  selectedModelId,
+  models,
+  onSelectModel,
+  onValueChange,
+  onSubmit,
+  isBusy = false,
+  autoFocus = false,
+  inputRef,
+}: UsePromptFormStateProps) {
+  const [input, setInput] = React.useState(initialValue)
+  const [localModelId, setLocalModelId] = React.useState(
+    selectedModelId || "gemini-3.6-flash-high",
+  )
+
+  const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
+  const effectiveInputRef = inputRef || internalInputRef
+  const onValueChangeRef = React.useRef(onValueChange)
+
+  const {
+    selectedImages,
+    fileInputRef,
+    handleImageSelect,
+    handleRemoveImage,
+    clearImages,
+  } = useImageAttachments()
+
+  React.useEffect(() => {
+    onValueChangeRef.current = onValueChange
+  })
+
+  const updateInput = React.useCallback((val: string) => {
+    setInput(val)
+    onValueChangeRef.current?.(val)
+  }, [])
+
+  const {
+    isVoiceListening,
+    isVoiceSupported,
+    voiceError,
+    handleToggleVoice,
+    stopAndReset,
+  } = usePromptVoiceInput({ input, updateInput })
+
+  const activeModelId = selectedModelId || localModelId
+  const normalizedModels = React.useMemo(
+    () => normalizeModels(models),
+    [models],
+  )
+
+  React.useEffect(() => {
+    if (autoFocus) {
+      effectiveInputRef.current?.focus()
+    }
+  }, [autoFocus, effectiveInputRef])
+
+  function handleSelectModel(mId: string) {
+    setLocalModelId(mId)
+    onSelectModel?.(mId)
+  }
+
+  function handleSubmit(event?: React.FormEvent) {
+    event?.preventDefault()
+    stopAndReset()
+    const text = input.trim()
+    if ((!text && selectedImages.length === 0) || isBusy) return
+
+    if (selectedImages.length > 0) {
+      onSubmit(
+        text,
+        selectedImages.map((img) => img.file),
+      )
+    } else {
+      onSubmit(text)
+    }
+    updateInput("")
+    clearImages()
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  const hasContent = input.trim().length > 0 || selectedImages.length > 0
+
+  return {
+    input,
+    updateInput,
+    effectiveInputRef,
+    fileInputRef,
+    selectedImages,
+    handleImageSelect,
+    handleRemoveImage,
+    activeModelId,
+    normalizedModels,
+    handleSelectModel,
+    isVoiceListening,
+    isVoiceSupported,
+    voiceError,
+    handleToggleVoice,
+    handleSubmit,
+    handleKeyDown,
+    hasContent,
+  }
+}

--- a/frontend/src/components/ui/message-scroller.tsx
+++ b/frontend/src/components/ui/message-scroller.tsx
@@ -40,7 +40,7 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
+        "size-full min-h-0 min-w-0 max-w-full scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overflow-x-hidden overscroll-contain data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
         className,
       )}
       {...props}
@@ -55,7 +55,7 @@ function MessageScrollerContent({
   return (
     <MessageScrollerPrimitive.Content
       data-slot="message-scroller-content"
-      className={cn("flex h-max min-h-full flex-col gap-6", className)}
+      className={cn("flex h-max min-h-full min-w-0 w-full max-w-full flex-col gap-6 overflow-x-hidden", className)}
       {...props}
     />
   )
@@ -70,10 +70,7 @@ function MessageScrollerItem({
     <MessageScrollerPrimitive.Item
       data-slot="message-scroller-item"
       scrollAnchor={scrollAnchor}
-      className={cn(
-        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
-        className,
-      )}
+      className={cn("min-w-0 w-full max-w-full shrink-0 overflow-x-hidden", className)}
       {...props}
     />
   )

--- a/frontend/src/hooks/__tests__/useSpeechRecognition.test.ts
+++ b/frontend/src/hooks/__tests__/useSpeechRecognition.test.ts
@@ -1,0 +1,174 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useSpeechRecognition } from "@/hooks/useSpeechRecognition"
+
+let lastInstance: MockSpeechRecognition | null = null
+
+class MockSpeechRecognition {
+  continuous = true
+  interimResults = true
+  lang = "en-US"
+  onstart: (() => void) | null = null
+  onresult: ((event: unknown) => void) | null = null
+  onerror: ((event: unknown) => void) | null = null
+  onend: (() => void) | null = null
+
+  constructor() {
+    lastInstance = this
+  }
+
+  start = vi.fn(() => {
+    this.onstart?.()
+  })
+
+  stop = vi.fn(() => {
+    this.onend?.()
+  })
+
+  abort = vi.fn(() => {
+    this.onend?.()
+  })
+}
+
+describe("useSpeechRecognition", () => {
+  beforeEach(() => {
+    lastInstance = null
+    // @ts-expect-error Mocking window global
+    window.SpeechRecognition = MockSpeechRecognition
+  })
+
+  afterEach(() => {
+    // @ts-expect-error Resetting window global
+    delete window.SpeechRecognition
+    // @ts-expect-error Resetting webkit window global
+    delete window.webkitSpeechRecognition
+    vi.restoreAllMocks()
+  })
+
+  it("initializes with isSupported true when SpeechRecognition exists", () => {
+    const { result } = renderHook(() => useSpeechRecognition())
+    expect(result.current.isSupported).toBe(true)
+    expect(result.current.isListening).toBe(false)
+  })
+
+  it("starts and stops listening cleanly", () => {
+    const onTranscriptChange = vi.fn()
+    const { result } = renderHook(() =>
+      useSpeechRecognition({ onTranscriptChange }),
+    )
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    expect(result.current.isListening).toBe(true)
+
+    act(() => {
+      result.current.stopListening()
+    })
+
+    expect(result.current.isListening).toBe(false)
+  })
+
+  it("processes interim and final results in sequence without duplication", () => {
+    const onTranscriptChange = vi.fn()
+    const { result } = renderHook(() =>
+      useSpeechRecognition({ onTranscriptChange }),
+    )
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    // 1. Interim hypothesis
+    act(() => {
+      lastInstance?.onresult?.({
+        resultIndex: 0,
+        results: [
+          {
+            0: { transcript: "hello", confidence: 0.9 },
+            isFinal: false,
+            length: 1,
+          },
+        ],
+      })
+    })
+
+    expect(result.current.transcript).toBe("hello")
+    expect(result.current.interimTranscript).toBe("hello")
+    expect(result.current.finalTranscript).toBe("")
+
+    // 2. Updated interim hypothesis (same index 0)
+    act(() => {
+      lastInstance?.onresult?.({
+        resultIndex: 0,
+        results: [
+          {
+            0: { transcript: "hello world", confidence: 0.95 },
+            isFinal: false,
+            length: 1,
+          },
+        ],
+      })
+    })
+
+    expect(result.current.transcript).toBe("hello world")
+    expect(result.current.interimTranscript).toBe("hello world")
+    expect(result.current.finalTranscript).toBe("")
+
+    // 3. Finalized result
+    act(() => {
+      lastInstance?.onresult?.({
+        resultIndex: 0,
+        results: [
+          {
+            0: { transcript: "hello world", confidence: 0.98 },
+            isFinal: true,
+            length: 1,
+          },
+        ],
+      })
+    })
+
+    expect(result.current.transcript).toBe("hello world")
+    expect(result.current.interimTranscript).toBe("")
+    expect(result.current.finalTranscript).toBe("hello world")
+
+    // 4. Second phrase interim
+    act(() => {
+      lastInstance?.onresult?.({
+        resultIndex: 1,
+        results: [
+          {
+            0: { transcript: "hello world", confidence: 0.98 },
+            isFinal: true,
+            length: 1,
+          },
+          {
+            0: { transcript: "how are you", confidence: 0.9 },
+            isFinal: false,
+            length: 1,
+          },
+        ],
+      })
+    })
+
+    expect(result.current.transcript).toBe("hello world how are you")
+    expect(result.current.interimTranscript).toBe("how are you")
+    expect(result.current.finalTranscript).toBe("hello world")
+  })
+
+  it("handles non-fatal no-speech errors gracefully", () => {
+    const onError = vi.fn()
+    const { result } = renderHook(() => useSpeechRecognition({ onError }))
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    act(() => {
+      result.current.resetError()
+    })
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/frontend/src/hooks/__tests__/useSpeechRecognition.test.ts
+++ b/frontend/src/hooks/__tests__/useSpeechRecognition.test.ts
@@ -30,6 +30,23 @@ class MockSpeechRecognition {
   })
 }
 
+function emitSpeechResult(
+  results: Array<{ transcript: string; isFinal: boolean; confidence?: number }>,
+) {
+  const formattedResults = results.map((r) => ({
+    0: { transcript: r.transcript, confidence: r.confidence ?? 0.95 },
+    isFinal: r.isFinal,
+    length: 1,
+  }))
+
+  act(() => {
+    lastInstance?.onresult?.({
+      resultIndex: Math.max(0, results.length - 1),
+      results: formattedResults,
+    })
+  })
+}
+
 describe("useSpeechRecognition", () => {
   beforeEach(() => {
     lastInstance = null
@@ -60,98 +77,48 @@ describe("useSpeechRecognition", () => {
     act(() => {
       result.current.startListening()
     })
-
     expect(result.current.isListening).toBe(true)
 
     act(() => {
       result.current.stopListening()
     })
-
     expect(result.current.isListening).toBe(false)
   })
 
-  it("processes interim and final results in sequence without duplication", () => {
-    const onTranscriptChange = vi.fn()
-    const { result } = renderHook(() =>
-      useSpeechRecognition({ onTranscriptChange }),
-    )
-
+  it("handles interim hypothesis updates without finalizing", () => {
+    const { result } = renderHook(() => useSpeechRecognition())
     act(() => {
       result.current.startListening()
     })
 
-    // 1. Interim hypothesis
-    act(() => {
-      lastInstance?.onresult?.({
-        resultIndex: 0,
-        results: [
-          {
-            0: { transcript: "hello", confidence: 0.9 },
-            isFinal: false,
-            length: 1,
-          },
-        ],
-      })
-    })
-
+    emitSpeechResult([{ transcript: "hello", isFinal: false }])
     expect(result.current.transcript).toBe("hello")
     expect(result.current.interimTranscript).toBe("hello")
     expect(result.current.finalTranscript).toBe("")
+  })
 
-    // 2. Updated interim hypothesis (same index 0)
+  it("commits finalized transcript results cleanly", () => {
+    const { result } = renderHook(() => useSpeechRecognition())
     act(() => {
-      lastInstance?.onresult?.({
-        resultIndex: 0,
-        results: [
-          {
-            0: { transcript: "hello world", confidence: 0.95 },
-            isFinal: false,
-            length: 1,
-          },
-        ],
-      })
+      result.current.startListening()
     })
 
-    expect(result.current.transcript).toBe("hello world")
-    expect(result.current.interimTranscript).toBe("hello world")
-    expect(result.current.finalTranscript).toBe("")
-
-    // 3. Finalized result
-    act(() => {
-      lastInstance?.onresult?.({
-        resultIndex: 0,
-        results: [
-          {
-            0: { transcript: "hello world", confidence: 0.98 },
-            isFinal: true,
-            length: 1,
-          },
-        ],
-      })
-    })
-
+    emitSpeechResult([{ transcript: "hello world", isFinal: true }])
     expect(result.current.transcript).toBe("hello world")
     expect(result.current.interimTranscript).toBe("")
     expect(result.current.finalTranscript).toBe("hello world")
+  })
 
-    // 4. Second phrase interim
+  it("aggregates sequential phrases without word duplication", () => {
+    const { result } = renderHook(() => useSpeechRecognition())
     act(() => {
-      lastInstance?.onresult?.({
-        resultIndex: 1,
-        results: [
-          {
-            0: { transcript: "hello world", confidence: 0.98 },
-            isFinal: true,
-            length: 1,
-          },
-          {
-            0: { transcript: "how are you", confidence: 0.9 },
-            isFinal: false,
-            length: 1,
-          },
-        ],
-      })
+      result.current.startListening()
     })
+
+    emitSpeechResult([
+      { transcript: "hello world", isFinal: true },
+      { transcript: "how are you", isFinal: false },
+    ])
 
     expect(result.current.transcript).toBe("hello world how are you")
     expect(result.current.interimTranscript).toBe("how are you")
@@ -159,13 +126,10 @@ describe("useSpeechRecognition", () => {
   })
 
   it("handles non-fatal no-speech errors gracefully", () => {
-    const onError = vi.fn()
-    const { result } = renderHook(() => useSpeechRecognition({ onError }))
-
+    const { result } = renderHook(() => useSpeechRecognition())
     act(() => {
       result.current.startListening()
     })
-
     act(() => {
       result.current.resetError()
     })

--- a/frontend/src/hooks/__tests__/useSpeechRecognition.test.ts
+++ b/frontend/src/hooks/__tests__/useSpeechRecognition.test.ts
@@ -17,34 +17,32 @@ class MockSpeechRecognition {
     lastInstance = this
   }
 
-  start = vi.fn(() => {
-    this.onstart?.()
-  })
-
-  stop = vi.fn(() => {
-    this.onend?.()
-  })
-
-  abort = vi.fn(() => {
-    this.onend?.()
-  })
+  start = vi.fn(() => this.onstart?.())
+  stop = vi.fn(() => this.onend?.())
+  abort = vi.fn(() => this.onend?.())
 }
 
 function emitSpeechResult(
   results: Array<{ transcript: string; isFinal: boolean; confidence?: number }>,
 ) {
-  const formattedResults = results.map((r) => ({
-    0: { transcript: r.transcript, confidence: r.confidence ?? 0.95 },
-    isFinal: r.isFinal,
-    length: 1,
-  }))
-
   act(() => {
     lastInstance?.onresult?.({
       resultIndex: Math.max(0, results.length - 1),
-      results: formattedResults,
+      results: results.map((r) => ({
+        0: { transcript: r.transcript, confidence: r.confidence ?? 0.95 },
+        isFinal: r.isFinal,
+        length: 1,
+      })),
     })
   })
+}
+
+function setupActiveHook() {
+  const rendered = renderHook(() => useSpeechRecognition())
+  act(() => {
+    rendered.result.current.startListening()
+  })
+  return rendered.result
 }
 
 describe("useSpeechRecognition", () => {
@@ -86,11 +84,7 @@ describe("useSpeechRecognition", () => {
   })
 
   it("handles interim hypothesis updates without finalizing", () => {
-    const { result } = renderHook(() => useSpeechRecognition())
-    act(() => {
-      result.current.startListening()
-    })
-
+    const result = setupActiveHook()
     emitSpeechResult([{ transcript: "hello", isFinal: false }])
     expect(result.current.transcript).toBe("hello")
     expect(result.current.interimTranscript).toBe("hello")
@@ -98,11 +92,7 @@ describe("useSpeechRecognition", () => {
   })
 
   it("commits finalized transcript results cleanly", () => {
-    const { result } = renderHook(() => useSpeechRecognition())
-    act(() => {
-      result.current.startListening()
-    })
-
+    const result = setupActiveHook()
     emitSpeechResult([{ transcript: "hello world", isFinal: true }])
     expect(result.current.transcript).toBe("hello world")
     expect(result.current.interimTranscript).toBe("")
@@ -110,11 +100,7 @@ describe("useSpeechRecognition", () => {
   })
 
   it("aggregates sequential phrases without word duplication", () => {
-    const { result } = renderHook(() => useSpeechRecognition())
-    act(() => {
-      result.current.startListening()
-    })
-
+    const result = setupActiveHook()
     emitSpeechResult([
       { transcript: "hello world", isFinal: true },
       { transcript: "how are you", isFinal: false },
@@ -126,10 +112,7 @@ describe("useSpeechRecognition", () => {
   })
 
   it("handles non-fatal no-speech errors gracefully", () => {
-    const { result } = renderHook(() => useSpeechRecognition())
-    act(() => {
-      result.current.startListening()
-    })
+    const result = setupActiveHook()
     act(() => {
       result.current.resetError()
     })

--- a/frontend/src/hooks/useAIChatFeedState.ts
+++ b/frontend/src/hooks/useAIChatFeedState.ts
@@ -62,6 +62,33 @@ function updateAssistantPart(
   })
 }
 
+function syncThreadMessages({
+  activeThreadId,
+  transcriptMessages,
+  threadChanged,
+  setLocalMessages,
+}: {
+  activeThreadId: string | null
+  transcriptMessages: ChatUIMessage[] | null
+  threadChanged: boolean
+  setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>
+}) {
+  if (!activeThreadId) {
+    setLocalMessages([])
+    return
+  }
+  if (!transcriptMessages) return
+
+  if (threadChanged) {
+    setLocalMessages(transcriptMessages)
+    return
+  }
+
+  setLocalMessages((current) =>
+    transcriptMessages.length >= current.length ? transcriptMessages : current,
+  )
+}
+
 function useThreadTranscript({
   activeThreadId,
   isStreaming,
@@ -75,7 +102,7 @@ function useThreadTranscript({
   const { data: activeThreadDetail } = useQuery({
     queryKey: ["ai-thread", activeThreadId],
     queryFn: () => AiThreadsService.getChatThread({ id: activeThreadId! }),
-    enabled: !!activeThreadId,
+    enabled: Boolean(activeThreadId),
   })
 
   React.useEffect(() => {
@@ -84,24 +111,16 @@ function useThreadTranscript({
     const threadChanged = previousThreadIdRef.current !== activeThreadId
     previousThreadIdRef.current = activeThreadId
 
-    if (activeThreadId && activeThreadDetail?.transcript) {
-      const msgs =
-        (activeThreadDetail.transcript as { messages?: ChatUIMessage[] })
-          ?.messages || []
+    const transcriptMessages =
+      (activeThreadDetail?.transcript as { messages?: ChatUIMessage[] })
+        ?.messages || null
 
-      if (threadChanged) {
-        setLocalMessages(msgs)
-      } else {
-        setLocalMessages((current) => {
-          if (msgs.length >= current.length) {
-            return msgs
-          }
-          return current
-        })
-      }
-    } else if (!activeThreadId) {
-      setLocalMessages([])
-    }
+    syncThreadMessages({
+      activeThreadId,
+      transcriptMessages,
+      threadChanged,
+      setLocalMessages,
+    })
   }, [activeThreadDetail, isStreaming, activeThreadId, setLocalMessages])
 }
 

--- a/frontend/src/hooks/useAIChatFeedState.ts
+++ b/frontend/src/hooks/useAIChatFeedState.ts
@@ -38,12 +38,20 @@ function updateAssistantPart(
   return messages.map((msg) => {
     if (msg.id !== assistantMsgId) return msg
     const parts = [...msg.parts]
-    const lastPart = parts[parts.length - 1]
+    const lastIndex = parts.length - 1
+    const lastPart = parts[lastIndex]
+
     if (lastPart && lastPart.type === partType) {
       if (lastPart.type === "thought") {
-        lastPart.content += delta
+        parts[lastIndex] = {
+          ...lastPart,
+          content: (lastPart.content || "") + delta,
+        }
       } else {
-        lastPart.text += delta
+        parts[lastIndex] = {
+          ...lastPart,
+          text: (lastPart.text || "") + delta,
+        }
       }
     } else if (partType === "thought") {
       parts.push({ type: "thought", content: delta })
@@ -63,6 +71,7 @@ function useThreadTranscript({
   isStreaming: boolean
   setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>
 }) {
+  const previousThreadIdRef = React.useRef<string | null>(null)
   const { data: activeThreadDetail } = useQuery({
     queryKey: ["ai-thread", activeThreadId],
     queryFn: () => AiThreadsService.getChatThread({ id: activeThreadId! }),
@@ -71,11 +80,25 @@ function useThreadTranscript({
 
   React.useEffect(() => {
     if (isStreaming) return
+
+    const threadChanged = previousThreadIdRef.current !== activeThreadId
+    previousThreadIdRef.current = activeThreadId
+
     if (activeThreadId && activeThreadDetail?.transcript) {
       const msgs =
         (activeThreadDetail.transcript as { messages?: ChatUIMessage[] })
           ?.messages || []
-      setLocalMessages(msgs)
+
+      if (threadChanged) {
+        setLocalMessages(msgs)
+      } else {
+        setLocalMessages((current) => {
+          if (msgs.length >= current.length) {
+            return msgs
+          }
+          return current
+        })
+      }
     } else if (!activeThreadId) {
       setLocalMessages([])
     }
@@ -98,6 +121,9 @@ export function useAIChatFeedState({
   const [localMessages, setLocalMessages] = React.useState<ChatUIMessage[]>([])
   const [pendingQuestion, setPendingQuestion] =
     React.useState<AskUserToolPart | null>(null)
+  const [threadDrafts, setThreadDrafts] = React.useState<
+    Record<string, string>
+  >({})
   const initialLoadedRef = React.useRef(false)
 
   React.useEffect(() => {
@@ -108,6 +134,24 @@ export function useAIChatFeedState({
   }, [threads])
 
   useThreadTranscript({ activeThreadId, isStreaming, setLocalMessages })
+
+  const setThreadDraft = React.useCallback(
+    (threadId: string | null, text: string) => {
+      const key = threadId ?? "new-chat"
+      setThreadDrafts((prev) => ({ ...prev, [key]: text }))
+    },
+    [],
+  )
+
+  const clearThreadDraft = React.useCallback((threadId: string | null) => {
+    const key = threadId ?? "new-chat"
+    setThreadDrafts((prev) => {
+      if (!(key in prev)) return prev
+      const copy = { ...prev }
+      delete copy[key]
+      return copy
+    })
+  }, [])
 
   const createThreadMutation = useMutation({
     mutationFn: (prompt?: string) =>
@@ -124,6 +168,7 @@ export function useAIChatFeedState({
     (text: string) => {
       if (!text.trim() || isStreaming) return
 
+      clearThreadDraft(activeThreadId)
       const { userMsg, assistantMsg } = createMessageTurn(text)
       setLocalMessages((prev) => [...prev, userMsg, assistantMsg])
       setPendingQuestion(null)
@@ -169,6 +214,7 @@ export function useAIChatFeedState({
     },
     [
       activeThreadId,
+      clearThreadDraft,
       isStreaming,
       createThreadMutation,
       selectedModelId,
@@ -203,6 +249,9 @@ export function useAIChatFeedState({
     localMessages,
     setLocalMessages,
     pendingQuestion,
+    threadDrafts,
+    setThreadDraft,
+    clearThreadDraft,
     isStreaming,
     stopStream,
     handleSendMessage,

--- a/frontend/src/hooks/useSpeechRecognition.ts
+++ b/frontend/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,340 @@
+import * as React from "react"
+
+export interface SpeechRecognitionHookOptions {
+  lang?: string
+  continuous?: boolean
+  interimResults?: boolean
+  onTranscriptChange?: (state: {
+    transcript: string
+    finalTranscript: string
+    interimTranscript: string
+  }) => void
+  onError?: (error: string) => void
+}
+
+export interface UseSpeechRecognitionReturn {
+  isListening: boolean
+  isSupported: boolean
+  transcript: string
+  finalTranscript: string
+  interimTranscript: string
+  error: string | null
+  startListening: () => void
+  stopListening: () => void
+  toggleListening: () => void
+  resetTranscript: () => void
+  resetError: () => void
+}
+
+interface SpeechRecognitionResultItem {
+  transcript: string
+  confidence: number
+}
+
+interface SpeechRecognitionResultLike {
+  isFinal: boolean
+  length: number
+  [index: number]: SpeechRecognitionResultItem
+}
+
+interface SpeechRecognitionEventLike {
+  resultIndex: number
+  results: {
+    length: number
+    [index: number]: SpeechRecognitionResultLike
+  }
+}
+
+interface SpeechRecognitionErrorEventLike {
+  error: string
+  message?: string
+}
+
+interface BrowserSpeechRecognition {
+  continuous: boolean
+  interimResults: boolean
+  lang: string
+  onstart: (() => void) | null
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null
+  onend: (() => void) | null
+  start: () => void
+  stop: () => void
+  abort: () => void
+}
+
+type SpeechRecognitionConstructor = new () => BrowserSpeechRecognition
+
+function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null
+  const win = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionConstructor
+    webkitSpeechRecognition?: SpeechRecognitionConstructor
+  }
+  return win.SpeechRecognition || win.webkitSpeechRecognition || null
+}
+
+function getReadableErrorMessage(errorCode: string): string {
+  switch (errorCode) {
+    case "not-allowed":
+    case "service-not-allowed":
+      return "Microphone access denied. Please allow microphone permissions."
+    case "no-speech":
+      return "No speech detected."
+    case "network":
+      return "Speech service network error."
+    case "audio-capture":
+      return "No microphone found or audio capture error."
+    default:
+      return `Speech recognition error: ${errorCode}`
+  }
+}
+
+function extractSessionTranscripts(
+  results: SpeechRecognitionEventLike["results"],
+): { sessionFinal: string; sessionInterim: string } {
+  let sessionFinal = ""
+  let sessionInterim = ""
+
+  for (let i = 0; i < results.length; ++i) {
+    const res = results[i]
+    if (res?.[0]) {
+      const text = res[0].transcript
+      if (res.isFinal) {
+        sessionFinal += (sessionFinal ? " " : "") + text.trim()
+      } else {
+        sessionInterim += (sessionInterim ? " " : "") + text.trim()
+      }
+    }
+  }
+
+  return { sessionFinal, sessionInterim }
+}
+
+export function useSpeechRecognition({
+  lang = "en-US",
+  continuous = true,
+  interimResults = true,
+  onTranscriptChange,
+  onError,
+}: SpeechRecognitionHookOptions = {}): UseSpeechRecognitionReturn {
+  const [isListening, setIsListening] = React.useState(false)
+  const [finalTranscript, setFinalTranscript] = React.useState("")
+  const [interimTranscript, setInterimTranscript] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+
+  const SpeechRecognitionClass = React.useMemo(
+    () => getSpeechRecognitionConstructor(),
+    [],
+  )
+  const isSupported = Boolean(SpeechRecognitionClass)
+
+  const recognitionRef = React.useRef<BrowserSpeechRecognition | null>(null)
+  const isExplicitlyStoppedRef = React.useRef(true)
+  const isRecognizingRef = React.useRef(false)
+  const isStartingRef = React.useRef(false)
+
+  // Accumulated finals across silence auto-restarts
+  const baseFinalRef = React.useRef("")
+  const currentSessionFinalRef = React.useRef("")
+
+  const onTranscriptChangeRef = React.useRef(onTranscriptChange)
+  const onErrorRef = React.useRef(onError)
+
+  React.useEffect(() => {
+    onTranscriptChangeRef.current = onTranscriptChange
+    onErrorRef.current = onError
+  })
+
+  const resetError = React.useCallback(() => setError(null), [])
+
+  const resetTranscript = React.useCallback(() => {
+    baseFinalRef.current = ""
+    currentSessionFinalRef.current = ""
+    setFinalTranscript("")
+    setInterimTranscript("")
+  }, [])
+
+  const safeStart = React.useCallback(() => {
+    const recognition = recognitionRef.current
+    if (!recognition || isRecognizingRef.current || isStartingRef.current) {
+      return
+    }
+    try {
+      isStartingRef.current = true
+      recognition.start()
+    } catch {
+      isStartingRef.current = false
+    }
+  }, [])
+
+  const handleResult = React.useCallback(
+    (event: SpeechRecognitionEventLike) => {
+      const { sessionFinal, sessionInterim } = extractSessionTranscripts(
+        event.results,
+      )
+      currentSessionFinalRef.current = sessionFinal
+
+      const combinedFinal = [baseFinalRef.current, sessionFinal]
+        .filter(Boolean)
+        .join(" ")
+        .trim()
+
+      const fullTranscript = [combinedFinal, sessionInterim]
+        .filter(Boolean)
+        .join(" ")
+        .trim()
+
+      setFinalTranscript(combinedFinal)
+      setInterimTranscript(sessionInterim)
+
+      onTranscriptChangeRef.current?.({
+        transcript: fullTranscript,
+        finalTranscript: combinedFinal,
+        interimTranscript: sessionInterim,
+      })
+    },
+    [],
+  )
+
+  const handleError = React.useCallback(
+    (event: SpeechRecognitionErrorEventLike) => {
+      const errCode = event.error
+      if (errCode === "no-speech" || errCode === "aborted") {
+        return
+      }
+
+      if (errCode === "not-allowed" || errCode === "service-not-allowed") {
+        isExplicitlyStoppedRef.current = true
+        setIsListening(false)
+      }
+
+      const message = getReadableErrorMessage(errCode)
+      setError(message)
+      onErrorRef.current?.(message)
+    },
+    [],
+  )
+
+  const handleEnd = React.useCallback(() => {
+    isRecognizingRef.current = false
+    isStartingRef.current = false
+
+    // Merge session final into base final for upcoming restart
+    if (currentSessionFinalRef.current) {
+      baseFinalRef.current = [
+        baseFinalRef.current,
+        currentSessionFinalRef.current,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .trim()
+      currentSessionFinalRef.current = ""
+    }
+    setInterimTranscript("")
+
+    if (!isExplicitlyStoppedRef.current) {
+      // Auto-restart after silence timeout
+      setTimeout(() => {
+        if (!isExplicitlyStoppedRef.current) {
+          safeStart()
+        }
+      }, 50)
+    } else {
+      setIsListening(false)
+    }
+  }, [safeStart])
+
+  React.useEffect(() => {
+    if (!SpeechRecognitionClass) return
+
+    const instance = new SpeechRecognitionClass()
+    instance.continuous = continuous
+    instance.interimResults = interimResults
+    instance.lang = lang
+
+    instance.onstart = () => {
+      isStartingRef.current = false
+      isRecognizingRef.current = true
+      setIsListening(true)
+      setError(null)
+    }
+
+    instance.onresult = handleResult
+    instance.onerror = handleError
+    instance.onend = handleEnd
+
+    recognitionRef.current = instance
+
+    return () => {
+      isExplicitlyStoppedRef.current = true
+      try {
+        instance.abort()
+      } catch {
+        // ignore
+      }
+      recognitionRef.current = null
+    }
+  }, [
+    SpeechRecognitionClass,
+    continuous,
+    interimResults,
+    lang,
+    handleResult,
+    handleError,
+    handleEnd,
+  ])
+
+  const startListening = React.useCallback(() => {
+    if (!isSupported) {
+      const err = "Speech recognition is not supported in this browser."
+      setError(err)
+      onErrorRef.current?.(err)
+      return
+    }
+    setError(null)
+    isExplicitlyStoppedRef.current = false
+    safeStart()
+  }, [isSupported, safeStart])
+
+  const stopListening = React.useCallback(() => {
+    isExplicitlyStoppedRef.current = true
+    setIsListening(false)
+    isStartingRef.current = false
+    const recognition = recognitionRef.current
+    if (recognition && isRecognizingRef.current) {
+      try {
+        recognition.stop()
+      } catch {
+        // ignore
+      }
+    }
+  }, [])
+
+  const toggleListening = React.useCallback(() => {
+    if (isListening) {
+      stopListening()
+    } else {
+      startListening()
+    }
+  }, [isListening, startListening, stopListening])
+
+  const transcript = React.useMemo(
+    () => [finalTranscript, interimTranscript].filter(Boolean).join(" ").trim(),
+    [finalTranscript, interimTranscript],
+  )
+
+  return {
+    isListening,
+    isSupported,
+    transcript,
+    finalTranscript,
+    interimTranscript,
+    error,
+    startListening,
+    stopListening,
+    toggleListening,
+    resetTranscript,
+    resetError,
+  }
+}

--- a/frontend/src/lib/__tests__/markdown-stream.test.ts
+++ b/frontend/src/lib/__tests__/markdown-stream.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { completeStreamingMarkdown } from "@/lib/markdown-stream"
+
+describe("completeStreamingMarkdown", () => {
+  it("returns empty string when given empty input", () => {
+    expect(completeStreamingMarkdown("")).toBe("")
+  })
+
+  it("auto-closes open code blocks", () => {
+    const unclosedCode = "Here is code:\n```typescript\nconst x = 10"
+    const completed = completeStreamingMarkdown(unclosedCode)
+    expect(completed).toBe("Here is code:\n```typescript\nconst x = 10\n```")
+  })
+
+  it("auto-closes open inline code", () => {
+    const unclosedInline = "Check `variable"
+    const completed = completeStreamingMarkdown(unclosedInline)
+    expect(completed).toBe("Check `variable`")
+  })
+
+  it("auto-closes open bold markers", () => {
+    const unclosedBold = "This is **important"
+    const completed = completeStreamingMarkdown(unclosedBold)
+    expect(completed).toBe("This is **important**")
+  })
+
+  it("ensures trailing headings are terminated with newline for instant block parsing", () => {
+    const inFlightHeading = "### Strategic Overview"
+    const completed = completeStreamingMarkdown(inFlightHeading)
+    expect(completed).toBe("### Strategic Overview\n")
+  })
+})

--- a/frontend/src/lib/markdown-stream.ts
+++ b/frontend/src/lib/markdown-stream.ts
@@ -1,44 +1,48 @@
 /**
  * Normalizes in-flight streaming markdown so partial/incomplete tokens
- * (like unclosed code fences, dangling asterisks, or uncompleted headings)
  * are rendered as structured HTML in real-time rather than raw markdown syntax.
  */
+
+function closeCodeBlocks(text: string): string | null {
+  const tripleBackticks = text.match(/```/g)
+  return tripleBackticks && tripleBackticks.length % 2 === 1
+    ? `${text}\n\`\`\``
+    : null
+}
+
+function closeInlineCode(text: string): string | null {
+  const singleBackticks = text.replace(/```/g, "").match(/`/g)
+  return singleBackticks && singleBackticks.length % 2 === 1
+    ? `${text}\``
+    : null
+}
+
+function closeBold(text: string): string {
+  const boldPairs = text.match(/\*\*/g)
+  return boldPairs && boldPairs.length % 2 === 1 ? `${text}**` : text
+}
+
+function closeItalics(text: string): string {
+  const remainingAsterisks = text.replace(/\*\*/g, "").match(/\*/g)
+  return remainingAsterisks && remainingAsterisks.length % 2 === 1
+    ? `${text}*`
+    : text
+}
+
+function terminateTrailingHeading(text: string): string {
+  return /(?:^|\n)#{1,6}\s+[^\n]+$/.test(text) ? `${text}\n` : text
+}
+
 export function completeStreamingMarkdown(raw: string): string {
   if (!raw) return ""
 
-  let text = raw
+  const codeClosed = closeCodeBlocks(raw)
+  if (codeClosed) return codeClosed
 
-  // 1. Auto-close code blocks if an odd number of triple backticks exists
-  const tripleBackticks = text.match(/```/g)
-  if (tripleBackticks && tripleBackticks.length % 2 === 1) {
-    text += "\n```"
-    return text
-  }
+  const inlineClosed = closeInlineCode(raw)
+  if (inlineClosed) return inlineClosed
 
-  // 2. Auto-close inline code if an odd number of single backticks exists
-  const singleBackticks = text.replace(/```/g, "").match(/`/g)
-  if (singleBackticks && singleBackticks.length % 2 === 1) {
-    text += "`"
-    return text
-  }
-
-  // 3. Auto-close bold markdown if an odd number of ** exists
-  const boldPairs = text.match(/\*\*/g)
-  if (boldPairs && boldPairs.length % 2 === 1) {
-    text += "**"
-  }
-
-  // 4. Auto-close italic markdown if an odd number of single * exists
-  const remainingAsterisks = text.replace(/\*\*/g, "").match(/\*/g)
-  if (remainingAsterisks && remainingAsterisks.length % 2 === 1) {
-    text += "*"
-  }
-
-  // 5. If text ends with an active heading line without a newline, ensure proper heading closure
-  // e.g. "### Heading Title"
-  if (/(?:^|\n)#{1,6}\s+[^\n]+$/.test(text)) {
-    text += "\n"
-  }
-
-  return text
+  const withBold = closeBold(raw)
+  const withItalics = closeItalics(withBold)
+  return terminateTrailingHeading(withItalics)
 }

--- a/frontend/src/lib/markdown-stream.ts
+++ b/frontend/src/lib/markdown-stream.ts
@@ -1,0 +1,44 @@
+/**
+ * Normalizes in-flight streaming markdown so partial/incomplete tokens
+ * (like unclosed code fences, dangling asterisks, or uncompleted headings)
+ * are rendered as structured HTML in real-time rather than raw markdown syntax.
+ */
+export function completeStreamingMarkdown(raw: string): string {
+  if (!raw) return ""
+
+  let text = raw
+
+  // 1. Auto-close code blocks if an odd number of triple backticks exists
+  const tripleBackticks = text.match(/```/g)
+  if (tripleBackticks && tripleBackticks.length % 2 === 1) {
+    text += "\n```"
+    return text
+  }
+
+  // 2. Auto-close inline code if an odd number of single backticks exists
+  const singleBackticks = text.replace(/```/g, "").match(/`/g)
+  if (singleBackticks && singleBackticks.length % 2 === 1) {
+    text += "`"
+    return text
+  }
+
+  // 3. Auto-close bold markdown if an odd number of ** exists
+  const boldPairs = text.match(/\*\*/g)
+  if (boldPairs && boldPairs.length % 2 === 1) {
+    text += "**"
+  }
+
+  // 4. Auto-close italic markdown if an odd number of single * exists
+  const remainingAsterisks = text.replace(/\*\*/g, "").match(/\*/g)
+  if (remainingAsterisks && remainingAsterisks.length % 2 === 1) {
+    text += "*"
+  }
+
+  // 5. If text ends with an active heading line without a newline, ensure proper heading closure
+  // e.g. "### Heading Title"
+  if (/(?:^|\n)#{1,6}\s+[^\n]+$/.test(text)) {
+    text += "\n"
+  }
+
+  return text
+}

--- a/frontend/src/routes/_layout/ai.tsx
+++ b/frontend/src/routes/_layout/ai.tsx
@@ -130,6 +130,8 @@ function AIPage() {
     localMessages,
     setLocalMessages,
     pendingQuestion,
+    threadDrafts,
+    setThreadDraft,
     isStreaming,
     stopStream,
     handleSendMessage,
@@ -254,7 +256,10 @@ function AIPage() {
 
         <div className="mx-auto flex w-full max-w-2xl flex-col gap-2 px-4 pb-4 shrink-0">
           <PromptForm
+            key={activeThreadId ?? "new-chat"}
             inputRef={promptInputRef}
+            initialValue={threadDrafts[activeThreadId ?? "new-chat"] ?? ""}
+            onValueChange={(val) => setThreadDraft(activeThreadId, val)}
             placeholder="Ask anything"
             isBusy={isStreaming}
             selectedModelId={selectedModelId}
@@ -262,6 +267,7 @@ function AIPage() {
             onSelectModel={setSelectedModelId}
             onSubmit={handleSendMessage}
             onStop={stopStream}
+            autoFocus
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Resolves open Issue #113 by delivering hover-triggered message actions with localized timestamps, canonical Web Speech API voice recognition input with a solid red indicator, real-time live markdown streaming formatting with `remark-breaks` and `completeStreamingMarkdown`, consistent multi-turn reasoning thoughts, thread draft buffering across navigation, and full viewport scroll stability.

### Highlights

1. **Message Hover Actions (`ChatMessageActions.tsx`)**:
   - Renders on hover (`group-hover:opacity-100 opacity-0 transition-opacity`).
   - For Assistant responses: Copy button precedes timestamp (`[Copy Button] [8:42 PM]`).
   - For User prompts: Timestamp precedes copy button (`[8:42 PM] [Copy Button]`).
   - Copies markdown to clipboard via `navigator.clipboard.writeText(...)` and provides 2000ms visual checkmark confirmation.

2. **Web Speech API Voice Recognition (`useSpeechRecognition.ts` & `VoiceInputButton.tsx`)**:
   - Separates interim hypothesis chunks from final committed transcripts to eliminate word duplication.
   - Automatically recovers from silence timeouts (50ms debounce) when recording is active.
   - Clean, static red mic icon (`text-red-500`) with normal transparent button container (no pulsing animations or outer rings).

3. **Per-Thread Draft Isolation (`useAIChatFeedState.ts` & `ai.tsx`)**:
   - Isolates in-flight prompt drafts per thread (`threadDrafts[activeThreadId ?? "new-chat"]`).
   - Switching threads preserves and restores typed/spoken text with autofocus.

4. **Multi-Turn Thinking & Thought Markdown (`ThoughtPart.tsx` & `ai_chat_runner.py`)**:
   - Added `ReactMarkdown` to `ThoughtContent` to parse LLM reasoning markdown (`**bold**`, `*italic*`, lists, code blocks).
   - Render immediate Thinking indicator during streaming across all multi-turn messages.
   - Reconstructed `<thought>{thought}</thought>\n\n{text}` in assistant history to reinforce in-context reasoning on every turn.

5. **Streaming Markdown Normalizer (`markdown-stream.ts` & `TextPart.tsx`)**:
   - Added `completeStreamingMarkdown` to auto-close open code fences (```` ``` ````), inline code (`` ` ``), and dangling bold/italics (`**`) in real-time.
   - Added `remark-breaks` so newlines trigger immediate block parsing instead of flashing raw `###` or `1.` syntax.

6. **Scroll Stability & Strict State Immutability (`message-scroller.tsx` & `useAIChatFeedState.ts`)**:
   - Refactored `updateAssistantPart` to be strictly immutable, eliminating React 19 double-updater word duplication.
   - Removed `[content-visibility:auto]`, `contain-intrinsic-size`, and `contain-content` from message scroller to eliminate midway scroll teleportation.
   - Added `overflow-x-hidden` and `break-words [overflow-wrap:anywhere]` to eliminate horizontal scrollbars.

---

### Verification
- **Frontend Unit Tests**: 48 / 48 passed across 13 test suites.
- **Backend Test Suite**: 544 / 544 passed.
- **Linters, Types & Build**: 0 errors across `biome`, `tsc`, `ruff`, and `mypy`; `vite build` clean.