### PR TITLE
feat(ai): add multimodal image input and vision API support (#112)

### DIFF
--- a/backend/app/api/routes/ai_threads.py
+++ b/backend/app/api/routes/ai_threads.py
@@ -338,10 +338,16 @@ async def chat_stream(
     """Server-Sent Events streaming endpoint for AI conversation."""
     thread = _get_owned_thread(session=session, current_user=current_user, thread_id=id)
 
+    user_parts: list[dict[str, Any]] = [{"type": "text", "text": body.message}]
+    if body.images:
+        for img in body.images:
+            if img:
+                user_parts.append({"type": "image_url", "image_url": {"url": img}})
+
     user_msg = {
         "id": f"msg_{uuid.uuid4().hex[:12]}",
         "role": "user",
-        "parts": [{"type": "text", "text": body.message}],
+        "parts": user_parts,
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     crud.append_message_to_transcript(
@@ -357,6 +363,7 @@ async def chat_stream(
                 message=body.message,
                 transcript=thread.transcript,
                 model=body.model,
+                images=body.images,
             ):
                 delta = _collect_stream_part(
                     event_name=event_name,

--- a/backend/app/api/routes/ai_threads.py
+++ b/backend/app/api/routes/ai_threads.py
@@ -315,7 +315,7 @@ async def _save_assistant_turn(
     if thread.message_count <= 2:
         try:
             ai_title = await generate_ai_thread_title(
-                user_prompt=payload.body.message,
+                user_prompt=payload.body.message.strip() or "Image analysis",
                 assistant_response=payload.accumulated_text,
                 model=payload.body.model,
             )
@@ -338,11 +338,31 @@ async def chat_stream(
     """Server-Sent Events streaming endpoint for AI conversation."""
     thread = _get_owned_thread(session=session, current_user=current_user, thread_id=id)
 
-    user_parts: list[dict[str, Any]] = [{"type": "text", "text": body.message}]
-    if body.images:
-        for img in body.images:
-            if img:
-                user_parts.append({"type": "image_url", "image_url": {"url": img}})
+    message_text = body.message.strip()
+    clean_images: list[str] = [
+        img.strip()
+        for img in (body.images or [])
+        if img
+        and img.strip()
+        and (
+            img.strip().startswith("data:image/")
+            or img.strip().startswith("http://")
+            or img.strip().startswith("https://")
+        )
+    ]
+    if not message_text and not clean_images:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Message content or at least one image is required",
+        )
+
+    effective_prompt = message_text or "Analyze the attached image(s)"
+
+    user_parts: list[dict[str, Any]] = []
+    if message_text:
+        user_parts.append({"type": "text", "text": message_text})
+    for img in clean_images:
+        user_parts.append({"type": "image_url", "image_url": {"url": img}})
 
     user_msg = {
         "id": f"msg_{uuid.uuid4().hex[:12]}",
@@ -360,10 +380,10 @@ async def chat_stream(
 
         try:
             async for event_name, payload in default_chat_stream_runner(
-                message=body.message,
+                message=effective_prompt,
                 transcript=thread.transcript,
                 model=body.model,
-                images=body.images,
+                images=clean_images or None,
             ):
                 delta = _collect_stream_part(
                     event_name=event_name,

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -405,6 +405,6 @@ class AIModelsPublic(SQLModel):
 
 
 class ChatMessageRequest(SQLModel):
-    message: str = Field(min_length=1, max_length=25000)
+    message: str = Field(default="", max_length=25000)
     model: str | None = Field(default=None, max_length=100)
-    images: list[str] | None = Field(default=None)
+    images: list[str] | None = Field(default=None, max_length=10)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -407,3 +407,4 @@ class AIModelsPublic(SQLModel):
 class ChatMessageRequest(SQLModel):
     message: str = Field(min_length=1, max_length=25000)
     model: str | None = Field(default=None, max_length=100)
+    images: list[str] | None = Field(default=None)

--- a/backend/app/services/agentic/scraping_extraction.py
+++ b/backend/app/services/agentic/scraping_extraction.py
@@ -41,10 +41,9 @@ def _load_selectors() -> dict[str, Any]:
                 "[data-testid='sidebarColumn'], [data-testid='primaryColumn'], main[role='main']"
             ),
             "sidebar_link": (
-                selectors.get("feed", {}).get(
-                    "news_trends",
-                    "[data-testid='trend'], a[href*='/search?q='], [data-testid^='news_sidebar_article']",
-                )
+                selectors.get("sidebar", {}).get("sidebar_link")
+                or selectors.get("feed", {}).get("news_trends")
+                or "[data-testid^='news_sidebar_article'], [data-testid='trend'], a[href*='/search?q=']"
             ),
             "tweet_container": selectors.get("feed", {}).get(
                 "timeline_post", "[data-testid='tweet']"

--- a/backend/app/services/agentic/scraping_graph.py
+++ b/backend/app/services/agentic/scraping_graph.py
@@ -437,6 +437,15 @@ def _route_after_session_check(state: ScrapingGraphState) -> str:
     return "scrape_explore_trends"
 
 
+def _route_after_trends_scraped(state: ScrapingGraphState) -> str:
+    """Route after explore scraping: abort if error or no topics scraped."""
+    if state.get("status") in ("error", "unrecoverable") or not state.get(
+        "scraped_topics"
+    ):
+        return END
+    return "extract_topic_timelines"
+
+
 def build_scraping_graph() -> Any:
     """Compile LangGraph StateGraph for trending topics scraping and extraction."""
     workflow = StateGraph(ScrapingGraphState)
@@ -454,7 +463,14 @@ def build_scraping_graph() -> Any:
             "scrape_explore_trends": "scrape_explore_trends",
         },
     )
-    workflow.add_edge("scrape_explore_trends", "extract_topic_timelines")
+    workflow.add_conditional_edges(
+        "scrape_explore_trends",
+        _route_after_trends_scraped,
+        {
+            END: END,
+            "extract_topic_timelines": "extract_topic_timelines",
+        },
+    )
     workflow.add_edge("extract_topic_timelines", "persist_scraped_batch")
     workflow.add_edge("persist_scraped_batch", END)
     return workflow.compile()
@@ -483,17 +499,26 @@ def _make_abort_scraped_batch_report(
 
 def _format_scraped_batch_report(*, final_state: dict[str, Any]) -> ScrapedBatchReport:
     """Format and validate final ScrapedBatchReport from completed graph state."""
+    raw_status = final_state.get("status")
+    error = final_state.get("error")
+    persisted_count = int(final_state.get("persisted_topic_count", 0))
+
+    if error and persisted_count == 0:
+        status = raw_status if raw_status in ("error", "unrecoverable") else "error"
+    else:
+        status = raw_status or "persisted"
+
     return ScrapedBatchReport(
         scraped_topics=final_state.get("scraped_topics", []),
         topic_tweets_map=final_state.get("topic_tweets_map", {}),
         topic_summaries=final_state.get("topic_summaries", {}),
         failed_topics=final_state.get("failed_topics", []),
-        persisted_topic_count=int(final_state.get("persisted_topic_count", 0)),
+        persisted_topic_count=persisted_count,
         persisted_tweet_count=int(final_state.get("persisted_tweet_count", 0)),
         page_state=final_state.get("page_state", "ok"),
         session_recovery=final_state.get("session_recovery"),
-        status=final_state.get("status", "persisted"),
-        error=final_state.get("error"),
+        status=status,
+        error=error,
     )
 
 

--- a/backend/app/services/ai_chat_runner.py
+++ b/backend/app/services/ai_chat_runner.py
@@ -75,6 +75,8 @@ def _extract_images_from_parts(parts: list[dict[str, Any]]) -> list[str]:
             url = ""
             if isinstance(part.get("image_url"), dict):
                 url = str(part["image_url"].get("url", "")).strip()
+            elif isinstance(part.get("image_url"), str):
+                url = str(part.get("image_url", "")).strip()
             elif part.get("url"):
                 url = str(part.get("url", "")).strip()
             if url:

--- a/backend/app/services/ai_chat_runner.py
+++ b/backend/app/services/ai_chat_runner.py
@@ -66,34 +66,75 @@ def _build_assistant_history_content(thought: str, text: str) -> str:
     return text
 
 
+def _extract_images_from_parts(parts: list[dict[str, Any]]) -> list[str]:
+    """Extract image URLs from message parts."""
+    images: list[str] = []
+    for part in parts:
+        ptype = part.get("type")
+        if ptype in ("image_url", "image"):
+            url = ""
+            if isinstance(part.get("image_url"), dict):
+                url = str(part["image_url"].get("url", "")).strip()
+            elif part.get("url"):
+                url = str(part.get("url", "")).strip()
+            if url:
+                images.append(url)
+    return images
+
+
+def _build_human_message_content(
+    text: str, images: list[str] | None = None
+) -> str | list[str | dict[Any, Any]]:
+    if not images:
+        return text
+    content: list[str | dict[Any, Any]] = []
+    if text:
+        content.append({"type": "text", "text": text})
+    for img in images:
+        if img:
+            content.append({"type": "image_url", "image_url": {"url": img}})
+    return content
+
+
 def _convert_transcript_item(item: dict[str, Any]) -> BaseMessage | None:
     role = item.get("role")
     parts = item.get("parts", [])
     text = _extract_text_from_parts(parts)
     thought = _extract_thought_from_parts(parts)
-    if not text and not thought:
+    images = _extract_images_from_parts(parts)
+
+    if not text and not thought and not images:
         return None
     if role == "user":
-        return HumanMessage(content=text)
+        content = _build_human_message_content(text, images)
+        return HumanMessage(content=content)
     if role == "assistant":
         return AIMessage(content=_build_assistant_history_content(thought, text))
     return None
 
 
 def _is_latest_message_matching(
-    converted: list[BaseMessage], current_message: str
+    converted: list[BaseMessage],
+    current_message: str,
+    images: list[str] | None = None,
 ) -> bool:
     if not converted:
         return False
     last = converted[-1]
-    return isinstance(last, HumanMessage) and last.content == current_message
+    if not isinstance(last, HumanMessage):
+        return False
+    expected_content = _build_human_message_content(current_message, images)
+    return last.content == expected_content
 
 
 def _ensure_latest_human_message(
-    converted: list[BaseMessage], current_message: str
+    converted: list[BaseMessage],
+    current_message: str,
+    images: list[str] | None = None,
 ) -> None:
-    if not _is_latest_message_matching(converted, current_message):
-        converted.append(HumanMessage(content=current_message))
+    if not _is_latest_message_matching(converted, current_message, images):
+        content = _build_human_message_content(current_message, images)
+        converted.append(HumanMessage(content=content))
 
 
 def _build_message_history(
@@ -101,6 +142,7 @@ def _build_message_history(
     transcript: dict[str, Any] | None,
     current_message: str,
     max_history_messages: int = 40,
+    images: list[str] | None = None,
 ) -> list[BaseMessage]:
     """Convert JSONB transcript messages into LangChain BaseMessage objects."""
     raw_messages = (transcript or {}).get("messages", [])
@@ -109,7 +151,7 @@ def _build_message_history(
         for item in raw_messages
         if (msg := _convert_transcript_item(item)) is not None
     ]
-    _ensure_latest_human_message(converted, current_message)
+    _ensure_latest_human_message(converted, current_message, images=images)
     if len(converted) > max_history_messages:
         converted = converted[-max_history_messages:]
 
@@ -122,11 +164,13 @@ async def default_chat_stream_runner(
     transcript: dict[str, Any] | None = None,
     smooth_delay: float = 0.0,
     model: str | None = None,
+    images: list[str] | None = None,
 ) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
     """Stream AI chat conversation tokens and thinking thoughts word-by-word."""
     messages = _build_message_history(
         transcript=transcript,
         current_message=message,
+        images=images,
     )
 
     try:

--- a/backend/app/services/ai_completion_client.py
+++ b/backend/app/services/ai_completion_client.py
@@ -22,13 +22,18 @@ MESSAGE_ROLE_MAP: dict[type[BaseMessage], str] = {
 
 def format_messages_for_openai(
     messages: list[BaseMessage],
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     """Format LangChain BaseMessage objects into OpenAI messages format."""
-    return [
-        {"role": role, "content": str(msg.content)}
-        for msg in messages
-        if (role := MESSAGE_ROLE_MAP.get(type(msg))) is not None
-    ]
+    formatted: list[dict[str, Any]] = []
+    for msg in messages:
+        role = MESSAGE_ROLE_MAP.get(type(msg))
+        if role is None:
+            continue
+        if isinstance(msg.content, list):
+            formatted.append({"role": role, "content": msg.content})
+        else:
+            formatted.append({"role": role, "content": str(msg.content)})
+    return formatted
 
 
 def _extract_reasoning(data: dict[str, Any]) -> str | None:

--- a/backend/app/services/browser/selectors/x_selectors.json
+++ b/backend/app/services/browser/selectors/x_selectors.json
@@ -14,8 +14,15 @@
     "notifications": "a[href*=\"/notifications\"]"
   },
   "feed": {
-    "news_trends": "[data-testid=\"trend\"]",
+    "todays_news": "[data-testid^=\"news_sidebar_article\"]",
+    "news_trends": "[data-testid^=\"news_sidebar_article\"], [data-testid=\"trend\"]",
     "timeline_post": "[data-testid=\"tweet\"]"
+  },
+  "sidebar": {
+    "container": "[data-testid=\"sidebarColumn\"], [data-testid=\"primaryColumn\"], main[role=\"main\"]",
+    "todays_news": "[data-testid^=\"news_sidebar_article\"]",
+    "trends": "[data-testid=\"trend\"]",
+    "sidebar_link": "[data-testid^=\"news_sidebar_article\"], [data-testid=\"trend\"], a[href*=\"/search?q=\"]"
   },
   "overlays": {
     "sheet_dialog": "[data-testid=\"sheetDialog\"]",

--- a/backend/scrape_config.json
+++ b/backend/scrape_config.json
@@ -6,7 +6,7 @@
   "output_directory": "./data/scraped_trends",
   "selectors": {
     "sidebar_container": "[data-testid='sidebarColumn'], [data-testid='primaryColumn'], main[role='main']",
-    "sidebar_link": "[data-testid='trend'], a[href*='/search?q='], [data-testid^='news_sidebar_article']",
+    "sidebar_link": "[data-testid^='news_sidebar_article'], [data-testid='trend'], a[href*='/search?q=']",
 
     "tweet_container": "[data-testid='tweet']",
     "summary_selectors": [

--- a/backend/scripts/scrape_trending_topics.py
+++ b/backend/scripts/scrape_trending_topics.py
@@ -6,6 +6,7 @@ on status without parsing log output.
 """
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -115,10 +116,28 @@ def _should_skip_link(
 
 async def _resolve_link_href(link: Any, *, clean_title: str) -> str:
     """Resolve href attribute or construct search query URL."""
-    url = await link.get_attribute("href")
+    try:
+        if hasattr(link, "get_attribute"):
+            testid = await link.get_attribute("data-testid")
+            if (
+                testid
+                and isinstance(testid, str)
+                and testid.startswith("news_sidebar_article_")
+            ):
+                raw_b64 = testid[len("news_sidebar_article_") :]
+                decoded = base64.b64decode(raw_b64).decode("utf-8")
+                if ":" in decoded:
+                    trend_id = decoded.split(":")[-1]
+                    return f"https://x.com/i/trending/{trend_id}"
+    except Exception:
+        pass
+
+    url = await link.get_attribute("href") if hasattr(link, "get_attribute") else None
     if not url:
         try:
-            nested_a = link.locator("a[href*='/search?q=']").first
+            nested_a = link.locator(
+                "a[href*='/search?q='], a[href*='/i/trending/']"
+            ).first
             if await nested_a.count() > 0:
                 url = await nested_a.get_attribute("href")
         except Exception:
@@ -544,13 +563,53 @@ async def scrape_trending_topics(
 
 
 async def navigate_to_trends(
-    page: Any, *, target_url: str = "https://x.com/explore"
+    page: Any, *, target_url: str = "https://x.com/home"
 ) -> bool:
-    """Navigate to X.com explore/trends and verify authenticated page state."""
-    state = await detect_page_state(page)
-    if state in {"logged_out", "rate_limited", "captcha"}:
-        return False
-    await page.goto(target_url, wait_until="domcontentloaded")
+    """Navigate to X.com home (with explore fallback) and verify authenticated page state."""
+    curr_url = getattr(page, "url", "")
+    if isinstance(curr_url, str) and curr_url and not curr_url.startswith("about:"):
+        state = await detect_page_state(page)
+        if state in {"logged_out", "captcha"}:
+            return False
+
+    try:
+        await page.goto(target_url, wait_until="domcontentloaded")
+    except Exception as nav_err:
+        logger.warning(f"Error navigating to {target_url}: {nav_err}")
+
+    # Twitter SPA renders a transient skeleton during initial hydration; check for sidebar trends
+    for _ in range(8):
+        await asyncio.sleep(0.5)
+        post_state = await detect_page_state(page)
+        if post_state in {"logged_out", "captcha"}:
+            return False
+        if hasattr(page, "locator"):
+            try:
+                trend_count = await page.locator(
+                    "[data-testid^='news_sidebar_article'], [data-testid='trend']"
+                ).count()
+                if trend_count > 0:
+                    return True
+            except Exception:
+                pass
+        if post_state == "ok":
+            return True
+
+    # Fallback to explore if sidebar didn't load on target_url
+    if target_url != "https://x.com/explore":
+        try:
+            logger.info("Retrying navigation with explore fallback...")
+            await page.goto("https://x.com/explore", wait_until="domcontentloaded")
+            for _ in range(6):
+                await asyncio.sleep(0.5)
+                post_state = await detect_page_state(page)
+                if post_state == "ok":
+                    return True
+                if post_state in {"logged_out", "captcha"}:
+                    return False
+        except Exception as fallback_err:
+            logger.warning(f"Explore fallback failed: {fallback_err}")
+
     post_state = await detect_page_state(page)
     return post_state not in {"logged_out", "rate_limited", "captcha"}
 
@@ -569,12 +628,12 @@ def _format_trend_url(identifier: str, *, is_url: bool, topic_title: str) -> str
 
 
 async def _wait_for_trends_dom(page: Any) -> None:
-    """Wait for trend elements to appear in the DOM."""
+    """Wait for trend or news article elements to appear in the DOM."""
     try:
         if hasattr(page, "locator"):
-            await page.locator("[data-testid='trend']").first.wait_for(
-                state="visible", timeout=10000
-            )
+            await page.locator(
+                "[data-testid^='news_sidebar_article'], [data-testid='trend']"
+            ).first.wait_for(state="visible", timeout=10000)
     except Exception as e:
         logger.debug(f"Wait for trend element timed out or skipped: {e}")
 
@@ -611,8 +670,9 @@ async def extract_trending_sidebar(
     """Extract structured TrendingTopic models from the X.com sidebar."""
     sidebar_link_sel = (
         selectors.get("selectors", {}).get("sidebar_link")
+        or selectors.get("sidebar", {}).get("sidebar_link")
         or selectors.get("feed", {}).get("news_trends")
-        or "[data-testid='trend'], a[href*='/search?q='], [data-testid^='news_sidebar_article']"
+        or "[data-testid^='news_sidebar_article'], [data-testid='trend'], a[href*='/search?q=']"
     )
     heuristic = selectors.get("link_heuristic", {"must_contain_newline": False})
 

--- a/backend/scripts/scrape_trending_topics.py
+++ b/backend/scripts/scrape_trending_topics.py
@@ -125,7 +125,8 @@ async def _resolve_link_href(link: Any, *, clean_title: str) -> str:
                 and testid.startswith("news_sidebar_article_")
             ):
                 raw_b64 = testid[len("news_sidebar_article_") :]
-                decoded = base64.b64decode(raw_b64).decode("utf-8")
+                padded_b64 = raw_b64 + "=" * (-len(raw_b64) % 4)
+                decoded = base64.b64decode(padded_b64).decode("utf-8", errors="ignore")
                 if ":" in decoded:
                     trend_id = decoded.split(":")[-1]
                     return f"https://x.com/i/trending/{trend_id}"

--- a/backend/tests/api/routes/test_ai_threads.py
+++ b/backend/tests/api/routes/test_ai_threads.py
@@ -336,3 +336,107 @@ def test_chat_stream_with_multimodal_images_persists(
     assert user_parts[0] == {"type": "text", "text": "Analyze this chart"}
     assert user_parts[1]["type"] == "image_url"
     assert "data:image/png;base64" in user_parts[1]["image_url"]["url"]
+
+
+def test_chat_stream_rejects_empty_message_without_images(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    t = _create_thread(client, superuser_token_headers)
+    tid = t["id"]
+    res = client.post(
+        f"{settings.API_V1_STR}/ai/threads/{tid}/chat",
+        headers=superuser_token_headers,
+        json={"message": "   ", "images": []},
+    )
+    assert res.status_code == 422
+    assert "at least one image" in res.json()["detail"].lower()
+
+
+def test_chat_stream_accepts_empty_message_with_valid_images(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    async def fake_astream(messages: Any):  # noqa: ARG001
+        last = messages[-1]
+        assert isinstance(last.content, list)
+        assert last.content[0]["text"] == "Analyze the attached image(s)"
+        yield AIMessageChunk(content="Looks like a clear blue sky.")
+
+    mock_model = MagicMock()
+    mock_model.astream = fake_astream
+
+    t = _create_thread(client, superuser_token_headers)
+    tid = t["id"]
+
+    with (
+        patch(
+            "app.services.ai_completion_client.stream_direct_openai_proxy",
+            side_effect=ConnectionError("proxy down"),
+        ),
+        patch(
+            "app.services.ai_completion_client.get_chat_model",
+            return_value=mock_model,
+        ),
+    ):
+        res = client.post(
+            f"{settings.API_V1_STR}/ai/threads/{tid}/chat",
+            headers=superuser_token_headers,
+            json={
+                "message": "",
+                "images": ["https://example.com/sky.png"],
+            },
+        )
+    assert res.status_code == 200
+    assert "sky." in res.text
+
+
+def test_chat_stream_filters_malformed_image_schemes(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    async def fake_astream(messages: Any):  # noqa: ARG001
+        last = messages[-1]
+        assert isinstance(last.content, list)
+        # Should have only kept the valid https:// URL, dropping javascript: and file:
+        assert len(last.content) == 2
+        assert last.content[1]["image_url"]["url"] == "https://example.com/valid.jpg"
+        yield AIMessageChunk(content="Safe response")
+
+    mock_model = MagicMock()
+    mock_model.astream = fake_astream
+
+    t = _create_thread(client, superuser_token_headers)
+    tid = t["id"]
+
+    with (
+        patch(
+            "app.services.ai_completion_client.stream_direct_openai_proxy",
+            side_effect=ConnectionError("proxy down"),
+        ),
+        patch(
+            "app.services.ai_completion_client.get_chat_model",
+            return_value=mock_model,
+        ),
+    ):
+        res = client.post(
+            f"{settings.API_V1_STR}/ai/threads/{tid}/chat",
+            headers=superuser_token_headers,
+            json={
+                "message": "Check this",
+                "images": [
+                    "javascript:alert(1)",
+                    "file:///etc/passwd",
+                    "https://example.com/valid.jpg",
+                ],
+            },
+        )
+    assert res.status_code == 200
+    assert '"Safe "' in res.text
+    assert '"response"' in res.text
+
+    detail = client.get(
+        f"{settings.API_V1_STR}/ai/threads/{tid}",
+        headers=superuser_token_headers,
+    ).json()
+    parts = detail["transcript"]["messages"][0]["parts"]
+    assert len(parts) == 2
+    assert parts[0]["text"] == "Check this"
+    assert parts[1]["image_url"]["url"] == "https://example.com/valid.jpg"

--- a/backend/tests/api/routes/test_ai_threads.py
+++ b/backend/tests/api/routes/test_ai_threads.py
@@ -284,3 +284,55 @@ def test_list_ai_models(
     assert "default_model" in data
     assert len(data["data"]) > 0
     assert any(m["id"] == "gemini-3.6-flash-high" for m in data["data"])
+
+
+def test_chat_stream_with_multimodal_images_persists(
+    client: TestClient, superuser_token_headers: dict[str, str]
+) -> None:
+    async def fake_astream(messages: Any):  # noqa: ARG001
+        # Check that the last message content was parsed into multimodal list
+        last = messages[-1]
+        assert isinstance(last.content, list)
+        assert last.content[0]["text"] == "Analyze this chart"
+        assert "data:image/png;base64" in last.content[1]["image_url"]["url"]
+        yield AIMessageChunk(content="This chart shows 40% growth!")
+
+    mock_model = MagicMock()
+    mock_model.astream = fake_astream
+
+    t = _create_thread(client, superuser_token_headers, origin="composer")
+    tid = t["id"]
+
+    with (
+        patch(
+            "app.services.ai_completion_client.stream_direct_openai_proxy",
+            side_effect=ConnectionError("proxy down"),
+        ),
+        patch(
+            "app.services.ai_completion_client.get_chat_model",
+            return_value=mock_model,
+        ),
+    ):
+        stream_res = client.post(
+            f"{settings.API_V1_STR}/ai/threads/{tid}/chat",
+            headers=superuser_token_headers,
+            json={
+                "message": "Analyze this chart",
+                "images": [
+                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                ],
+            },
+        )
+    assert stream_res.status_code == 200
+    assert "text/event-stream" in stream_res.headers["content-type"]
+    assert "growth!" in stream_res.text
+
+    detail = client.get(
+        f"{settings.API_V1_STR}/ai/threads/{tid}",
+        headers=superuser_token_headers,
+    ).json()
+    user_parts = detail["transcript"]["messages"][0]["parts"]
+    assert len(user_parts) == 2
+    assert user_parts[0] == {"type": "text", "text": "Analyze this chart"}
+    assert user_parts[1]["type"] == "image_url"
+    assert "data:image/png;base64" in user_parts[1]["image_url"]["url"]

--- a/backend/tests/api/routes/test_trending.py
+++ b/backend/tests/api/routes/test_trending.py
@@ -188,3 +188,37 @@ def test_draft_from_trending_topic_not_found(
         headers=headers,
     )
     assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_resolve_link_href_variations() -> None:
+    import base64
+    from unittest.mock import AsyncMock, MagicMock
+
+    from scripts.scrape_trending_topics import _resolve_link_href
+
+    # 1. Padded base64 trend ID: AiTrend:987654321
+    b64_padded = base64.b64encode(b"AiTrend:987654321").decode("utf-8")
+    mock_link_padded = MagicMock()
+    mock_link_padded.get_attribute = AsyncMock(
+        return_value=f"news_sidebar_article_{b64_padded}"
+    )
+    resolved = await _resolve_link_href(mock_link_padded, clean_title="Tech News")
+    assert resolved == "https://x.com/i/trending/987654321"
+
+    # 2. Unpadded base64 (stripped "=" padding)
+    b64_unpadded = b64_padded.rstrip("=")
+    mock_link_unpadded = MagicMock()
+    mock_link_unpadded.get_attribute = AsyncMock(
+        return_value=f"news_sidebar_article_{b64_unpadded}"
+    )
+    resolved2 = await _resolve_link_href(mock_link_unpadded, clean_title="Tech News")
+    assert resolved2 == "https://x.com/i/trending/987654321"
+
+    # 3. Standard href fallback
+    mock_link_href = MagicMock()
+    mock_link_href.get_attribute = AsyncMock(
+        side_effect=lambda attr: "/search?q=AI" if attr == "href" else None
+    )
+    resolved3 = await _resolve_link_href(mock_link_href, clean_title="AI")
+    assert resolved3 == "/search?q=AI"

--- a/backend/tests/services/test_ai_chat_runner.py
+++ b/backend/tests/services/test_ai_chat_runner.py
@@ -209,3 +209,65 @@ async def test_generate_ai_thread_title_success() -> None:
             assistant_response="TypeScript 5.8 introduces granular checks...",
         )
     assert title == "TypeScript 5.8 Deep Dive"
+
+
+def test_build_message_history_with_images() -> None:
+    images = ["data:image/png;base64,abc123", "https://example.com/photo.jpg"]
+    messages = _build_message_history(
+        transcript=None,
+        current_message="Check these charts",
+        images=images,
+    )
+    assert len(messages) == 2
+    assert isinstance(messages[0], SystemMessage)
+    last_msg = messages[1]
+    assert isinstance(last_msg, HumanMessage)
+    assert isinstance(last_msg.content, list)
+    assert last_msg.content[0] == {"type": "text", "text": "Check these charts"}
+    assert last_msg.content[1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,abc123"},
+    }
+    assert last_msg.content[2] == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/photo.jpg"},
+    }
+
+
+def test_build_message_history_transcript_with_image_parts() -> None:
+    transcript = {
+        "messages": [
+            {
+                "role": "user",
+                "parts": [
+                    {"type": "text", "text": "Previous prompt"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/old.png"},
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "parts": [
+                    {"type": "text", "text": "Looks like an architecture diagram"}
+                ],
+            },
+        ]
+    }
+    messages = _build_message_history(
+        transcript=transcript,
+        current_message="Can you improve it?",
+    )
+    assert len(messages) == 4
+    first_human = messages[1]
+    assert isinstance(first_human, HumanMessage)
+    assert isinstance(first_human.content, list)
+    assert first_human.content[0] == {"type": "text", "text": "Previous prompt"}
+    assert first_human.content[1] == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/old.png"},
+    }
+    assert isinstance(messages[2], AIMessage)
+    assert isinstance(messages[3], HumanMessage)
+    assert messages[3].content == "Can you improve it?"

--- a/backend/tests/services/test_ai_chat_runner.py
+++ b/backend/tests/services/test_ai_chat_runner.py
@@ -271,3 +271,22 @@ def test_build_message_history_transcript_with_image_parts() -> None:
     assert isinstance(messages[2], AIMessage)
     assert isinstance(messages[3], HumanMessage)
     assert messages[3].content == "Can you improve it?"
+
+
+def test_extract_images_from_parts_variations() -> None:
+    from app.services.ai_chat_runner import _extract_images_from_parts
+
+    parts = [
+        {"type": "text", "text": "Some text"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/dict.png"}},
+        {"type": "image_url", "image_url": "https://example.com/string.png"},
+        {"type": "image", "url": "https://example.com/direct.png"},
+        {"type": "image_url", "image_url": None},
+        {"type": "other", "url": "https://example.com/ignored.png"},
+    ]
+    extracted = _extract_images_from_parts(parts)
+    assert extracted == [
+        "https://example.com/dict.png",
+        "https://example.com/string.png",
+        "https://example.com/direct.png",
+    ]

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -195,6 +195,20 @@ export const ChatMessageRequestSchema = {
                 }
             ],
             title: 'Model'
+        },
+        images: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Images'
         }
     },
     type: 'object',

--- a/frontend/src/client/schemas.gen.ts
+++ b/frontend/src/client/schemas.gen.ts
@@ -181,8 +181,8 @@ export const ChatMessageRequestSchema = {
         message: {
             type: 'string',
             maxLength: 25000,
-            minLength: 1,
-            title: 'Message'
+            title: 'Message',
+            default: ''
         },
         model: {
             anyOf: [
@@ -202,7 +202,8 @@ export const ChatMessageRequestSchema = {
                     items: {
                         type: 'string'
                     },
-                    type: 'array'
+                    type: 'array',
+                    maxItems: 10
                 },
                 {
                     type: 'null'
@@ -212,7 +213,6 @@ export const ChatMessageRequestSchema = {
         }
     },
     type: 'object',
-    required: ['message'],
     title: 'ChatMessageRequest'
 } as const;
 

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -37,7 +37,7 @@ export type Body_posts_upload_media = {
 };
 
 export type ChatMessageRequest = {
-    message: string;
+    message?: string;
     model?: (string | null);
     images?: (Array<(string)> | null);
 };

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -39,6 +39,7 @@ export type Body_posts_upload_media = {
 export type ChatMessageRequest = {
     message: string;
     model?: (string | null);
+    images?: (Array<(string)> | null);
 };
 
 export type ChatThreadCreate = {

--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -24,23 +24,55 @@ function extractTextParts(parts: ChatUIMessage["parts"]): string {
     .trim()
 }
 
+function extractImageUrls(parts: ChatUIMessage["parts"]): string[] {
+  const urls: string[] = []
+  for (const p of parts) {
+    if (p.type === "image_url" || p.type === "image") {
+      const url =
+        (p as { url?: string }).url ||
+        (p as { image_url?: { url: string } }).image_url?.url
+      if (url) {
+        urls.push(url)
+      }
+    }
+  }
+  return urls
+}
+
 function getMessageTimestamp(message: ChatUIMessage): string | undefined {
   return message.createdAt || (message as { created_at?: string }).created_at
 }
 
 function UserMessageBubble({ message }: { message: ChatUIMessage }) {
   const text = extractTextParts(message.parts)
+  const imageUrls = extractImageUrls(message.parts)
   const createdAt = getMessageTimestamp(message)
 
   return (
     <div className="group relative flex flex-col items-end w-full">
       <Message align="end">
         <MessageContent>
-          <Bubble align="end" variant="outline">
-            <BubbleContent className="rounded-3xl border border-border bg-background text-foreground font-normal px-5 py-3 leading-relaxed shadow-none">
-              {text}
-            </BubbleContent>
-          </Bubble>
+          <div className="flex flex-col items-end gap-2 max-w-full">
+            {imageUrls.length > 0 && (
+              <div className="flex flex-wrap justify-end gap-2 max-w-sm">
+                {imageUrls.map((url, idx) => (
+                  <img
+                    key={idx}
+                    src={url}
+                    alt={`Attachment ${idx + 1}`}
+                    className="max-h-48 max-w-xs object-cover rounded-2xl border border-border/80 shadow-sm"
+                  />
+                ))}
+              </div>
+            )}
+            {text && (
+              <Bubble align="end" variant="outline">
+                <BubbleContent className="rounded-3xl border border-border bg-background text-foreground font-normal px-5 py-3 leading-relaxed shadow-none">
+                  {text}
+                </BubbleContent>
+              </Bubble>
+            )}
+          </div>
         </MessageContent>
       </Message>
       <ChatMessageActions

--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -24,15 +24,35 @@ function extractTextParts(parts: ChatUIMessage["parts"]): string {
     .trim()
 }
 
+function isValidImageUrl(url: string): boolean {
+  if (!url) return false
+  const trimmed = url.trim().toLowerCase()
+  return (
+    trimmed.startsWith("data:image/") ||
+    trimmed.startsWith("https://") ||
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("blob:") ||
+    trimmed.startsWith("/")
+  )
+}
+
 function extractImageUrls(parts: ChatUIMessage["parts"]): string[] {
   const urls: string[] = []
   for (const p of parts) {
     if (p.type === "image_url" || p.type === "image") {
-      const url =
-        (p as { url?: string }).url ||
-        (p as { image_url?: { url: string } }).image_url?.url
-      if (url) {
-        urls.push(url)
+      let rawUrl = ""
+      if ("url" in p && typeof p.url === "string") {
+        rawUrl = p.url
+      } else if (
+        "image_url" in p &&
+        p.image_url &&
+        typeof p.image_url === "object" &&
+        "url" in p.image_url
+      ) {
+        rawUrl = String(p.image_url.url || "")
+      }
+      if (rawUrl && isValidImageUrl(rawUrl)) {
+        urls.push(rawUrl)
       }
     }
   }
@@ -61,6 +81,9 @@ function UserMessageBubble({ message }: { message: ChatUIMessage }) {
                     src={url}
                     alt={`Attachment ${idx + 1}`}
                     className="max-h-48 max-w-xs object-cover rounded-2xl border border-border/80 shadow-sm"
+                    onError={(e) => {
+                      ;(e.currentTarget as HTMLElement).style.display = "none"
+                    }}
                   />
                 ))}
               </div>

--- a/frontend/src/components/Chat/__tests__/ChatMessage.test.tsx
+++ b/frontend/src/components/Chat/__tests__/ChatMessage.test.tsx
@@ -106,4 +106,37 @@ describe("ChatMessage component", () => {
     expect(img).toBeInTheDocument()
     expect(img).toHaveAttribute("src", "https://example.com/chart.png")
   })
+
+  it("filters out unsafe image URL schemes", () => {
+    const message: ChatUIMessage = {
+      id: "msg-unsafe",
+      role: "user",
+      parts: [
+        { type: "text", text: "Malicious test" },
+        { type: "image_url", url: "javascript:alert(1)" },
+      ],
+    }
+
+    render(<ChatMessage message={message} />)
+    expect(screen.queryByAltText("Attachment 1")).not.toBeInTheDocument()
+  })
+
+  it("hides broken images on error", () => {
+    const message: ChatUIMessage = {
+      id: "msg-broken",
+      role: "user",
+      parts: [
+        { type: "text", text: "Broken preview" },
+        { type: "image_url", url: "https://example.com/broken.png" },
+      ],
+    }
+
+    render(<ChatMessage message={message} />)
+    const img = screen.getByAltText("Attachment 1")
+    expect(img).toBeVisible()
+
+    // Trigger image loading error
+    fireEvent.error(img)
+    expect(img).toHaveStyle({ display: "none" })
+  })
 })

--- a/frontend/src/components/Chat/__tests__/ChatMessage.test.tsx
+++ b/frontend/src/components/Chat/__tests__/ChatMessage.test.tsx
@@ -89,4 +89,21 @@ describe("ChatMessage component", () => {
     expect(screen.getByText(/TechCrunch Article/i)).toBeInTheDocument()
     expect(screen.getByText(/techcrunch\.com/i)).toBeInTheDocument()
   })
+
+  it("renders user attached image thumbnails", () => {
+    const message: ChatUIMessage = {
+      id: "msg-5",
+      role: "user",
+      parts: [
+        { type: "text", text: "Look at this preview" },
+        { type: "image_url", url: "https://example.com/chart.png" },
+      ],
+    }
+
+    render(<ChatMessage message={message} />)
+    expect(screen.getByText("Look at this preview")).toBeInTheDocument()
+    const img = screen.getByAltText("Attachment 1")
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute("src", "https://example.com/chart.png")
+  })
 })

--- a/frontend/src/components/Chat/__tests__/PromptForm.test.tsx
+++ b/frontend/src/components/Chat/__tests__/PromptForm.test.tsx
@@ -84,4 +84,35 @@ describe("PromptForm component", () => {
     )
     expect(screen.getByText("Upload Image")).toBeInTheDocument()
   })
+
+  it("submits attached images alongside prompt text", () => {
+    window.URL.createObjectURL = vi.fn().mockReturnValue("blob:preview-1")
+    window.URL.revokeObjectURL = vi.fn()
+
+    const handleSubmit = vi.fn()
+    const { container } = render(
+      <PromptForm
+        onSubmit={handleSubmit}
+        onStop={vi.fn()}
+        isBusy={false}
+        placeholder="Ask anything…"
+      />,
+    )
+
+    const file = new File(["dummy content"], "chart.png", { type: "image/png" })
+    const fileInput = container.querySelector(
+      "input[type='file']",
+    ) as HTMLInputElement
+    expect(fileInput).toBeInTheDocument()
+
+    fireEvent.change(fileInput, { target: { files: [file] } })
+
+    const textarea = screen.getByPlaceholderText("Ask anything…")
+    fireEvent.change(textarea, { target: { value: "Analyze this chart" } })
+
+    const sendBtn = screen.getByLabelText("Send message")
+    fireEvent.click(sendBtn)
+
+    expect(handleSubmit).toHaveBeenCalledWith("Analyze this chart", [file])
+  })
 })

--- a/frontend/src/components/Chat/__tests__/PromptForm.test.tsx
+++ b/frontend/src/components/Chat/__tests__/PromptForm.test.tsx
@@ -114,5 +114,42 @@ describe("PromptForm component", () => {
     fireEvent.click(sendBtn)
 
     expect(handleSubmit).toHaveBeenCalledWith("Analyze this chart", [file])
+    // Verify blob URL was revoked on clear
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview-1")
+  })
+
+  it("filters out non-image files and files larger than 10MB", () => {
+    window.URL.createObjectURL = vi.fn().mockReturnValue("blob:preview-valid")
+    window.URL.revokeObjectURL = vi.fn()
+
+    const { container } = render(
+      <PromptForm
+        onSubmit={vi.fn()}
+        onStop={vi.fn()}
+        isBusy={false}
+        placeholder="Ask anything…"
+      />,
+    )
+
+    const fileInput = container.querySelector(
+      "input[type='file']",
+    ) as HTMLInputElement
+
+    const validImg = new File(["valid"], "photo.jpg", { type: "image/jpeg" })
+    const pdfFile = new File(["pdf content"], "doc.pdf", {
+      type: "application/pdf",
+    })
+    // 11MB file
+    const hugeImg = new File([new ArrayBuffer(11 * 1024 * 1024)], "huge.png", {
+      type: "image/png",
+    })
+
+    fireEvent.change(fileInput, {
+      target: { files: [validImg, pdfFile, hugeImg] },
+    })
+
+    // Only validImg should be accepted (createObjectURL called once)
+    expect(window.URL.createObjectURL).toHaveBeenCalledTimes(1)
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(validImg)
   })
 })

--- a/frontend/src/components/Chat/types.ts
+++ b/frontend/src/components/Chat/types.ts
@@ -88,8 +88,15 @@ export interface ThoughtPart {
   content: string
 }
 
+export interface ImageUrlPart {
+  type: "image_url" | "image"
+  url?: string
+  image_url?: { url: string }
+}
+
 export type ChatMessagePart =
   | TextMessagePart
+  | ImageUrlPart
   | SourceUrlPart
   | AskUserToolPart
   | WebSearchToolPart

--- a/frontend/src/components/Chat/usePromptFormState.ts
+++ b/frontend/src/components/Chat/usePromptFormState.ts
@@ -25,6 +25,9 @@ function isPlainEnterPress(
   return true
 }
 
+const MAX_IMAGE_COUNT = 5
+const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024 // 10 MB
+
 export function useImageAttachments() {
   const [selectedImages, setSelectedImages] = React.useState<AttachmentImage[]>(
     [],
@@ -35,7 +38,17 @@ export function useImageAttachments() {
     const files = e.target.files
     if (!files || files.length === 0) return
 
-    const newImages = Array.from(files).map((file) => ({
+    const validFiles: File[] = []
+    for (const file of Array.from(files)) {
+      if (!file.type.startsWith("image/")) continue
+      if (file.size > MAX_IMAGE_SIZE_BYTES) continue
+      validFiles.push(file)
+    }
+
+    const availableSlots = Math.max(0, MAX_IMAGE_COUNT - selectedImages.length)
+    const allowedFiles = validFiles.slice(0, availableSlots)
+
+    const newImages = allowedFiles.map((file) => ({
       file,
       preview: URL.createObjectURL(file),
     }))
@@ -49,7 +62,7 @@ export function useImageAttachments() {
   function handleRemoveImage(index: number) {
     setSelectedImages((prev) => {
       const target = prev[index]
-      if (target) {
+      if (target?.preview) {
         URL.revokeObjectURL(target.preview)
       }
       return prev.filter((_, i) => i !== index)
@@ -57,8 +70,25 @@ export function useImageAttachments() {
   }
 
   function clearImages() {
-    setSelectedImages([])
+    setSelectedImages((prev) => {
+      for (const img of prev) {
+        if (img.preview) {
+          URL.revokeObjectURL(img.preview)
+        }
+      }
+      return []
+    })
   }
+
+  React.useEffect(() => {
+    return () => {
+      for (const img of selectedImages) {
+        if (img.preview) {
+          URL.revokeObjectURL(img.preview)
+        }
+      }
+    }
+  }, [selectedImages])
 
   return {
     selectedImages,

--- a/frontend/src/components/PostInput/PostActionBar.tsx
+++ b/frontend/src/components/PostInput/PostActionBar.tsx
@@ -1,4 +1,4 @@
-import { Calendar, ImageIcon, Plus } from "lucide-react"
+import { Calendar, ImageIcon, Loader2, Plus } from "lucide-react"
 import * as React from "react"
 
 import type { Platform } from "@/components/Common/PlatformSelector"
@@ -35,40 +35,20 @@ function PencilSparklesIcon({
   )
 }
 
-export interface PostActionBarProps {
-  isSubmitting: boolean
-  isContentEmpty: boolean
-  canPublishOrSchedule?: boolean
-  currentLength?: number
-  platform?: Platform
-  isXPremium?: boolean
-  isAiGenerating?: boolean
-  onActionTypeChange: (type: "draft" | "schedule" | "post") => void
-  onImageClick?: () => void
-  onDraftClick: () => void
-  onAiDraftClick?: () => void
-  onScheduleClick: () => void
-  onPostClick: () => void
-  onCancelClick?: () => void
-  showCancel?: boolean
-  scheduledAt?: Date | undefined
-  onScheduleChange?: (date: Date | undefined) => void
-  isScheduleOpen: boolean
-  onToggleSchedule: (open: boolean) => void
-}
-
 interface LeftControlsProps {
   isScheduleOpen: boolean
   isScheduled: boolean
   isSubmitting: boolean
   isAiGenerating?: boolean
   isAiMode?: boolean
+  isContentEmpty?: boolean
   scheduledAt?: Date | undefined
   onScheduleChange?: (date: Date | undefined) => void
   onToggleSchedule: (open: boolean) => void
   onActionTypeChange: (type: "draft" | "schedule" | "post") => void
   onImageClick?: () => void
   onToggleAiMode?: () => void
+  onAiDraftSubmit?: () => void
 }
 
 function ScheduleAndMediaControls({
@@ -77,13 +57,23 @@ function ScheduleAndMediaControls({
   isSubmitting,
   isAiGenerating,
   isAiMode,
+  isContentEmpty,
   scheduledAt,
   onScheduleChange,
   onToggleSchedule,
   onActionTypeChange,
   onImageClick,
   onToggleAiMode,
+  onAiDraftSubmit,
 }: LeftControlsProps) {
+  const handleAiDraftClick = () => {
+    if (!isContentEmpty && onAiDraftSubmit) {
+      onAiDraftSubmit()
+    } else {
+      onToggleAiMode?.()
+    }
+  }
+
   const mediaAndAiButtons = (
     <>
       <Button
@@ -109,17 +99,31 @@ function ScheduleAndMediaControls({
             ? "text-primary bg-primary/20 ring-1 ring-primary/40 shadow-xs"
             : "text-muted-foreground hover:text-primary hover:bg-primary/10"
         }`}
-        aria-label={isAiMode ? "Disable AI Draft Mode" : "Draft with AI"}
-        title={
-          isAiMode
-            ? "AI Draft Mode Active (click to toggle off)"
-            : "Draft with AI"
+        aria-label={
+          isAiGenerating
+            ? "Generating AI Draft..."
+            : isAiMode
+              ? "Disable AI Draft Mode"
+              : "Draft with AI"
         }
-        onClick={onToggleAiMode}
+        title={
+          isAiGenerating
+            ? "Drafting post in background with AI..."
+            : !isContentEmpty
+              ? "Draft with AI"
+              : isAiMode
+                ? "AI Draft Mode Active (click to toggle off)"
+                : "Draft with AI"
+        }
+        onClick={handleAiDraftClick}
         disabled={isSubmitting || isAiGenerating}
         data-testid="ai-draft-btn"
       >
-        <PencilSparklesIcon className="h-4.5 w-4.5" />
+        {isAiGenerating ? (
+          <Loader2 className="h-4.5 w-4.5 animate-spin text-primary" />
+        ) : (
+          <PencilSparklesIcon className="h-4.5 w-4.5" />
+        )}
       </Button>
     </>
   )
@@ -388,12 +392,14 @@ export const PostActionBar = React.memo(function PostActionBar({
         isSubmitting={isSubmitting}
         isAiGenerating={isAiGenerating}
         isAiMode={isAiMode}
+        isContentEmpty={isContentEmpty}
         scheduledAt={scheduledAt}
         onScheduleChange={onScheduleChange}
         onToggleSchedule={onToggleSchedule}
         onActionTypeChange={onActionTypeChange}
         onImageClick={onImageClick}
         onToggleAiMode={onToggleAiMode}
+        onAiDraftSubmit={onAiDraftSubmit}
       />
 
       <ActionButtonsGroup

--- a/frontend/src/components/PostInput/PostInputBox.tsx
+++ b/frontend/src/components/PostInput/PostInputBox.tsx
@@ -156,6 +156,25 @@ function PostInputFormBody({
   isScheduleOpen,
   setIsScheduleOpen,
 }: PostInputFormBodyProps) {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault()
+      if (isAiMode && onAiDraftSubmit) {
+        onAiDraftSubmit()
+      } else {
+        handleSubmit(scheduledAt || isScheduleOpen ? "schedule" : "post")
+      }
+    } else if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      isAiMode &&
+      onAiDraftSubmit
+    ) {
+      event.preventDefault()
+      onAiDraftSubmit()
+    }
+  }
+
   return (
     <div className="flex-1 min-w-0">
       <div className="flex items-center justify-between gap-2 mb-1.5">
@@ -174,6 +193,7 @@ function PostInputFormBody({
         ref={textareaRef}
         value={content}
         onChange={handleContentChange}
+        onKeyDown={handleKeyDown}
         placeholder={
           isAiMode
             ? "Type a topic, idea, or notes for AI to draft..."
@@ -320,6 +340,11 @@ export function PostInputBox({
     textareaRef,
   })
 
+  const handleToggleAiMode = React.useCallback(() => {
+    form.toggleAiMode()
+    setTimeout(() => textareaRef.current?.focus(), 50)
+  }, [form.toggleAiMode])
+
   return (
     <section
       aria-label={editMode ? "Edit post" : "Post composer"}
@@ -358,7 +383,7 @@ export function PostInputBox({
         isXPremium={Boolean(xStatus?.is_premium)}
         onImageClick={() => fileInputRef.current?.click()}
         handleSubmit={onSubmitHandler}
-        onToggleAiMode={form.toggleAiMode}
+        onToggleAiMode={handleToggleAiMode}
         onAiDraftSubmit={onAiDraftHandler}
         onCancel={onCancel}
         scheduledAt={form.scheduledAt}

--- a/frontend/src/components/PostInput/__tests__/PostActionBar.test.tsx
+++ b/frontend/src/components/PostInput/__tests__/PostActionBar.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { PostActionBar } from "../PostActionBar"
+
+describe("PostActionBar - Draft with AI Button", () => {
+  it("toggles AI mode when content is empty and ai-draft-btn is clicked", () => {
+    const onToggleAiMode = vi.fn()
+    const onAiDraftSubmit = vi.fn()
+
+    render(
+      <PostActionBar
+        isSubmitting={false}
+        isContentEmpty={true}
+        isScheduleOpen={false}
+        onToggleSchedule={vi.fn()}
+        onActionTypeChange={vi.fn()}
+        onDraftClick={vi.fn()}
+        onScheduleClick={vi.fn()}
+        onPostClick={vi.fn()}
+        onToggleAiMode={onToggleAiMode}
+        onAiDraftSubmit={onAiDraftSubmit}
+      />,
+    )
+
+    const aiButton = screen.getByTestId("ai-draft-btn")
+    expect(aiButton).toBeInTheDocument()
+
+    fireEvent.click(aiButton)
+    expect(onToggleAiMode).toHaveBeenCalledTimes(1)
+    expect(onAiDraftSubmit).not.toHaveBeenCalled()
+  })
+
+  it("triggers onAiDraftSubmit directly when content is NOT empty and ai-draft-btn is clicked", () => {
+    const onToggleAiMode = vi.fn()
+    const onAiDraftSubmit = vi.fn()
+
+    render(
+      <PostActionBar
+        isSubmitting={false}
+        isContentEmpty={false}
+        currentLength={25}
+        isScheduleOpen={false}
+        onToggleSchedule={vi.fn()}
+        onActionTypeChange={vi.fn()}
+        onDraftClick={vi.fn()}
+        onScheduleClick={vi.fn()}
+        onPostClick={vi.fn()}
+        onToggleAiMode={onToggleAiMode}
+        onAiDraftSubmit={onAiDraftSubmit}
+      />,
+    )
+
+    const aiButton = screen.getByTestId("ai-draft-btn")
+    fireEvent.click(aiButton)
+
+    expect(onAiDraftSubmit).toHaveBeenCalledTimes(1)
+    expect(onToggleAiMode).not.toHaveBeenCalled()
+  })
+
+  it("disables button and displays loader when isAiGenerating is true", () => {
+    render(
+      <PostActionBar
+        isSubmitting={false}
+        isContentEmpty={false}
+        isAiGenerating={true}
+        isScheduleOpen={false}
+        onToggleSchedule={vi.fn()}
+        onActionTypeChange={vi.fn()}
+        onDraftClick={vi.fn()}
+        onScheduleClick={vi.fn()}
+        onPostClick={vi.fn()}
+      />,
+    )
+
+    const aiButton = screen.getByTestId("ai-draft-btn")
+    expect(aiButton).toBeDisabled()
+    expect(aiButton).toHaveAttribute("aria-label", "Generating AI Draft...")
+  })
+
+  it("submits AI draft when in AI mode and primary button is clicked", () => {
+    const onAiDraftSubmit = vi.fn()
+
+    render(
+      <PostActionBar
+        isSubmitting={false}
+        isContentEmpty={false}
+        isAiMode={true}
+        currentLength={25}
+        isScheduleOpen={false}
+        onToggleSchedule={vi.fn()}
+        onActionTypeChange={vi.fn()}
+        onDraftClick={vi.fn()}
+        onScheduleClick={vi.fn()}
+        onPostClick={vi.fn()}
+        onAiDraftSubmit={onAiDraftSubmit}
+      />,
+    )
+
+    const primaryBtn = screen.getByTestId("primary-post-btn")
+    expect(primaryBtn).toHaveTextContent("Draft")
+
+    fireEvent.click(primaryBtn)
+    expect(onAiDraftSubmit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/PostInput/useComposerSubmission.ts
+++ b/frontend/src/components/PostInput/useComposerSubmission.ts
@@ -88,8 +88,12 @@ export function useComposerSubmission({
   }
 
   return {
-    isSuccess: form.createPostMutation.isSuccess,
-    isSubmitting: form.createPostMutation.isPending || form.isUploadingMedia,
+    isSuccess:
+      form.createPostMutation.isSuccess || form.aiDraftMutation.isSuccess,
+    isSubmitting:
+      form.createPostMutation.isPending ||
+      form.isUploadingMedia ||
+      form.aiDraftMutation.isPending,
     onSubmitHandler: form.handleSubmit,
     onAiDraftHandler: form.handleAiDraft,
   }

--- a/frontend/src/components/PostInput/usePostForm.ts
+++ b/frontend/src/components/PostInput/usePostForm.ts
@@ -227,7 +227,7 @@ function useAiDraftMutation(
     },
     onSuccess: (_, variables) => {
       draftingStore.removeDraft(variables.draftId)
-      showSuccessToast("Draft created and saved to your drafts!")
+      showSuccessToast("Draft created! View it under Posts → Drafts.")
       queryClient.invalidateQueries({ queryKey: ["posts"] })
     },
     onError: (err, variables) => {
@@ -314,7 +314,8 @@ export function usePostForm(options?: UsePostFormOptions) {
     ...media,
     handleSubmit,
     createPostMutation,
+    aiDraftMutation,
     handleAiDraft,
-    isGeneratingAiDraft: false,
+    isGeneratingAiDraft: aiDraftMutation.isPending,
   }
 }

--- a/frontend/src/hooks/useAIChatFeedState.ts
+++ b/frontend/src/hooks/useAIChatFeedState.ts
@@ -8,14 +8,34 @@ import type {
 } from "@/components/Chat/types"
 import { useAIChatStream } from "@/hooks/useAIChatStream"
 
-function createMessageTurn(text: string): {
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}
+
+function createMessageTurn(
+  text: string,
+  imageUrls: string[] = [],
+): {
   userMsg: ChatUIMessage
   assistantMsg: ChatUIMessage
 } {
+  const parts: ChatUIMessage["parts"] = []
+  if (text.trim()) {
+    parts.push({ type: "text", text: text.trim() })
+  }
+  for (const url of imageUrls) {
+    parts.push({ type: "image_url", url })
+  }
+
   const userMsg: ChatUIMessage = {
     id: `local-user-${Date.now()}`,
     role: "user",
-    parts: [{ type: "text", text: text.trim() }],
+    parts,
     createdAt: new Date().toISOString(),
   }
 
@@ -184,52 +204,63 @@ export function useAIChatFeedState({
   })
 
   const handleSendMessage = React.useCallback(
-    (text: string) => {
-      if (!text.trim() || isStreaming) return
+    async (text: string, attachedImages?: File[]) => {
+      const trimmedText = text.trim()
+      const hasImages = Boolean(attachedImages && attachedImages.length > 0)
+      if ((!trimmedText && !hasImages) || isStreaming) return
+
+      let base64Images: string[] = []
+      if (hasImages && attachedImages) {
+        try {
+          base64Images = await Promise.all(attachedImages.map(fileToDataUrl))
+        } catch {
+          base64Images = []
+        }
+      }
 
       clearThreadDraft(activeThreadId)
-      const { userMsg, assistantMsg } = createMessageTurn(text)
+      const promptText =
+        trimmedText || (hasImages ? "Analyze the attached image(s)" : "")
+      const { userMsg, assistantMsg } = createMessageTurn(
+        promptText,
+        base64Images,
+      )
       setLocalMessages((prev) => [...prev, userMsg, assistantMsg])
       setPendingQuestion(null)
 
-      async function execute() {
-        let targetThreadId = activeThreadId
-        if (!targetThreadId) {
-          try {
-            const newThread = await createThreadMutation.mutateAsync(
-              text.trim(),
-            )
-            targetThreadId = newThread.id
-            setActiveThreadId(newThread.id)
-          } catch {
-            return
-          }
+      let targetThreadId = activeThreadId
+      if (!targetThreadId) {
+        try {
+          const newThread = await createThreadMutation.mutateAsync(promptText)
+          targetThreadId = newThread.id
+          setActiveThreadId(newThread.id)
+        } catch {
+          return
         }
-
-        startStream(
-          targetThreadId,
-          text.trim(),
-          {
-            onThought: (content) =>
-              setLocalMessages((prev) =>
-                updateAssistantPart(prev, assistantMsg.id, "thought", content),
-              ),
-            onTextDelta: (delta) =>
-              setLocalMessages((prev) =>
-                updateAssistantPart(prev, assistantMsg.id, "text", delta),
-              ),
-            onDone: () => {
-              queryClient.invalidateQueries({ queryKey: ["ai-threads"] })
-              queryClient.invalidateQueries({
-                queryKey: ["ai-thread", targetThreadId],
-              })
-            },
-          },
-          selectedModelId,
-        )
       }
 
-      execute()
+      startStream(
+        targetThreadId,
+        promptText,
+        {
+          onThought: (content) =>
+            setLocalMessages((prev) =>
+              updateAssistantPart(prev, assistantMsg.id, "thought", content),
+            ),
+          onTextDelta: (delta) =>
+            setLocalMessages((prev) =>
+              updateAssistantPart(prev, assistantMsg.id, "text", delta),
+            ),
+          onDone: () => {
+            queryClient.invalidateQueries({ queryKey: ["ai-threads"] })
+            queryClient.invalidateQueries({
+              queryKey: ["ai-thread", targetThreadId],
+            })
+          },
+        },
+        selectedModelId,
+        base64Images.length > 0 ? base64Images : undefined,
+      )
     },
     [
       activeThreadId,

--- a/frontend/src/hooks/useAIChatStream.ts
+++ b/frontend/src/hooks/useAIChatStream.ts
@@ -107,12 +107,14 @@ async function executeChatStreamRequest({
   message,
   handlers,
   model,
+  images,
   signal,
 }: {
   threadId: string
   message: string
   handlers: StreamEventHandlers
   model?: string
+  images?: string[]
   signal: AbortSignal
 }) {
   const token = getAuthToken()
@@ -122,7 +124,7 @@ async function executeChatStreamRequest({
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ message, model }),
+    body: JSON.stringify({ message, model, images }),
     signal,
   })
 
@@ -147,6 +149,7 @@ export function useAIChatStream() {
       message: string,
       handlers: StreamEventHandlers = {},
       model?: string,
+      images?: string[],
     ) => {
       stop()
       const controller = new AbortController()
@@ -159,6 +162,7 @@ export function useAIChatStream() {
           message,
           handlers,
           model,
+          images,
           signal: controller.signal,
         })
       } catch (err: unknown) {


### PR DESCRIPTION
## Description
Closes #112

This PR adds end-to-end multimodal image capability to the LinkX Copilot (`/ai`), hardens input validation, resolves browser blob memory leaks, and fixes the Post Composer "Draft with AI" button and X trends right sidebar scraper.

### Changes
1. **Multimodal Image Support (`#112`)**:
   - Backend `ChatMessageRequest` model with `images: list[str] | None = Field(default=None, max_length=10)`.
   - Thread transcript persistence of image parts (`{"type": "image_url", "image_url": {"url": ...}}`).
   - `ai_chat_runner.py` LangChain message conversion to `HumanMessage(content=[{"type": "text", ...}, {"type": "image_url", ...}])`.
   - `ai_completion_client.py` message formatter preserving list structure for OpenAI vision endpoints.
   - Frontend `useAIChatStream` and `useAIChatFeedState` supporting image streaming via base64 data URLs.
   - `UserMessageBubble` rounded image thumbnails and `PromptForm` image selector.

2. **Hardening & Security Audits**:
   - Defaulted empty text with images to `"Analyze the attached image(s)"`.
   - Limited images to max 5 on frontend and max 10 on backend; capped file size to 10MB.
   - Revoked `URL.createObjectURL` blob URLs on clear, remove, and component unmount.
   - Sanitized image URLs against unsafe schemes (`javascript:...`) and added `onError` fallback on broken images.
   - Added automatic base64 padding to X sidebar article trend ID decoding.

3. **Composer & Scraper Fixes**:
   - Fixed composer action bar to directly trigger background post drafting when content is present.
   - Added `Enter` (without Shift) and `Cmd+Enter` shortcuts in AI mode.
   - Updated scraper to target `https://x.com/home` right sidebar Today's News articles.
   - Fixed `ScrapingGraph` error routing to prevent empty/error scraping runs from falsely reporting success.

### Verification
- Backend unit tests: 26/26 passed (`test_ai_threads.py`, `test_ai_chat_runner.py`, `test_trending.py`)
- Frontend unit tests: 59/59 passed (`PromptForm.test.tsx`, `ChatMessage.test.tsx`, etc.)
- Full linting, formatting, and production build passed.