### PR TITLE
feat(chat): multi-thread prompt queue, image normalization, and draft context memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ frontend/.env.*
 # macOS metadata
 .DS_Store
 **/.DS_Store
+
+# Python cache
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,11 +107,55 @@ cd backend && uv run pytest tests/ -v
 # 5. If you changed backend OpenAPI schemas, regenerate frontend SDK
 bash ./scripts/generate-client.sh
 
-# 6. Verify git status; commit only after explicit approval
+# 6. Verify CodeScene Code Health Quality Gates (Local MCP or CLI)
+# Run CodeScene delta analysis against master to catch complexity/degradation before pushing
+python3 scripts/check_codescene.py  # or call cs-mcp analyze_change_set tool
+
+# 7. Verify git status; commit only after explicit approval
 git status
 git add .
 git commit -m "feat(scope): descriptive message"
 ```
+
+## CodeScene MCP & Code Health Quality Gates
+
+LinkX uses **CodeScene** for automated Code Health reviews on PRs. A PR check fails if any modified file degrades or introduces code health smells.
+
+### CodeScene MCP Server
+The local CodeScene MCP server binary (`/opt/homebrew/bin/cs-mcp`) is installed and configured in `~/.gemini/config/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "codescene": {
+      "command": "/opt/homebrew/bin/cs-mcp"
+    }
+  }
+}
+```
+
+Key MCP tools provided by `cs-mcp`:
+- `analyze_change_set`: Compares branch against base (`origin/master`) and verifies Code Health quality gates.
+- `code_health_review`: Performs deep analysis on a single file with line numbers and refactoring suggestions.
+- `code_health_score`: Retrieves current numeric score (1.0 - 10.0) for a file.
+- `pre_commit_code_health_safeguard`: Analyzes staged changes before committing.
+
+### Code Health Quality Standards (Must Follow)
+To keep CodeScene CI checks green, all code must respect these thresholds:
+1. **Low Cyclomatic Complexity**:
+   - Backend functions: Cyclomatic complexity **<= 9** (module mean <= 4.0).
+   - Frontend components/hooks: Cyclomatic complexity **<= 9** (components <= 10).
+2. **Function Arguments**:
+   - Maximum **<= 4 arguments** per function. Use keyword config/payload dicts or dataclasses/Pydantic models for larger parameter sets.
+3. **Function Length**:
+   - Maximum **<= 70 lines of code** per function. Break large methods into cohesive private helper functions.
+4. **Nesting Depth**:
+   - Maximum **< 4 levels** of nested blocks (`if`, `for`, `try`). Use early returns / guards.
+5. **No Complex Conditionals**:
+   - Avoid chaining multiple `&&` and `||` logic in single `if` statements (max 2 branches). Extract to descriptive boolean variables.
+6. **No "Bumpy Road Ahead"**:
+   - Avoid repeated deeply nested conditional blocks within a single function. Extract subroutines.
+
 
 ## AI Agents (Cursor, Copilot, etc.)
 

--- a/backend/app/api/routes/ai_threads.py
+++ b/backend/app/api/routes/ai_threads.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
@@ -30,6 +31,7 @@ from app.services.ai_chat_runner import (
     format_sse,
     generate_ai_thread_title,
 )
+from app.services.ai_image_utils import sanitize_image_urls as _clean_image_urls
 
 router = APIRouter(prefix="/ai/threads", tags=["ai-threads"])
 
@@ -69,31 +71,87 @@ def _handle_thought_part(
 
 
 def _handle_tool_part(
+    *,
     event_name: str,
     payload: dict[str, Any],
     assistant_parts: list[dict[str, Any]],
 ) -> None:
-    part: dict[str, Any] = {
-        "type": "tool_call",
-        "name": payload.get("name"),
+    tool_id = str(payload.get("id") or f"call_{uuid.uuid4().hex[:8]}")
+    tool_name = str(payload.get("name") or "tool")
+
+    if event_name == "tool_output":
+        for part in reversed(assistant_parts):
+            if part.get("type") in ("tool_call", "tool-call") and (
+                part.get("toolCallId") == tool_id
+                or part.get("name") == tool_name
+                or (part.get("tool") and part["tool"].get("name") == tool_name)
+            ):
+                part["state"] = "completed"
+                if "output" in payload:
+                    part["output"] = payload["output"]
+                if "tool" in part and isinstance(part["tool"], dict):
+                    part["tool"]["state"] = "completed"
+                    part["tool"]["output"] = payload.get("output")
+                return
+
+    tool_item: dict[str, Any] = {
+        "id": tool_id,
+        "name": tool_name,
         "state": "running" if event_name == "tool_start" else "completed",
     }
     if "input" in payload:
-        part["input"] = payload["input"]
+        tool_item["input"] = payload["input"]
     if "output" in payload:
-        part["output"] = payload["output"]
-    assistant_parts.append(part)
+        tool_item["output"] = payload["output"]
+
+    assistant_parts.append(
+        {
+            "type": "tool-call",
+            "toolCallId": tool_id,
+            "name": tool_name,
+            "state": tool_item["state"],
+            "tool": tool_item,
+        }
+    )
 
 
 def _handle_draft_part(
-    payload: dict[str, Any], assistant_parts: list[dict[str, Any]]
+    *, payload: dict[str, Any], assistant_parts: list[dict[str, Any]]
 ) -> None:
+    content = str(payload.get("content", ""))
+    post_id = str(payload.get("post_id", ""))
+    platform = str(payload.get("platform", "x"))
+    status = str(payload.get("status", "draft"))
+
     assistant_parts.append(
         {
             "type": "draft_artifact",
-            "post_id": payload.get("post_id"),
-            "content": payload.get("content"),
-            "platform": payload.get("platform"),
+            "artifact": {
+                "id": post_id,
+                "postId": post_id,
+                "content": content,
+                "platform": platform,
+                "characterCount": payload.get("char_count") or len(content),
+                "status": status,
+            },
+            "post_id": post_id,
+            "content": content,
+            "platform": platform,
+        }
+    )
+
+
+def _handle_trending_part(
+    *, payload: dict[str, Any], assistant_parts: list[dict[str, Any]]
+) -> None:
+    topics = payload.get("topics", [])
+    assistant_parts.append(
+        {
+            "type": "trending_artifact",
+            "artifact": {
+                "topics": topics,
+                "count": payload.get("count", len(topics)),
+            },
         }
     )
 
@@ -110,9 +168,15 @@ def _collect_stream_part(
     if event_name == "thought":
         _handle_thought_part(payload, assistant_parts)
     elif event_name in {"tool_start", "tool_output"}:
-        _handle_tool_part(event_name, payload, assistant_parts)
+        _handle_tool_part(
+            event_name=event_name,
+            payload=payload,
+            assistant_parts=assistant_parts,
+        )
     elif event_name == "draft_artifact":
-        _handle_draft_part(payload, assistant_parts)
+        _handle_draft_part(payload=payload, assistant_parts=assistant_parts)
+    elif event_name == "trending_artifact":
+        _handle_trending_part(payload=payload, assistant_parts=assistant_parts)
     return ""
 
 
@@ -162,14 +226,14 @@ def _build_fallback_models(default_model_id: str) -> list[AIModelInfo]:
     return result
 
 
-def _is_allowed_proxy_model(item: dict[str, Any]) -> bool:
+def _is_allowed_proxy_model(item: dict[str, Any], default_model_id: str) -> bool:
     raw_id = item.get("id")
     if not raw_id:
         return False
     model_id = str(raw_id)
+    if model_id == default_model_id:
+        return True
     if model_id in EXCLUDED_MODELS:
-        return False
-    if model_id.lower().startswith("gemini"):
         return False
     return str(item.get("owned_by", "")).lower() != "antigravity"
 
@@ -194,18 +258,37 @@ def _fetch_models_from_proxy(default_model_id: str) -> list[AIModelInfo]:
                 is_default=(str(item["id"]) == default_model_id),
             )
             for item in items
-            if _is_allowed_proxy_model(item)
+            if _is_allowed_proxy_model(item, default_model_id)
         ]
+
+
+def _ensure_default_model(
+    models: list[AIModelInfo], default_model_id: str
+) -> list[AIModelInfo]:
+    if any(m.id == default_model_id for m in models):
+        return models
+    return [
+        AIModelInfo(
+            id=default_model_id,
+            name=FRIENDLY_MODEL_NAMES.get(default_model_id, default_model_id),
+            provider="OpenAI",
+            is_default=True,
+        ),
+        *models,
+    ]
 
 
 @router.get("/models", response_model=AIModelsPublic)
 def list_ai_models() -> Any:
     """List available AI models from the proxy/backend with friendly labels."""
     default_model_id = settings.AI_MODEL.removeprefix("openai/")
+    if default_model_id.startswith("gemini"):
+        default_model_id = "gpt-5.4"
     try:
         models = _fetch_models_from_proxy(default_model_id)
         if models:
-            return AIModelsPublic(data=models, default_model=default_model_id)
+            resolved = _ensure_default_model(models, default_model_id)
+            return AIModelsPublic(data=resolved, default_model=default_model_id)
     except Exception:
         pass
     fallback = _build_fallback_models(default_model_id)
@@ -338,21 +421,9 @@ async def _save_assistant_turn(
             pass
 
 
-VALID_IMAGE_SCHEMES = ("data:image/", "http://", "https://")
-
-
-def _is_valid_image_url(url: Any) -> bool:
-    if not isinstance(url, str):
-        return False
-    trimmed = url.strip()
-    return any(trimmed.startswith(scheme) for scheme in VALID_IMAGE_SCHEMES)
-
-
 def _sanitize_image_urls(images: list[str] | None) -> list[str]:
-    """Filter and sanitize valid image data URLs or HTTP/HTTPS image links."""
-    if not images:
-        return []
-    return [img.strip() for img in images if _is_valid_image_url(img)]
+    """Filter, sanitize, and convert valid image data URLs or HTTP/HTTPS image links."""
+    return _clean_image_urls(images=images)
 
 
 def _build_user_message_dict(
@@ -397,17 +468,26 @@ async def chat_stream(
     )
 
     effective_prompt = message_text or "Analyze the attached image(s)"
+    user_id_str = str(current_user.id)
+    transcript_copy = copy.deepcopy(thread.transcript)
 
     async def event_generator() -> AsyncGenerator[str, None]:
         accumulated_text = ""
         assistant_parts: list[dict[str, Any]] = []
 
+        target_model = body.model
+        if target_model and target_model.startswith("gemini"):
+            target_model = "gpt-5.4"
+
         try:
             async for event_name, payload in default_chat_stream_runner(
                 message=effective_prompt,
-                transcript=thread.transcript,
-                model=body.model,
+                transcript=transcript_copy,
+                model=target_model,
                 images=clean_images or None,
+                user_id=user_id_str,
+                session=session,
+                thread_id=str(thread.id),
             ):
                 delta = _collect_stream_part(
                     event_name=event_name,
@@ -415,6 +495,19 @@ async def chat_stream(
                     assistant_parts=assistant_parts,
                 )
                 accumulated_text += delta
+                if event_name == "draft_artifact" and isinstance(payload, dict):
+                    post_id_val = (
+                        payload.get("post_id")
+                        or payload.get("postId")
+                        or payload.get("id")
+                    )
+                    if post_id_val:
+                        try:
+                            thread.post_id = uuid.UUID(str(post_id_val))
+                            session.add(thread)
+                            session.commit()
+                        except Exception:
+                            pass
                 yield format_sse(event=event_name, data=payload)
 
             await _save_assistant_turn(

--- a/backend/app/api/routes/ai_threads.py
+++ b/backend/app/api/routes/ai_threads.py
@@ -70,6 +70,39 @@ def _handle_thought_part(
         assistant_parts.append({"type": "thought", "content": thought_content})
 
 
+def _is_matching_tool_part(
+    *, part: dict[str, Any], tool_id: str, tool_name: str
+) -> bool:
+    """Check if a transcript part matches the target tool call."""
+    if part.get("type") not in ("tool_call", "tool-call"):
+        return False
+    if part.get("toolCallId") == tool_id or part.get("name") == tool_name:
+        return True
+    tool_data = part.get("tool")
+    return isinstance(tool_data, dict) and tool_data.get("name") == tool_name
+
+
+def _update_existing_tool_part(
+    *,
+    assistant_parts: list[dict[str, Any]],
+    tool_id: str,
+    tool_name: str,
+    output: Any,
+) -> bool:
+    """Update state and output on an existing tool part if found."""
+    for part in reversed(assistant_parts):
+        if _is_matching_tool_part(part=part, tool_id=tool_id, tool_name=tool_name):
+            part["state"] = "completed"
+            if output is not None:
+                part["output"] = output
+            tool_data = part.get("tool")
+            if isinstance(tool_data, dict):
+                tool_data["state"] = "completed"
+                tool_data["output"] = output
+            return True
+    return False
+
+
 def _handle_tool_part(
     *,
     event_name: str,
@@ -78,21 +111,17 @@ def _handle_tool_part(
 ) -> None:
     tool_id = str(payload.get("id") or f"call_{uuid.uuid4().hex[:8]}")
     tool_name = str(payload.get("name") or "tool")
+    output = payload.get("output")
 
     if event_name == "tool_output":
-        for part in reversed(assistant_parts):
-            if part.get("type") in ("tool_call", "tool-call") and (
-                part.get("toolCallId") == tool_id
-                or part.get("name") == tool_name
-                or (part.get("tool") and part["tool"].get("name") == tool_name)
-            ):
-                part["state"] = "completed"
-                if "output" in payload:
-                    part["output"] = payload["output"]
-                if "tool" in part and isinstance(part["tool"], dict):
-                    part["tool"]["state"] = "completed"
-                    part["tool"]["output"] = payload.get("output")
-                return
+        updated = _update_existing_tool_part(
+            assistant_parts=assistant_parts,
+            tool_id=tool_id,
+            tool_name=tool_name,
+            output=output,
+        )
+        if updated:
+            return
 
     tool_item: dict[str, Any] = {
         "id": tool_id,
@@ -101,8 +130,8 @@ def _handle_tool_part(
     }
     if "input" in payload:
         tool_item["input"] = payload["input"]
-    if "output" in payload:
-        tool_item["output"] = payload["output"]
+    if output is not None:
+        tool_item["output"] = output
 
     assistant_parts.append(
         {
@@ -165,18 +194,29 @@ def _collect_stream_part(
     """Append structured message parts and return text delta if present."""
     if event_name == "text_delta":
         return str(payload.get("content", ""))
-    if event_name == "thought":
-        _handle_thought_part(payload, assistant_parts)
-    elif event_name in {"tool_start", "tool_output"}:
-        _handle_tool_part(
+
+    part_dispatch = {
+        "thought": lambda: _handle_thought_part(payload, assistant_parts),
+        "tool_start": lambda: _handle_tool_part(
             event_name=event_name,
             payload=payload,
             assistant_parts=assistant_parts,
-        )
-    elif event_name == "draft_artifact":
-        _handle_draft_part(payload=payload, assistant_parts=assistant_parts)
-    elif event_name == "trending_artifact":
-        _handle_trending_part(payload=payload, assistant_parts=assistant_parts)
+        ),
+        "tool_output": lambda: _handle_tool_part(
+            event_name=event_name,
+            payload=payload,
+            assistant_parts=assistant_parts,
+        ),
+        "draft_artifact": lambda: _handle_draft_part(
+            payload=payload, assistant_parts=assistant_parts
+        ),
+        "trending_artifact": lambda: _handle_trending_part(
+            payload=payload, assistant_parts=assistant_parts
+        ),
+    }
+    action = part_dispatch.get(event_name)
+    if action:
+        action()
     return ""
 
 
@@ -198,32 +238,24 @@ EXCLUDED_MODELS = {
 
 
 def _build_fallback_models(default_model_id: str) -> list[AIModelInfo]:
-    known_candidates: list[tuple[str, str, str]] = [
-        (
-            default_model_id,
-            FRIENDLY_MODEL_NAMES.get(default_model_id, default_model_id),
-            "OpenAI",
-        ),
-        ("gpt-5.4", "5.4", "OpenAI"),
-        ("gpt-5.4-mini", "5.4 Mini", "OpenAI"),
-        ("gpt-5.5", "5.5", "OpenAI"),
-        ("gpt-5.6-sol", "5.6 Sol", "OpenAI"),
-        ("gpt-5.6-terra", "5.6 Terra", "OpenAI"),
+    ids = [
+        default_model_id,
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.5",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
     ]
-    seen: set[str] = set()
-    result: list[AIModelInfo] = []
-    for mid, name, provider in known_candidates:
-        if mid and mid not in seen:
-            seen.add(mid)
-            result.append(
-                AIModelInfo(
-                    id=mid,
-                    name=name,
-                    provider=provider,
-                    is_default=(mid == default_model_id),
-                )
-            )
-    return result
+    unique_ids = dict.fromkeys(m for m in ids if m)
+    return [
+        AIModelInfo(
+            id=mid,
+            name=FRIENDLY_MODEL_NAMES.get(mid, mid),
+            provider="OpenAI",
+            is_default=(mid == default_model_id),
+        )
+        for mid in unique_ids
+    ]
 
 
 def _is_allowed_proxy_model(item: dict[str, Any], default_model_id: str) -> bool:
@@ -443,6 +475,83 @@ def _build_user_message_dict(
     }
 
 
+def _maybe_link_draft_post(
+    *, thread: ChatThread, session: Session, event_name: str, payload: Any
+) -> None:
+    """Auto-link newly created draft post ID to chat thread."""
+    if event_name != "draft_artifact" or not isinstance(payload, dict):
+        return
+    post_id_val = payload.get("post_id") or payload.get("postId") or payload.get("id")
+    if not post_id_val:
+        return
+    try:
+        thread.post_id = uuid.UUID(str(post_id_val))
+        session.add(thread)
+        session.commit()
+    except Exception:
+        pass
+
+
+class ChatStreamContext(NamedTuple):
+    thread: ChatThread
+    session: Session
+    body: ChatMessageRequest
+    clean_images: list[str]
+    user_id_str: str
+    effective_prompt: str
+
+
+async def _generate_chat_events(
+    *,
+    ctx: ChatStreamContext,
+) -> AsyncGenerator[str, None]:
+    """Execute chat stream and yield formatted SSE events."""
+    accumulated_text = ""
+    assistant_parts: list[dict[str, Any]] = []
+
+    target_model = ctx.body.model
+    if target_model and target_model.startswith("gemini"):
+        target_model = "gpt-5.4"
+
+    transcript_copy = copy.deepcopy(ctx.thread.transcript)
+    try:
+        async for event_name, payload in default_chat_stream_runner(
+            message=ctx.effective_prompt,
+            transcript=transcript_copy,
+            model=target_model,
+            images=ctx.clean_images or None,
+            user_id=ctx.user_id_str,
+            session=ctx.session,
+            thread_id=str(ctx.thread.id),
+        ):
+            delta = _collect_stream_part(
+                event_name=event_name,
+                payload=payload,
+                assistant_parts=assistant_parts,
+            )
+            accumulated_text += delta
+            _maybe_link_draft_post(
+                thread=ctx.thread,
+                session=ctx.session,
+                event_name=event_name,
+                payload=payload,
+            )
+            yield format_sse(event=event_name, data=payload)
+
+        await _save_assistant_turn(
+            session=ctx.session,
+            thread=ctx.thread,
+            payload=AssistantTurnPayload(
+                body=ctx.body,
+                accumulated_text=accumulated_text,
+                assistant_parts=assistant_parts,
+            ),
+        )
+
+    except Exception as exc:
+        yield format_sse(event="error", data={"message": str(exc)})
+
+
 @router.post("/{id}/chat")
 async def chat_stream(
     *,
@@ -468,63 +577,18 @@ async def chat_stream(
     )
 
     effective_prompt = message_text or "Analyze the attached image(s)"
-    user_id_str = str(current_user.id)
-    transcript_copy = copy.deepcopy(thread.transcript)
-
-    async def event_generator() -> AsyncGenerator[str, None]:
-        accumulated_text = ""
-        assistant_parts: list[dict[str, Any]] = []
-
-        target_model = body.model
-        if target_model and target_model.startswith("gemini"):
-            target_model = "gpt-5.4"
-
-        try:
-            async for event_name, payload in default_chat_stream_runner(
-                message=effective_prompt,
-                transcript=transcript_copy,
-                model=target_model,
-                images=clean_images or None,
-                user_id=user_id_str,
-                session=session,
-                thread_id=str(thread.id),
-            ):
-                delta = _collect_stream_part(
-                    event_name=event_name,
-                    payload=payload,
-                    assistant_parts=assistant_parts,
-                )
-                accumulated_text += delta
-                if event_name == "draft_artifact" and isinstance(payload, dict):
-                    post_id_val = (
-                        payload.get("post_id")
-                        or payload.get("postId")
-                        or payload.get("id")
-                    )
-                    if post_id_val:
-                        try:
-                            thread.post_id = uuid.UUID(str(post_id_val))
-                            session.add(thread)
-                            session.commit()
-                        except Exception:
-                            pass
-                yield format_sse(event=event_name, data=payload)
-
-            await _save_assistant_turn(
-                session=session,
-                thread=thread,
-                payload=AssistantTurnPayload(
-                    body=body,
-                    accumulated_text=accumulated_text,
-                    assistant_parts=assistant_parts,
-                ),
-            )
-
-        except Exception as exc:
-            yield format_sse(event="error", data={"message": str(exc)})
+    stream_ctx = ChatStreamContext(
+        thread=thread,
+        session=session,
+        body=body,
+        clean_images=clean_images,
+        user_id_str=str(current_user.id),
+        effective_prompt=effective_prompt,
+    )
+    events = _generate_chat_events(ctx=stream_ctx)
 
     return StreamingResponse(
-        event_generator(),
+        events,
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -120,8 +120,8 @@ class Settings(BaseSettings):
     OPENAI_API_COMPATIBLE_BASE_URL: str = "http://127.0.0.1:8317/v1"
     AI_API_KEY: str | None = None
     AI_API_BASE: str = "http://127.0.0.1:8317/v1"
-    AI_MODEL: str = "openai/gemini-3.6-flash-high"
-    VISION_AI_MODEL: str = "openai/gemini-3-flash"
+    AI_MODEL: str = "openai/gpt-5.6-luna"
+    VISION_AI_MODEL: str = "openai/gpt-5.6-luna"
 
     def _check_default_secret(self, var_name: str, value: str | None) -> None:
         if value == "changethis":

--- a/backend/app/services/agentic/agent_supervisor.py
+++ b/backend/app/services/agentic/agent_supervisor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -17,7 +18,7 @@ from langgraph.prebuilt import create_react_agent
 from sqlmodel import Session, col, select
 
 from app import crud
-from app.models import ChatThread, Post, PostUpdate
+from app.models import ChatThread, Post, PostPublic, PostUpdate
 from app.services.agentic.client import get_chat_model
 from app.services.agentic.tools.context_tools import (
     get_recent_post_history as raw_get_recent_post_history,
@@ -103,39 +104,111 @@ Be helpful, concise, engaging, and decisive. Execute tools autonomously whenever
 """
 
 
-def build_copilot_tools(
-    *,
-    user_id: str,
-    session: Session,
-    thread_id: str | None = None,
-) -> list[BaseTool]:
-    """Construct context-bound tools for the authenticated user and database session."""
+@dataclass(frozen=True)
+class CopilotContext:
+    user_id: str
+    session: Session
+    thread_id: str | None = None
+
+    @property
+    def user_uuid(self) -> uuid.UUID | None:
+        try:
+            return uuid.UUID(self.user_id)
+        except (ValueError, TypeError):
+            return None
+
+
+def _resolve_by_post_id(*, ctx: CopilotContext, post_id: str) -> Post | None:
+    if post_id.strip().lower() in ("none", "null", "undefined"):
+        return None
+    try:
+        p_uuid = uuid.UUID(post_id.strip())
+        post = crud.get_post(session=ctx.session, post_id=p_uuid)
+        if post and post.owner_id == ctx.user_uuid:
+            return post
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
+def _resolve_by_thread_id(*, ctx: CopilotContext) -> Post | None:
+    if not ctx.thread_id:
+        return None
+    try:
+        t_uuid = uuid.UUID(ctx.thread_id)
+        thread = ctx.session.get(ChatThread, t_uuid)
+        if thread and thread.post_id:
+            post = crud.get_post(session=ctx.session, post_id=thread.post_id)
+            if post and post.owner_id == ctx.user_uuid:
+                return post
+    except Exception as exc:
+        logger.debug("Could not load thread post: %s", exc)
+    return None
+
+
+def _resolve_target_post(
+    *, ctx: CopilotContext, post_id: str | None = None
+) -> Post | None:
+    """Resolve target post by explicit ID, linked thread, or latest user draft."""
+    if not ctx.user_uuid:
+        return None
+    if post_id and post_id.strip():
+        resolved = _resolve_by_post_id(ctx=ctx, post_id=post_id)
+        if resolved:
+            return resolved
+
+    thread_post = _resolve_by_thread_id(ctx=ctx)
+    if thread_post:
+        return thread_post
+
+    statement = (
+        select(Post)
+        .where(Post.owner_id == ctx.user_uuid, Post.status == "draft")
+        .order_by(col(Post.updated_at).desc().nulls_last())
+    )
+    post = ctx.session.exec(statement).first()
+    _link_post_to_thread(ctx=ctx, post_id=post.id if post else None)
+    return post
+
+
+def _link_post_to_thread(*, ctx: CopilotContext, post_id: uuid.UUID | None) -> None:
+    if not ctx.thread_id or not post_id:
+        return
+    try:
+        t_uuid = uuid.UUID(ctx.thread_id)
+        thread = ctx.session.get(ChatThread, t_uuid)
+        if thread and thread.post_id != post_id:
+            thread.post_id = post_id
+            ctx.session.add(thread)
+            ctx.session.commit()
+    except Exception as exc:
+        logger.debug("Could not link post to thread: %s", exc)
+
+
+def _build_trend_tools(ctx: CopilotContext) -> list[BaseTool]:
+    """Build trending topic inspection tools."""
 
     @tool
     def get_latest_scraped_trends(limit: int = 10) -> dict[str, Any]:
-        """Query the most recent trending topics currently stored in the LinkX database.
-        Returns a dictionary with 'has_today_trends', 'latest_scrape_date', 'today_date', and 'topics'.
-        If 'has_today_trends' is False or 'topics' is empty, call scrape_live_explore_trends to get fresh trends for today.
-        """
+        """Query recent trending topics from LinkX database."""
         try:
-            user_uuid = uuid.UUID(user_id)
+            assert ctx.user_uuid is not None
             topics = crud.get_latest_trending_topics(
-                session=session, user_id=user_uuid, limit=limit
+                session=ctx.session, user_id=ctx.user_uuid, limit=limit
             )
             today_utc = datetime.now(timezone.utc).date()
-            has_today_trends = False
-            latest_date_str = None
-
+            has_today = False
+            latest_str = None
             if topics:
                 latest_dt = topics[0].last_seen_at or topics[0].created_at
                 if latest_dt:
-                    latest_date = (
+                    dt_val = (
                         latest_dt.date() if hasattr(latest_dt, "date") else latest_dt
                     )
-                    latest_date_str = latest_date.isoformat()
-                    has_today_trends = latest_date >= today_utc
+                    latest_str = dt_val.isoformat()
+                    has_today = dt_val >= today_utc
 
-            topic_items = [
+            items = [
                 {
                     "id": str(t.id),
                     "topic_title": t.topic_title,
@@ -150,14 +223,14 @@ def build_copilot_tools(
                 for t in topics
             ]
             return {
-                "has_today_trends": has_today_trends,
-                "latest_scrape_date": latest_date_str,
+                "has_today_trends": has_today,
+                "latest_scrape_date": latest_str,
                 "today_date": today_utc.isoformat(),
-                "count": len(topic_items),
-                "topics": topic_items,
+                "count": len(items),
+                "topics": items,
             }
         except Exception as e:
-            logger.error(f"Error in get_latest_scraped_trends tool: {e}")
+            logger.error("Error in get_latest_scraped_trends: %s", e)
             return {
                 "has_today_trends": False,
                 "latest_scrape_date": None,
@@ -170,39 +243,48 @@ def build_copilot_tools(
     def get_topic_tweets_and_summary(
         topic_id: str, max_tweets: int = 5
     ) -> dict[str, Any] | None:
-        """Retrieve deep topic context, Grok summary, and sample tweets for a specific topic ID from the database."""
+        """Retrieve topic tweets and Grok summary for a topic ID."""
         res = raw_get_topic_tweets_and_summary(
-            topic_id=topic_id, max_tweets=max_tweets, session=session
+            topic_id=topic_id, max_tweets=max_tweets, session=ctx.session
         )
         return res.model_dump() if res else None
 
+    return [get_latest_scraped_trends, get_topic_tweets_and_summary]
+
+
+def _build_context_tools(ctx: CopilotContext) -> list[BaseTool]:
+    """Build context and account status tools."""
+
     @tool
     def get_recent_post_history(limit: int = 5) -> list[dict[str, Any]]:
-        """Retrieve the user's recently published posts to analyze their writing style, voice, and formatting."""
+        """Retrieve the user's recently published posts."""
         posts = raw_get_recent_post_history(
-            user_id=user_id, limit=limit, session=session
+            user_id=ctx.user_id, limit=limit, session=ctx.session
         )
         return [p.model_dump() for p in posts]
 
     @tool
     def get_social_account_status() -> dict[str, Any]:
-        """Check whether the user's X.com (Twitter) and LinkedIn accounts are connected and authenticated."""
-        res = raw_get_social_account_status(user_id=user_id, session=session)
+        """Check user's X.com and LinkedIn account connection status."""
+        res = raw_get_social_account_status(user_id=ctx.user_id, session=ctx.session)
         return res.model_dump()
+
+    return [get_recent_post_history, get_social_account_status]
+
+
+def _build_scraping_tools(ctx: CopilotContext) -> list[BaseTool]:
+    """Build live web perception tools."""
 
     @tool
     async def scrape_live_explore_trends(max_topics: int = 3) -> dict[str, Any]:
-        """Launch live browser automation (Playwright) to scrape fresh trending topics directly from X.com Explore.
-        Use this tool when the database has no trends, when trends are outdated, or when the user explicitly asks to refresh/scrape trends from X.
-        """
+        """Scrape fresh trending topics directly from X.com Explore."""
         raw_result = await raw_scrape_live_explore_trends(
-            user_id=user_id, max_topics=max_topics, headless=True
+            user_id=ctx.user_id, max_topics=max_topics, headless=True
         )
-        # Fetch newly persisted topics
         try:
-            user_uuid = uuid.UUID(user_id)
-            fresh_topics = crud.get_latest_trending_topics(
-                session=session, user_id=user_uuid, limit=max_topics
+            assert ctx.user_uuid is not None
+            fresh = crud.get_latest_trending_topics(
+                session=ctx.session, user_id=ctx.user_uuid, limit=max_topics
             )
             raw_result["topics"] = [
                 {
@@ -213,104 +295,70 @@ def build_copilot_tools(
                     "summary": t.summary,
                     "topic_url": t.topic_url,
                 }
-                for t in fresh_topics
+                for t in fresh
             ]
         except Exception as e:
-            logger.debug(f"Could not load fresh topics for tool response: {e}")
+            logger.debug("Could not load fresh topics: %s", e)
             raw_result["topics"] = []
-
         return raw_result
 
     @tool
     async def scrape_topic_timeline(
         topic_url: str, max_tweets: int = 5
     ) -> dict[str, Any]:
-        """Navigate a browser directly to a specific topic URL on live X to scrape its latest timeline tweets and Grok summary."""
+        """Scrape topic timeline tweets and summary from live X."""
         return await raw_scrape_topic_timeline(
-            topic_url=topic_url, user_id=user_id, max_tweets=max_tweets
+            topic_url=topic_url, user_id=ctx.user_id, max_tweets=max_tweets
         )
+
+    return [scrape_live_explore_trends, scrape_topic_timeline]
+
+
+def _build_curation_tools() -> list[BaseTool]:
+    """Build content generation and validation tools."""
 
     @tool
     async def draft_social_post(
         prompt: str, platform: str = "linkx", topic_context: str | None = None
     ) -> dict[str, Any]:
-        """Generate high-engagement social media post copy based on a prompt or trending topic."""
+        """Generate high-engagement social media post copy."""
         text = await raw_draft_social_post(
             topic_title=prompt, topic_summary=topic_context, platform=platform
         )
-        return {
-            "content": text,
-            "platform": platform,
-            "char_count": len(text),
-        }
+        return {"content": text, "platform": platform, "char_count": len(text)}
 
     @tool
     def validate_post_constraints(content: str, platform: str = "x") -> dict[str, Any]:
-        """Validate character limits (280 for X, 3000 for LinkedIn) and formatting compliance for a post."""
+        """Validate character limits and formatting compliance."""
         res = raw_validate_post_constraints(content=content, platform=platform)
         return res.model_dump()
 
-    def _resolve_target_post(*, post_id: str | None = None) -> Post | None:
-        """Resolve the target post either by explicit ID, linked thread post, or latest draft."""
-        user_uuid: uuid.UUID | None = None
-        try:
-            user_uuid = uuid.UUID(user_id)
-        except (ValueError, TypeError):
-            return None
+    return [draft_social_post, validate_post_constraints]
 
-        # 1. If explicit post_id is supplied and valid
-        if (
-            post_id
-            and post_id.strip()
-            and post_id.strip().lower() not in ("none", "null", "undefined")
-        ):
-            try:
-                p_uuid = uuid.UUID(post_id.strip())
-                post = crud.get_post(session=session, post_id=p_uuid)
-                if post and post.owner_id == user_uuid:
-                    return post
-            except (ValueError, TypeError):
-                pass
 
-        # 2. If thread_id is available, check if the thread has a linked post
-        if thread_id:
-            try:
-                t_uuid = uuid.UUID(thread_id)
-                thread = session.get(ChatThread, t_uuid)
-                if thread and thread.post_id:
-                    post = crud.get_post(session=session, post_id=thread.post_id)
-                    if post and post.owner_id == user_uuid:
-                        return post
-            except Exception as exc:
-                logger.debug(f"Could not load thread post: {exc}")
+def _format_post_card(
+    *, post: Post | PostPublic, updated: bool = False
+) -> dict[str, Any]:
+    """Format standard post dictionary for chat UI rendering."""
+    return {
+        "post_id": str(post.id),
+        "id": str(post.id),
+        "postId": str(post.id),
+        "content": post.content,
+        "platform": post.platform,
+        "status": post.status,
+        "char_count": len(post.content),
+        "updated": updated,
+        "ui_rendered": True,
+        "instruction": "The post is rendered as an interactive component in chat. Do NOT repeat or output post content in your text reply.",
+    }
 
-        # 3. Fallback: query the user's most recent draft post
-        statement = (
-            select(Post)
-            .where(Post.owner_id == user_uuid, Post.status == "draft")
-            .order_by(col(Post.updated_at).desc().nulls_last())
-        )
-        post = session.exec(statement).first()
-        if post and thread_id:
-            try:
-                t_uuid = uuid.UUID(thread_id)
-                thread = session.get(ChatThread, t_uuid)
-                if thread and not thread.post_id:
-                    thread.post_id = post.id
-                    session.add(thread)
-                    session.commit()
-            except Exception as exc:
-                logger.debug(f"Could not link post to thread: {exc}")
-        return post
 
+def _build_get_latest_draft_tool(ctx: CopilotContext) -> BaseTool:
     @tool
     def get_latest_draft_post() -> dict[str, Any]:
-        """Retrieve the current active draft post being discussed or iterated on.
-        Call this tool when the user refers to the draft ('the post', 'my draft', 'the tweet')
-        or gives feedback, critique, or instructions on revising the current draft.
-        Returns the post details (post_id, content, platform, status, char_count, updated_at).
-        """
-        post = _resolve_target_post()
+        """Retrieve the current active draft post."""
+        post = _resolve_target_post(ctx=ctx)
         if not post:
             return {"message": "No active draft post found for this conversation."}
         return {
@@ -324,142 +372,80 @@ def build_copilot_tools(
             "updated_at": post.updated_at.isoformat() if post.updated_at else None,
         }
 
+    return get_latest_draft_post
+
+
+def _build_save_draft_tool(ctx: CopilotContext) -> BaseTool:
     @tool
     def save_draft_post(content: str, platform: str = "x") -> dict[str, Any]:
-        """Persist a BRAND NEW post draft to PostgreSQL ONLY when the user asks to start a new post from scratch.
-        CRITICAL: DO NOT use this tool if the user is asking to modify, shorten, lengthen, rephrase, critique, or update an existing post. For ANY modifications to an existing draft, you MUST use update_draft_post instead.
-        Calling this tool automatically renders the native interactive post component in the chat interface.
-        IMPORTANT: In your final assistant response, DO NOT repeat, quote, or re-paste the post content. The component already renders it. Simply state that the draft has been created or provide a brief 1-sentence strategic note.
-        """
+        """Persist a BRAND NEW post draft to PostgreSQL."""
         post = raw_save_draft_post(
-            user_id=user_id, content=content, platform=platform, session=session
+            user_id=ctx.user_id,
+            content=content,
+            platform=platform,
+            session=ctx.session,
         )
         if not post:
             return {"error": "Failed to save post draft to database"}
+        _link_post_to_thread(ctx=ctx, post_id=post.id)
+        return _format_post_card(post=post)
 
-        if thread_id:
-            try:
-                t_uuid = uuid.UUID(thread_id)
-                thread = session.get(ChatThread, t_uuid)
-                if thread:
-                    thread.post_id = post.id
-                    session.add(thread)
-                    session.commit()
-            except Exception as exc:
-                logger.debug(f"Failed to link post to thread: {exc}")
+    return save_draft_post
 
-        return {
-            "post_id": str(post.id),
-            "id": str(post.id),
-            "postId": str(post.id),
-            "content": post.content,
-            "platform": post.platform,
-            "status": post.status,
-            "char_count": len(post.content),
-            "ui_rendered": True,
-            "instruction": "The post is now rendered as an interactive post component in the chat. Do NOT repeat or output the post content in your text reply.",
-        }
 
+def _build_update_draft_tool(ctx: CopilotContext) -> BaseTool:
     @tool
     def update_draft_post(
         refined_content: str, post_id: str | None = None
     ) -> dict[str, Any]:
-        """Update an existing draft post in PostgreSQL with refined content.
-        ALWAYS call this tool when the user gives feedback on a post, asks for changes, tone adjustments,
-        shortening, lengthening, adding/removing emojis or hashtags, or comments on the draft.
-        DO NOT call save_draft_post for revisions—use this tool so the same post is edited in-place.
-        If post_id is omitted or not known, it automatically targets the active draft in this thread.
-        IMPORTANT: In your final assistant response, DO NOT repeat or re-paste the post content.
-        The UI component will update and display it automatically. Keep your reply to 1 concise sentence.
-        """
-        target_post = _resolve_target_post(post_id=post_id)
-        if not target_post:
+        """Update an existing draft post in PostgreSQL with refined content."""
+        target = _resolve_target_post(ctx=ctx, post_id=post_id)
+        if not target:
             created = raw_save_draft_post(
-                user_id=user_id,
+                user_id=ctx.user_id,
                 content=refined_content,
                 platform="x",
-                session=session,
+                session=ctx.session,
             )
             if not created:
                 return {"error": "Failed to update or create draft post"}
-            if thread_id:
-                try:
-                    t_uuid = uuid.UUID(thread_id)
-                    thread = session.get(ChatThread, t_uuid)
-                    if thread:
-                        thread.post_id = created.id
-                        session.add(thread)
-                        session.commit()
-                except Exception as exc:
-                    logger.debug(f"Could not link post to thread: {exc}")
-            return {
-                "post_id": str(created.id),
-                "id": str(created.id),
-                "postId": str(created.id),
-                "content": created.content,
-                "platform": created.platform,
-                "status": created.status,
-                "char_count": len(created.content),
-                "updated": True,
-                "ui_rendered": True,
-                "instruction": "The post has been created/updated as an interactive component in the chat. Do NOT repeat or output the post content in your text reply.",
-            }
+            _link_post_to_thread(ctx=ctx, post_id=created.id)
+            return _format_post_card(post=created, updated=True)
 
         post = raw_update_post_in_db(
-            post_id=str(target_post.id),
-            user_id=user_id,
+            post_id=str(target.id),
+            user_id=ctx.user_id,
             content=refined_content,
-            session=session,
+            session=ctx.session,
         )
         if not post:
-            return {"error": f"Failed to update post with ID {target_post.id}"}
+            return {"error": f"Failed to update post with ID {target.id}"}
+        _link_post_to_thread(ctx=ctx, post_id=post.id)
+        return _format_post_card(post=post, updated=True)
 
-        if thread_id:
-            try:
-                t_uuid = uuid.UUID(thread_id)
-                thread = session.get(ChatThread, t_uuid)
-                if thread and thread.post_id != post.id:
-                    thread.post_id = post.id
-                    session.add(thread)
-                    session.commit()
-            except Exception as exc:
-                logger.debug(f"Could not link updated post to thread: {exc}")
+    return update_draft_post
 
-        return {
-            "post_id": str(post.id),
-            "id": str(post.id),
-            "postId": str(post.id),
-            "content": post.content,
-            "platform": post.platform,
-            "status": post.status,
-            "char_count": len(post.content),
-            "updated": True,
-            "ui_rendered": True,
-            "instruction": "The updated post is now rendered as an interactive post component in the chat. Do NOT repeat or output the post content in your text reply.",
-        }
 
+def _build_schedule_draft_tool(ctx: CopilotContext) -> BaseTool:
     @tool
     def schedule_post_in_db(
         scheduled_at_iso: str, post_id: str | None = None
     ) -> dict[str, Any]:
-        """Schedule an existing draft post for future publication at the specified ISO timestamp."""
+        """Schedule an existing draft post for future publication."""
         try:
-            target_post = _resolve_target_post(post_id=post_id)
-            if not target_post:
+            target = _resolve_target_post(ctx=ctx, post_id=post_id)
+            if not target:
                 return {"error": "No post found to schedule"}
-
             scheduled_dt = datetime.fromisoformat(scheduled_at_iso)
             if scheduled_dt.tzinfo is None:
                 scheduled_dt = scheduled_dt.replace(tzinfo=timezone.utc)
-
             post_in = PostUpdate(status="scheduled", scheduled_at=scheduled_dt)
             updated = crud.update_post(
-                session=session, db_post=target_post, post_in=post_in
+                session=ctx.session, db_post=target, post_in=post_in
             )
             return {
                 "post_id": str(updated.id),
                 "id": str(updated.id),
-                "postId": str(updated.id),
                 "status": updated.status,
                 "scheduled_at": updated.scheduled_at.isoformat()
                 if updated.scheduled_at
@@ -468,20 +454,55 @@ def build_copilot_tools(
         except Exception as e:
             return {"error": f"Failed to schedule post: {e}"}
 
+    return schedule_post_in_db
+
+
+def _build_draft_tools(ctx: CopilotContext) -> list[BaseTool]:
+    """Build post creation, updating, and scheduling tools."""
     return [
-        get_latest_scraped_trends,
-        get_topic_tweets_and_summary,
-        get_recent_post_history,
-        get_social_account_status,
-        scrape_live_explore_trends,
-        scrape_topic_timeline,
-        draft_social_post,
-        validate_post_constraints,
-        get_latest_draft_post,
-        save_draft_post,
-        update_draft_post,
-        schedule_post_in_db,
+        _build_get_latest_draft_tool(ctx),
+        _build_save_draft_tool(ctx),
+        _build_update_draft_tool(ctx),
+        _build_schedule_draft_tool(ctx),
     ]
+
+
+def build_copilot_tools(
+    *,
+    user_id: str,
+    session: Session,
+    thread_id: str | None = None,
+) -> list[BaseTool]:
+    """Construct context-bound tools for the authenticated user and database session."""
+    ctx = CopilotContext(user_id=user_id, session=session, thread_id=thread_id)
+    return [
+        *_build_trend_tools(ctx),
+        *_build_context_tools(ctx),
+        *_build_scraping_tools(ctx),
+        *_build_curation_tools(),
+        *_build_draft_tools(ctx),
+    ]
+
+
+def _build_active_draft_prompt(
+    *, user_id: str, session: Session, thread_id: str | None
+) -> str:
+    """Extract context prompt for active draft post."""
+    try:
+        ctx = CopilotContext(user_id=user_id, session=session, thread_id=thread_id)
+        target = _resolve_target_post(ctx=ctx)
+        if not target:
+            return ""
+        return (
+            f"\n\n### ACTIVE DRAFT IN THIS CONVERSATION:\n"
+            f"- Post ID: {target.id}\n"
+            f"- Platform: {target.platform}\n"
+            f"- Current Content:\n```\n{target.content}\n```\n"
+            f'When user refers to draft/post, call update_draft_post(post_id="{target.id}").'
+        )
+    except Exception as exc:
+        logger.debug("Could not inject draft prompt: %s", exc)
+        return ""
 
 
 def build_copilot_agent(
@@ -498,39 +519,9 @@ def build_copilot_agent(
         session=session,
         thread_id=thread_id,
     )
-    prompt_text = COPILOT_AGENT_SYSTEM_PROMPT
-
-    # Dynamically inject active draft context if available for this thread/user
-    try:
-        user_uuid = uuid.UUID(user_id)
-        target_post: Post | None = None
-        if thread_id:
-            try:
-                t_uuid = uuid.UUID(thread_id)
-                thread = session.get(ChatThread, t_uuid)
-                if thread and thread.post_id:
-                    target_post = crud.get_post(session=session, post_id=thread.post_id)
-            except Exception:
-                pass
-        if not target_post:
-            statement = (
-                select(Post)
-                .where(Post.owner_id == user_uuid, Post.status == "draft")
-                .order_by(col(Post.updated_at).desc().nulls_last())
-            )
-            target_post = session.exec(statement).first()
-
-        if target_post:
-            prompt_text += (
-                f"\n\n### ACTIVE DRAFT IN THIS CONVERSATION:\n"
-                f"- Post ID: {target_post.id}\n"
-                f"- Platform: {target_post.platform}\n"
-                f"- Current Content:\n```\n{target_post.content}\n```\n"
-                f"When the user references 'this post', 'the draft', asks for revisions, or says 'make this more controversial', "
-                f'this is the draft to modify. NEVER ask the user for the draft text or ID. Directly call update_draft_post(post_id="{target_post.id}", refined_content=...)!'
-            )
-    except Exception as exc:
-        logger.debug(f"Could not inject active post context into agent: {exc}")
+    prompt_text = COPILOT_AGENT_SYSTEM_PROMPT + _build_active_draft_prompt(
+        user_id=user_id, session=session, thread_id=thread_id
+    )
 
     return create_react_agent(
         model=chat_model,

--- a/backend/app/services/agentic/agent_supervisor.py
+++ b/backend/app/services/agentic/agent_supervisor.py
@@ -1,0 +1,539 @@
+"""LangGraph Copilot Agent Supervisor with multi-tool capabilities.
+
+Equips the LinkX Copilot assistant with the full agentic tool suite:
+database queries, live Playwright scraping, LLM post curation, and PostgreSQL persistence.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from langchain_core.messages import SystemMessage
+from langchain_core.tools import BaseTool, tool
+from langgraph.prebuilt import create_react_agent
+from sqlmodel import Session, col, select
+
+from app import crud
+from app.models import ChatThread, Post, PostUpdate
+from app.services.agentic.client import get_chat_model
+from app.services.agentic.tools.context_tools import (
+    get_recent_post_history as raw_get_recent_post_history,
+)
+from app.services.agentic.tools.context_tools import (
+    get_social_account_status as raw_get_social_account_status,
+)
+from app.services.agentic.tools.context_tools import (
+    get_topic_tweets_and_summary as raw_get_topic_tweets_and_summary,
+)
+from app.services.agentic.tools.curation_tools import (
+    draft_social_post as raw_draft_social_post,
+)
+from app.services.agentic.tools.curation_tools import (
+    validate_post_constraints as raw_validate_post_constraints,
+)
+from app.services.agentic.tools.perception_tools import (
+    scrape_live_explore_trends as raw_scrape_live_explore_trends,
+)
+from app.services.agentic.tools.perception_tools import (
+    scrape_topic_timeline as raw_scrape_topic_timeline,
+)
+from app.services.agentic.tools.persistence_tools import (
+    save_draft_post as raw_save_draft_post,
+)
+from app.services.agentic.tools.persistence_tools import (
+    update_post_in_db as raw_update_post_in_db,
+)
+
+logger = logging.getLogger(__name__)
+
+COPILOT_AGENT_SYSTEM_PROMPT = """You are LinkX Copilot, the intelligent social media growth and automation assistant for X (formerly Twitter) and LinkedIn.
+
+You have access to a rich set of autonomous tools to query database state, scrape live explore feeds, curate social content, validate platform rules, and manage draft posts.
+
+### CRITICAL RULE 1: IN-PLACE DRAFT EDITING VS CREATING NEW DRAFTS
+- If the user says ANYTHING about a post—including asking for changes, edits, tone tweaks ("make it more controversial", "punchier", "funnier"), rewrites, shortening, lengthening, adding/removing hashtags or emojis, giving feedback, or critiquing a post:
+  **YOU MUST ALWAYS CALL `update_draft_post` TO EDIT THE SAME DRAFT IN-PLACE.**
+  **DO NOT CALL `save_draft_post` WHEN REVISING OR DISCUSSING AN EXISTING POST.**
+  Calling `save_draft_post` creates a duplicate post with a new ID, which clutters the database and confuses the user.
+- **NEVER ASK THE USER FOR THE POST TEXT OR POST ID**:
+  The draft content and ID are ALREADY in your conversation history and system context. Never reply with "Please paste the post text or share the draft/post ID".
+  Immediately rewrite the draft and call `update_draft_post`.
+- If you call `update_draft_post`, you do NOT need to specify `post_id` if you don't have it; it will automatically resolve and update the active draft post in this thread.
+- ONLY call `save_draft_post` when the user explicitly requests a BRAND NEW post on an entirely new topic from scratch, and is NOT discussing, modifying, or iterating on an existing draft.
+
+### CRITICAL RULE 2: NO POST CONTENT REPETITION IN CHAT
+When you call `save_draft_post` or `update_draft_post`, the UI automatically displays the post as a native interactive post component in the chat feed.
+The process of using the component tool to show the output post is completely sufficient.
+NEVER duplicate, quote, or re-paste the post text in your conversational response.
+Your final text response should ONLY be a brief 1-sentence note (e.g. "I've updated the draft above to be punchier.") or you may leave the text response minimal.
+DO NOT write "Here is the post:", DO NOT paste the post paragraphs, and DO NOT repeat what the post component already displays.
+
+### Core Autonomous Guidelines:
+1. **Trending Topics Inquiries ("What is trending?", "Show me trends")**:
+   - First, call `get_latest_scraped_trends` to check the database.
+   - Inspect `has_today_trends` and `latest_scrape_date` in the result:
+     - If `has_today_trends` is `False` (meaning the database has NO entries from today, or entries are from past days):
+       You MUST IMMEDIATELY call `scrape_live_explore_trends` to scrape fresh real-time trends from X.com Explore!
+     - If `scrape_live_explore_trends` succeeds, present the newly scraped trends to the user.
+     - If `scrape_live_explore_trends` encounters a browser or session error, fallback to presenting the cached topics from the database while noting to the user that they are from `latest_scrape_date`.
+     - If `has_today_trends` is `True`, present today's trending topics directly.
+   - Present the topics directly in your conversational markdown text as a clean, structured list (numbered, with topic title, category, post count/volume, and brief context).
+   - DO NOT rely on or use UI widgets/artifacts for trending topics—always provide the trends directly in your text response.
+
+2. **Drafting a Brand New Post from Scratch ("Draft a new post about...", "Write a tweet on...")**:
+   - Only for brand new topics where no draft is currently being discussed.
+   - If writing about a trending topic, you can fetch its details via `get_topic_tweets_and_summary`.
+   - Call `draft_social_post` or craft high-impact post copy following viral hooks and concise formatting.
+   - Call `validate_post_constraints` to ensure character limits (280 for X, 3000 for LinkedIn).
+   - Always call `save_draft_post` with the crafted content and target platform. This automatically saves the post to PostgreSQL and displays it directly as a native interactive post component in the chat interface.
+   - REMINDER: The component tool is entirely sufficient to show the post. DO NOT repeat the post content in your final text response.
+
+3. **Refining, Iterating, or Reacting to Feedback on a Post ("Make it shorter", "Remove hashtags", "Add 3 bullet points", "Change the hook", "Make it funnier")**:
+   - You can call `get_latest_draft_post` to inspect the current draft if needed.
+   - Call `update_draft_post` with the revised copy and target `post_id` (or omit `post_id` to auto-target the thread's draft).
+   - Summarize the improvement made in 1 concise sentence without repeating the post text.
+
+4. **Account & Diagnostics**:
+   - Use `get_social_account_status` when the user asks about connected accounts.
+
+Be helpful, concise, engaging, and decisive. Execute tools autonomously whenever necessary to provide accurate, live answers.
+"""
+
+
+def build_copilot_tools(
+    *,
+    user_id: str,
+    session: Session,
+    thread_id: str | None = None,
+) -> list[BaseTool]:
+    """Construct context-bound tools for the authenticated user and database session."""
+
+    @tool
+    def get_latest_scraped_trends(limit: int = 10) -> dict[str, Any]:
+        """Query the most recent trending topics currently stored in the LinkX database.
+        Returns a dictionary with 'has_today_trends', 'latest_scrape_date', 'today_date', and 'topics'.
+        If 'has_today_trends' is False or 'topics' is empty, call scrape_live_explore_trends to get fresh trends for today.
+        """
+        try:
+            user_uuid = uuid.UUID(user_id)
+            topics = crud.get_latest_trending_topics(
+                session=session, user_id=user_uuid, limit=limit
+            )
+            today_utc = datetime.now(timezone.utc).date()
+            has_today_trends = False
+            latest_date_str = None
+
+            if topics:
+                latest_dt = topics[0].last_seen_at or topics[0].created_at
+                if latest_dt:
+                    latest_date = (
+                        latest_dt.date() if hasattr(latest_dt, "date") else latest_dt
+                    )
+                    latest_date_str = latest_date.isoformat()
+                    has_today_trends = latest_date >= today_utc
+
+            topic_items = [
+                {
+                    "id": str(t.id),
+                    "topic_title": t.topic_title,
+                    "category": t.category,
+                    "post_count": t.post_count,
+                    "summary": t.summary,
+                    "topic_url": t.topic_url,
+                    "last_seen_at": t.last_seen_at.isoformat()
+                    if t.last_seen_at
+                    else None,
+                }
+                for t in topics
+            ]
+            return {
+                "has_today_trends": has_today_trends,
+                "latest_scrape_date": latest_date_str,
+                "today_date": today_utc.isoformat(),
+                "count": len(topic_items),
+                "topics": topic_items,
+            }
+        except Exception as e:
+            logger.error(f"Error in get_latest_scraped_trends tool: {e}")
+            return {
+                "has_today_trends": False,
+                "latest_scrape_date": None,
+                "today_date": datetime.now(timezone.utc).date().isoformat(),
+                "count": 0,
+                "topics": [],
+            }
+
+    @tool
+    def get_topic_tweets_and_summary(
+        topic_id: str, max_tweets: int = 5
+    ) -> dict[str, Any] | None:
+        """Retrieve deep topic context, Grok summary, and sample tweets for a specific topic ID from the database."""
+        res = raw_get_topic_tweets_and_summary(
+            topic_id=topic_id, max_tweets=max_tweets, session=session
+        )
+        return res.model_dump() if res else None
+
+    @tool
+    def get_recent_post_history(limit: int = 5) -> list[dict[str, Any]]:
+        """Retrieve the user's recently published posts to analyze their writing style, voice, and formatting."""
+        posts = raw_get_recent_post_history(
+            user_id=user_id, limit=limit, session=session
+        )
+        return [p.model_dump() for p in posts]
+
+    @tool
+    def get_social_account_status() -> dict[str, Any]:
+        """Check whether the user's X.com (Twitter) and LinkedIn accounts are connected and authenticated."""
+        res = raw_get_social_account_status(user_id=user_id, session=session)
+        return res.model_dump()
+
+    @tool
+    async def scrape_live_explore_trends(max_topics: int = 3) -> dict[str, Any]:
+        """Launch live browser automation (Playwright) to scrape fresh trending topics directly from X.com Explore.
+        Use this tool when the database has no trends, when trends are outdated, or when the user explicitly asks to refresh/scrape trends from X.
+        """
+        raw_result = await raw_scrape_live_explore_trends(
+            user_id=user_id, max_topics=max_topics, headless=True
+        )
+        # Fetch newly persisted topics
+        try:
+            user_uuid = uuid.UUID(user_id)
+            fresh_topics = crud.get_latest_trending_topics(
+                session=session, user_id=user_uuid, limit=max_topics
+            )
+            raw_result["topics"] = [
+                {
+                    "id": str(t.id),
+                    "topic_title": t.topic_title,
+                    "category": t.category,
+                    "post_count": t.post_count,
+                    "summary": t.summary,
+                    "topic_url": t.topic_url,
+                }
+                for t in fresh_topics
+            ]
+        except Exception as e:
+            logger.debug(f"Could not load fresh topics for tool response: {e}")
+            raw_result["topics"] = []
+
+        return raw_result
+
+    @tool
+    async def scrape_topic_timeline(
+        topic_url: str, max_tweets: int = 5
+    ) -> dict[str, Any]:
+        """Navigate a browser directly to a specific topic URL on live X to scrape its latest timeline tweets and Grok summary."""
+        return await raw_scrape_topic_timeline(
+            topic_url=topic_url, user_id=user_id, max_tweets=max_tweets
+        )
+
+    @tool
+    async def draft_social_post(
+        prompt: str, platform: str = "linkx", topic_context: str | None = None
+    ) -> dict[str, Any]:
+        """Generate high-engagement social media post copy based on a prompt or trending topic."""
+        text = await raw_draft_social_post(
+            topic_title=prompt, topic_summary=topic_context, platform=platform
+        )
+        return {
+            "content": text,
+            "platform": platform,
+            "char_count": len(text),
+        }
+
+    @tool
+    def validate_post_constraints(content: str, platform: str = "x") -> dict[str, Any]:
+        """Validate character limits (280 for X, 3000 for LinkedIn) and formatting compliance for a post."""
+        res = raw_validate_post_constraints(content=content, platform=platform)
+        return res.model_dump()
+
+    def _resolve_target_post(*, post_id: str | None = None) -> Post | None:
+        """Resolve the target post either by explicit ID, linked thread post, or latest draft."""
+        user_uuid: uuid.UUID | None = None
+        try:
+            user_uuid = uuid.UUID(user_id)
+        except (ValueError, TypeError):
+            return None
+
+        # 1. If explicit post_id is supplied and valid
+        if (
+            post_id
+            and post_id.strip()
+            and post_id.strip().lower() not in ("none", "null", "undefined")
+        ):
+            try:
+                p_uuid = uuid.UUID(post_id.strip())
+                post = crud.get_post(session=session, post_id=p_uuid)
+                if post and post.owner_id == user_uuid:
+                    return post
+            except (ValueError, TypeError):
+                pass
+
+        # 2. If thread_id is available, check if the thread has a linked post
+        if thread_id:
+            try:
+                t_uuid = uuid.UUID(thread_id)
+                thread = session.get(ChatThread, t_uuid)
+                if thread and thread.post_id:
+                    post = crud.get_post(session=session, post_id=thread.post_id)
+                    if post and post.owner_id == user_uuid:
+                        return post
+            except Exception as exc:
+                logger.debug(f"Could not load thread post: {exc}")
+
+        # 3. Fallback: query the user's most recent draft post
+        statement = (
+            select(Post)
+            .where(Post.owner_id == user_uuid, Post.status == "draft")
+            .order_by(col(Post.updated_at).desc().nulls_last())
+        )
+        post = session.exec(statement).first()
+        if post and thread_id:
+            try:
+                t_uuid = uuid.UUID(thread_id)
+                thread = session.get(ChatThread, t_uuid)
+                if thread and not thread.post_id:
+                    thread.post_id = post.id
+                    session.add(thread)
+                    session.commit()
+            except Exception as exc:
+                logger.debug(f"Could not link post to thread: {exc}")
+        return post
+
+    @tool
+    def get_latest_draft_post() -> dict[str, Any]:
+        """Retrieve the current active draft post being discussed or iterated on.
+        Call this tool when the user refers to the draft ('the post', 'my draft', 'the tweet')
+        or gives feedback, critique, or instructions on revising the current draft.
+        Returns the post details (post_id, content, platform, status, char_count, updated_at).
+        """
+        post = _resolve_target_post()
+        if not post:
+            return {"message": "No active draft post found for this conversation."}
+        return {
+            "post_id": str(post.id),
+            "id": str(post.id),
+            "postId": str(post.id),
+            "content": post.content,
+            "platform": post.platform,
+            "status": post.status,
+            "char_count": len(post.content),
+            "updated_at": post.updated_at.isoformat() if post.updated_at else None,
+        }
+
+    @tool
+    def save_draft_post(content: str, platform: str = "x") -> dict[str, Any]:
+        """Persist a BRAND NEW post draft to PostgreSQL ONLY when the user asks to start a new post from scratch.
+        CRITICAL: DO NOT use this tool if the user is asking to modify, shorten, lengthen, rephrase, critique, or update an existing post. For ANY modifications to an existing draft, you MUST use update_draft_post instead.
+        Calling this tool automatically renders the native interactive post component in the chat interface.
+        IMPORTANT: In your final assistant response, DO NOT repeat, quote, or re-paste the post content. The component already renders it. Simply state that the draft has been created or provide a brief 1-sentence strategic note.
+        """
+        post = raw_save_draft_post(
+            user_id=user_id, content=content, platform=platform, session=session
+        )
+        if not post:
+            return {"error": "Failed to save post draft to database"}
+
+        if thread_id:
+            try:
+                t_uuid = uuid.UUID(thread_id)
+                thread = session.get(ChatThread, t_uuid)
+                if thread:
+                    thread.post_id = post.id
+                    session.add(thread)
+                    session.commit()
+            except Exception as exc:
+                logger.debug(f"Failed to link post to thread: {exc}")
+
+        return {
+            "post_id": str(post.id),
+            "id": str(post.id),
+            "postId": str(post.id),
+            "content": post.content,
+            "platform": post.platform,
+            "status": post.status,
+            "char_count": len(post.content),
+            "ui_rendered": True,
+            "instruction": "The post is now rendered as an interactive post component in the chat. Do NOT repeat or output the post content in your text reply.",
+        }
+
+    @tool
+    def update_draft_post(
+        refined_content: str, post_id: str | None = None
+    ) -> dict[str, Any]:
+        """Update an existing draft post in PostgreSQL with refined content.
+        ALWAYS call this tool when the user gives feedback on a post, asks for changes, tone adjustments,
+        shortening, lengthening, adding/removing emojis or hashtags, or comments on the draft.
+        DO NOT call save_draft_post for revisions—use this tool so the same post is edited in-place.
+        If post_id is omitted or not known, it automatically targets the active draft in this thread.
+        IMPORTANT: In your final assistant response, DO NOT repeat or re-paste the post content.
+        The UI component will update and display it automatically. Keep your reply to 1 concise sentence.
+        """
+        target_post = _resolve_target_post(post_id=post_id)
+        if not target_post:
+            created = raw_save_draft_post(
+                user_id=user_id,
+                content=refined_content,
+                platform="x",
+                session=session,
+            )
+            if not created:
+                return {"error": "Failed to update or create draft post"}
+            if thread_id:
+                try:
+                    t_uuid = uuid.UUID(thread_id)
+                    thread = session.get(ChatThread, t_uuid)
+                    if thread:
+                        thread.post_id = created.id
+                        session.add(thread)
+                        session.commit()
+                except Exception as exc:
+                    logger.debug(f"Could not link post to thread: {exc}")
+            return {
+                "post_id": str(created.id),
+                "id": str(created.id),
+                "postId": str(created.id),
+                "content": created.content,
+                "platform": created.platform,
+                "status": created.status,
+                "char_count": len(created.content),
+                "updated": True,
+                "ui_rendered": True,
+                "instruction": "The post has been created/updated as an interactive component in the chat. Do NOT repeat or output the post content in your text reply.",
+            }
+
+        post = raw_update_post_in_db(
+            post_id=str(target_post.id),
+            user_id=user_id,
+            content=refined_content,
+            session=session,
+        )
+        if not post:
+            return {"error": f"Failed to update post with ID {target_post.id}"}
+
+        if thread_id:
+            try:
+                t_uuid = uuid.UUID(thread_id)
+                thread = session.get(ChatThread, t_uuid)
+                if thread and thread.post_id != post.id:
+                    thread.post_id = post.id
+                    session.add(thread)
+                    session.commit()
+            except Exception as exc:
+                logger.debug(f"Could not link updated post to thread: {exc}")
+
+        return {
+            "post_id": str(post.id),
+            "id": str(post.id),
+            "postId": str(post.id),
+            "content": post.content,
+            "platform": post.platform,
+            "status": post.status,
+            "char_count": len(post.content),
+            "updated": True,
+            "ui_rendered": True,
+            "instruction": "The updated post is now rendered as an interactive post component in the chat. Do NOT repeat or output the post content in your text reply.",
+        }
+
+    @tool
+    def schedule_post_in_db(
+        scheduled_at_iso: str, post_id: str | None = None
+    ) -> dict[str, Any]:
+        """Schedule an existing draft post for future publication at the specified ISO timestamp."""
+        try:
+            target_post = _resolve_target_post(post_id=post_id)
+            if not target_post:
+                return {"error": "No post found to schedule"}
+
+            scheduled_dt = datetime.fromisoformat(scheduled_at_iso)
+            if scheduled_dt.tzinfo is None:
+                scheduled_dt = scheduled_dt.replace(tzinfo=timezone.utc)
+
+            post_in = PostUpdate(status="scheduled", scheduled_at=scheduled_dt)
+            updated = crud.update_post(
+                session=session, db_post=target_post, post_in=post_in
+            )
+            return {
+                "post_id": str(updated.id),
+                "id": str(updated.id),
+                "postId": str(updated.id),
+                "status": updated.status,
+                "scheduled_at": updated.scheduled_at.isoformat()
+                if updated.scheduled_at
+                else None,
+            }
+        except Exception as e:
+            return {"error": f"Failed to schedule post: {e}"}
+
+    return [
+        get_latest_scraped_trends,
+        get_topic_tweets_and_summary,
+        get_recent_post_history,
+        get_social_account_status,
+        scrape_live_explore_trends,
+        scrape_topic_timeline,
+        draft_social_post,
+        validate_post_constraints,
+        get_latest_draft_post,
+        save_draft_post,
+        update_draft_post,
+        schedule_post_in_db,
+    ]
+
+
+def build_copilot_agent(
+    *,
+    user_id: str,
+    session: Session,
+    model: str | None = None,
+    thread_id: str | None = None,
+) -> Any:
+    """Compile a LangGraph ReAct agent equipped with LinkX tools."""
+    chat_model = get_chat_model(model=model, streaming=True)
+    tools = build_copilot_tools(
+        user_id=user_id,
+        session=session,
+        thread_id=thread_id,
+    )
+    prompt_text = COPILOT_AGENT_SYSTEM_PROMPT
+
+    # Dynamically inject active draft context if available for this thread/user
+    try:
+        user_uuid = uuid.UUID(user_id)
+        target_post: Post | None = None
+        if thread_id:
+            try:
+                t_uuid = uuid.UUID(thread_id)
+                thread = session.get(ChatThread, t_uuid)
+                if thread and thread.post_id:
+                    target_post = crud.get_post(session=session, post_id=thread.post_id)
+            except Exception:
+                pass
+        if not target_post:
+            statement = (
+                select(Post)
+                .where(Post.owner_id == user_uuid, Post.status == "draft")
+                .order_by(col(Post.updated_at).desc().nulls_last())
+            )
+            target_post = session.exec(statement).first()
+
+        if target_post:
+            prompt_text += (
+                f"\n\n### ACTIVE DRAFT IN THIS CONVERSATION:\n"
+                f"- Post ID: {target_post.id}\n"
+                f"- Platform: {target_post.platform}\n"
+                f"- Current Content:\n```\n{target_post.content}\n```\n"
+                f"When the user references 'this post', 'the draft', asks for revisions, or says 'make this more controversial', "
+                f'this is the draft to modify. NEVER ask the user for the draft text or ID. Directly call update_draft_post(post_id="{target_post.id}", refined_content=...)!'
+            )
+    except Exception as exc:
+        logger.debug(f"Could not inject active post context into agent: {exc}")
+
+    return create_react_agent(
+        model=chat_model,
+        tools=tools,
+        prompt=SystemMessage(content=prompt_text),
+    )

--- a/backend/app/services/agentic/client.py
+++ b/backend/app/services/agentic/client.py
@@ -18,6 +18,8 @@ def get_chat_model(
     target_model = model or settings.AI_MODEL
     # Strip optional provider prefix like 'openai/' if present for standard OpenAI client
     clean_model = target_model.removeprefix("openai/")
+    if clean_model.startswith("gemini"):
+        clean_model = "gpt-5.4"
     resolved_api_key = (
         settings.OPENAI_API_COMPATIBLE_API_KEY or settings.AI_API_KEY or "dummy-key"
     )

--- a/backend/app/services/ai_chat_runner.py
+++ b/backend/app/services/ai_chat_runner.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -9,11 +10,18 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
+from sqlmodel import Session
 
 from app.core.config import settings
 from app.services.agentic.client import get_chat_model
 from app.services.ai_completion_client import stream_raw_chat_completion
-from app.services.ai_stream_parser import stream_parsed_chunks
+from app.services.ai_image_utils import normalize_image_url, sanitize_image_urls
+from app.services.ai_stream_parser import (
+    process_buffer_step,
+    stream_parsed_chunks,
+)
+
+logger = logging.getLogger(__name__)
 
 LINKX_SYSTEM_PROMPT = """You are LinkX Copilot — an expert social media strategist, copywriter, and viral growth advisor.
 You help users craft high-performing, engaging posts for LinkedIn, X (Twitter), and cross-platform growth.
@@ -67,7 +75,7 @@ def _build_assistant_history_content(thought: str, text: str) -> str:
 
 
 def _extract_images_from_parts(parts: list[dict[str, Any]]) -> list[str]:
-    """Extract image URLs from message parts."""
+    """Extract and normalize image URLs from message parts."""
     images: list[str] = []
     for part in parts:
         ptype = part.get("type")
@@ -80,7 +88,9 @@ def _extract_images_from_parts(parts: list[dict[str, Any]]) -> list[str]:
             elif part.get("url"):
                 url = str(part.get("url", "")).strip()
             if url:
-                images.append(url)
+                normalized = normalize_image_url(url=url)
+                if normalized:
+                    images.append(normalized)
     return images
 
 
@@ -88,7 +98,7 @@ def _build_human_message_content(
     text: str, images: list[str] | None = None
 ) -> str | list[str | dict[Any, Any]]:
     if not images:
-        return text
+        return text or "[Empty message]"
     content: list[str | dict[Any, Any]] = []
     if text:
         content.append({"type": "text", "text": text})
@@ -104,10 +114,72 @@ def _convert_user_turn(text: str, images: list[str]) -> HumanMessage | None:
     return HumanMessage(content=_build_human_message_content(text, images))
 
 
-def _convert_assistant_turn(thought: str, text: str) -> AIMessage | None:
-    if not text and not thought:
+def _extract_assistant_content_from_parts(parts: list[dict[str, Any]]) -> str:
+    """Extract full conversational content including text and draft artifacts from assistant parts."""
+    blocks: list[str] = []
+
+    # 1. Extract any draft artifacts or draft tool calls
+    for part in parts:
+        ptype = part.get("type")
+        if ptype == "draft_artifact":
+            artifact = part.get("artifact", {})
+            post_id = (
+                artifact.get("postId")
+                or artifact.get("id")
+                or part.get("post_id")
+                or ""
+            )
+            content = artifact.get("content") or part.get("content") or ""
+            platform = artifact.get("platform") or part.get("platform") or "x"
+            if content:
+                id_str = f" (Post ID: {post_id})" if post_id else ""
+                blocks.append(f"[Draft Post{id_str}, Platform: {platform}]:\n{content}")
+        elif ptype in ("tool-call", "tool_call"):
+            tool_name = part.get("name") or part.get("tool", {}).get("name")
+            if tool_name in ("save_draft_post", "update_draft_post"):
+                tool_data = part.get("tool", {})
+                tool_output = tool_data.get("output") or part.get("output") or {}
+                tool_input = tool_data.get("input") or part.get("input") or {}
+                if isinstance(tool_output, dict) and tool_output.get("content"):
+                    p_id = tool_output.get("post_id") or tool_output.get("id") or ""
+                    p_content = tool_output.get("content")
+                    p_plat = tool_output.get("platform", "x")
+                    id_str = f" (Post ID: {p_id})" if p_id else ""
+                    blocks.append(
+                        f"[Draft Post{id_str}, Platform: {p_plat}]:\n{p_content}"
+                    )
+                elif isinstance(tool_input, dict) and (
+                    tool_input.get("content") or tool_input.get("refined_content")
+                ):
+                    p_content = tool_input.get("content") or tool_input.get(
+                        "refined_content"
+                    )
+                    p_id = tool_input.get("post_id", "")
+                    p_plat = tool_input.get("platform", "x")
+                    id_str = f" (Post ID: {p_id})" if p_id else ""
+                    blocks.append(
+                        f"[Draft Post{id_str}, Platform: {p_plat}]:\n{p_content}"
+                    )
+
+    # 2. Extract conversational text
+    text_chunks = [
+        str(part.get("text", ""))
+        for part in parts
+        if part.get("type") == "text" and part.get("text")
+    ]
+    if text_chunks:
+        blocks.append("\n".join(text_chunks).strip())
+
+    return "\n\n".join(b for b in blocks if b.strip()).strip()
+
+
+def _convert_assistant_turn(
+    thought: str, parts: list[dict[str, Any]]
+) -> AIMessage | None:
+    content = _extract_assistant_content_from_parts(parts)
+    if not content and not thought:
         return None
-    return AIMessage(content=_build_assistant_history_content(thought, text))
+    return AIMessage(content=_build_assistant_history_content(thought, content))
 
 
 def _convert_transcript_item(item: dict[str, Any]) -> BaseMessage | None:
@@ -121,7 +193,7 @@ def _convert_transcript_item(item: dict[str, Any]) -> BaseMessage | None:
     if role == "assistant":
         return _convert_assistant_turn(
             thought=_extract_thought_from_parts(parts),
-            text=_extract_text_from_parts(parts),
+            parts=parts,
         )
     return None
 
@@ -164,11 +236,29 @@ def _build_message_history(
         for item in raw_messages
         if (msg := _convert_transcript_item(item)) is not None
     ]
-    _ensure_latest_human_message(converted, current_message, images=images)
+    clean_images = sanitize_image_urls(images=images) if images else None
+    _ensure_latest_human_message(converted, current_message, images=clean_images)
     if len(converted) > max_history_messages:
         converted = converted[-max_history_messages:]
 
     return [SystemMessage(content=LINKX_SYSTEM_PROMPT), *converted]
+
+
+def _normalize_tool_output(raw_output: Any) -> Any:
+    if hasattr(raw_output, "content"):
+        content = raw_output.content
+        if isinstance(content, str):
+            try:
+                return json.loads(content)
+            except Exception:
+                return content
+        return content
+    if isinstance(raw_output, str):
+        try:
+            return json.loads(raw_output)
+        except Exception:
+            return raw_output
+    return raw_output
 
 
 async def default_chat_stream_runner(
@@ -177,13 +267,106 @@ async def default_chat_stream_runner(
     transcript: dict[str, Any] | None = None,
     model: str | None = None,
     images: list[str] | None = None,
+    user_id: str | None = None,
+    session: Session | None = None,
+    thread_id: str | None = None,
 ) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
-    """Stream AI chat conversation tokens and thinking thoughts word-by-word."""
+    """Stream AI chat conversation tokens, tool executions, and artifacts."""
     messages = _build_message_history(
         transcript=transcript,
         current_message=message,
         images=images,
     )
+
+    if user_id and session:
+        try:
+            from app.services.agentic.agent_supervisor import build_copilot_agent
+
+            agent = build_copilot_agent(
+                user_id=user_id,
+                session=session,
+                model=model,
+                thread_id=thread_id,
+            )
+            # Strip generic SystemMessage so create_react_agent uses its own copilot prompt with thread context
+            conversation_messages = [
+                m for m in messages if not isinstance(m, SystemMessage)
+            ]
+            in_thought = False
+            thought_buffer = ""
+
+            async for event in agent.astream_events(
+                {"messages": conversation_messages}, version="v2"
+            ):
+                kind = event.get("event")
+                if kind == "on_tool_start":
+                    if thought_buffer:
+                        final_ev = "thought" if in_thought else "text_delta"
+                        yield (final_ev, {"content": thought_buffer})
+                        thought_buffer = ""
+
+                    run_id = str(event.get("run_id", ""))
+                    name = str(event.get("name", ""))
+                    input_data = event.get("data", {}).get("input", {})
+                    yield (
+                        "tool_start",
+                        {"id": run_id, "name": name, "input": input_data},
+                    )
+                elif kind == "on_tool_end":
+                    run_id = str(event.get("run_id", ""))
+                    name = str(event.get("name", ""))
+                    raw_output = event.get("data", {}).get("output")
+                    output_data = _normalize_tool_output(raw_output)
+                    yield (
+                        "tool_output",
+                        {"id": run_id, "name": name, "output": output_data},
+                    )
+
+                    # Detect and emit rich artifact events for the UI
+                    if name in (
+                        "save_draft_post",
+                        "update_draft_post",
+                    ) and isinstance(output_data, dict):
+                        if output_data.get("post_id"):
+                            yield ("draft_artifact", output_data)
+
+                elif kind == "on_chat_model_stream":
+                    chunk = event.get("data", {}).get("chunk")
+                    # Handle reasoning content if provided by provider in kwargs
+                    reasoning = (
+                        getattr(chunk, "additional_kwargs", {}).get("reasoning_content")
+                        if hasattr(chunk, "additional_kwargs")
+                        else None
+                    )
+                    if reasoning and isinstance(reasoning, str):
+                        yield ("thought", {"content": reasoning})
+
+                    if (
+                        hasattr(chunk, "content")
+                        and isinstance(chunk.content, str)
+                        and chunk.content
+                    ):
+                        thought_buffer += chunk.content
+                        while thought_buffer:
+                            emitted, is_partial, thought_buffer, in_thought, ev_type = (
+                                process_buffer_step(thought_buffer, in_thought)
+                            )
+                            if emitted:
+                                yield (ev_type, {"content": emitted})
+                            if is_partial:
+                                break
+
+            if thought_buffer:
+                final_ev = "thought" if in_thought else "text_delta"
+                yield (final_ev, {"content": thought_buffer})
+                thought_buffer = ""
+
+            yield ("done", {})
+            return
+        except Exception as exc:
+            logger.warning(
+                f"Agent supervisor encountered error, falling back to direct LLM stream: {exc}"
+            )
 
     try:
         async for event in stream_parsed_chunks(

--- a/backend/app/services/ai_chat_runner.py
+++ b/backend/app/services/ai_chat_runner.py
@@ -10,7 +10,6 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from sqlmodel import Session
 
 from app.core.config import settings
 from app.services.agentic.client import get_chat_model
@@ -74,23 +73,27 @@ def _build_assistant_history_content(thought: str, text: str) -> str:
     return text
 
 
+def _extract_image_url_from_part(part: dict[str, Any]) -> str:
+    """Extract raw image URL or base64 from a part."""
+    if part.get("type") not in ("image_url", "image"):
+        return ""
+    img_val = part.get("image_url")
+    if isinstance(img_val, dict):
+        return str(img_val.get("url", "")).strip()
+    if isinstance(img_val, str):
+        return img_val.strip()
+    return str(part.get("url", "")).strip()
+
+
 def _extract_images_from_parts(parts: list[dict[str, Any]]) -> list[str]:
     """Extract and normalize image URLs from message parts."""
     images: list[str] = []
     for part in parts:
-        ptype = part.get("type")
-        if ptype in ("image_url", "image"):
-            url = ""
-            if isinstance(part.get("image_url"), dict):
-                url = str(part["image_url"].get("url", "")).strip()
-            elif isinstance(part.get("image_url"), str):
-                url = str(part.get("image_url", "")).strip()
-            elif part.get("url"):
-                url = str(part.get("url", "")).strip()
-            if url:
-                normalized = normalize_image_url(url=url)
-                if normalized:
-                    images.append(normalized)
+        raw_url = _extract_image_url_from_part(part)
+        if raw_url:
+            normalized = normalize_image_url(url=raw_url)
+            if normalized:
+                images.append(normalized)
     return images
 
 
@@ -114,63 +117,81 @@ def _convert_user_turn(text: str, images: list[str]) -> HumanMessage | None:
     return HumanMessage(content=_build_human_message_content(text, images))
 
 
+def _get_draft_field(
+    primary: dict[str, Any], fallback: dict[str, Any], *keys: str, default: str = ""
+) -> str:
+    for k in keys:
+        val = primary.get(k) or fallback.get(k)
+        if val:
+            return str(val)
+    return default
+
+
+def _extract_draft_block_from_artifact(part: dict[str, Any]) -> str | None:
+    if part.get("type") != "draft_artifact":
+        return None
+    art = part.get("artifact") or {}
+    content = _get_draft_field(art, part, "content")
+    if not content:
+        return None
+    post_id = _get_draft_field(art, part, "postId", "id", "post_id")
+    platform = _get_draft_field(art, part, "platform", default="x")
+    id_str = f" (Post ID: {post_id})" if post_id else ""
+    return f"[Draft Post{id_str}, Platform: {platform}]:\n{content}"
+
+
+def _extract_output_payload(output: Any) -> tuple[str | None, str, str]:
+    if isinstance(output, dict) and output.get("content"):
+        p_id = output.get("post_id") or output.get("id") or ""
+        return output["content"], str(p_id), str(output.get("platform", "x"))
+    return None, "", "x"
+
+
+def _extract_input_payload(inp: Any) -> tuple[str | None, str, str]:
+    if isinstance(inp, dict):
+        content = inp.get("content") or inp.get("refined_content")
+        if content:
+            return content, str(inp.get("post_id", "")), str(inp.get("platform", "x"))
+    return None, "", "x"
+
+
+def _extract_tool_payload(
+    tool_data: dict[str, Any], part: dict[str, Any]
+) -> tuple[str | None, str, str]:
+    content, p_id, plat = _extract_output_payload(
+        tool_data.get("output") or part.get("output")
+    )
+    if content:
+        return content, p_id, plat
+    return _extract_input_payload(tool_data.get("input") or part.get("input"))
+
+
+def _extract_draft_block_from_tool_call(part: dict[str, Any]) -> str | None:
+    if part.get("type") not in ("tool-call", "tool_call"):
+        return None
+    name = part.get("name") or part.get("tool", {}).get("name")
+    if name not in ("save_draft_post", "update_draft_post"):
+        return None
+    content, post_id, platform = _extract_tool_payload(part.get("tool", {}), part)
+    if not content:
+        return None
+    id_str = f" (Post ID: {post_id})" if post_id else ""
+    return f"[Draft Post{id_str}, Platform: {platform}]:\n{content}"
+
+
 def _extract_assistant_content_from_parts(parts: list[dict[str, Any]]) -> str:
     """Extract full conversational content including text and draft artifacts from assistant parts."""
     blocks: list[str] = []
-
-    # 1. Extract any draft artifacts or draft tool calls
     for part in parts:
-        ptype = part.get("type")
-        if ptype == "draft_artifact":
-            artifact = part.get("artifact", {})
-            post_id = (
-                artifact.get("postId")
-                or artifact.get("id")
-                or part.get("post_id")
-                or ""
-            )
-            content = artifact.get("content") or part.get("content") or ""
-            platform = artifact.get("platform") or part.get("platform") or "x"
-            if content:
-                id_str = f" (Post ID: {post_id})" if post_id else ""
-                blocks.append(f"[Draft Post{id_str}, Platform: {platform}]:\n{content}")
-        elif ptype in ("tool-call", "tool_call"):
-            tool_name = part.get("name") or part.get("tool", {}).get("name")
-            if tool_name in ("save_draft_post", "update_draft_post"):
-                tool_data = part.get("tool", {})
-                tool_output = tool_data.get("output") or part.get("output") or {}
-                tool_input = tool_data.get("input") or part.get("input") or {}
-                if isinstance(tool_output, dict) and tool_output.get("content"):
-                    p_id = tool_output.get("post_id") or tool_output.get("id") or ""
-                    p_content = tool_output.get("content")
-                    p_plat = tool_output.get("platform", "x")
-                    id_str = f" (Post ID: {p_id})" if p_id else ""
-                    blocks.append(
-                        f"[Draft Post{id_str}, Platform: {p_plat}]:\n{p_content}"
-                    )
-                elif isinstance(tool_input, dict) and (
-                    tool_input.get("content") or tool_input.get("refined_content")
-                ):
-                    p_content = tool_input.get("content") or tool_input.get(
-                        "refined_content"
-                    )
-                    p_id = tool_input.get("post_id", "")
-                    p_plat = tool_input.get("platform", "x")
-                    id_str = f" (Post ID: {p_id})" if p_id else ""
-                    blocks.append(
-                        f"[Draft Post{id_str}, Platform: {p_plat}]:\n{p_content}"
-                    )
+        draft_block = _extract_draft_block_from_artifact(
+            part
+        ) or _extract_draft_block_from_tool_call(part)
+        if draft_block:
+            blocks.append(draft_block)
+        elif part.get("type") == "text" and part.get("text"):
+            blocks.append(str(part["text"]))
 
-    # 2. Extract conversational text
-    text_chunks = [
-        str(part.get("text", ""))
-        for part in parts
-        if part.get("type") == "text" and part.get("text")
-    ]
-    if text_chunks:
-        blocks.append("\n".join(text_chunks).strip())
-
-    return "\n\n".join(b for b in blocks if b.strip()).strip()
+    return "\n\n".join(b.strip() for b in blocks if b.strip()).strip()
 
 
 def _convert_assistant_turn(
@@ -179,37 +200,22 @@ def _convert_assistant_turn(
     content = _extract_assistant_content_from_parts(parts)
     if not content and not thought:
         return None
-    return AIMessage(content=_build_assistant_history_content(thought, content))
+    return AIMessage(
+        content=_build_assistant_history_content(thought=thought, text=content)
+    )
 
 
 def _convert_transcript_item(item: dict[str, Any]) -> BaseMessage | None:
     role = item.get("role")
     parts = item.get("parts", [])
     if role == "user":
-        return _convert_user_turn(
-            text=_extract_text_from_parts(parts),
-            images=_extract_images_from_parts(parts),
-        )
+        text = _extract_text_from_parts(parts)
+        images = _extract_images_from_parts(parts)
+        return _convert_user_turn(text, images)
     if role == "assistant":
-        return _convert_assistant_turn(
-            thought=_extract_thought_from_parts(parts),
-            parts=parts,
-        )
+        thought = _extract_thought_from_parts(parts)
+        return _convert_assistant_turn(thought, parts)
     return None
-
-
-def _is_latest_message_matching(
-    converted: list[BaseMessage],
-    current_message: str,
-    images: list[str] | None = None,
-) -> bool:
-    if not converted:
-        return False
-    last = converted[-1]
-    if not isinstance(last, HumanMessage):
-        return False
-    expected_content = _build_human_message_content(current_message, images)
-    return last.content == expected_content
 
 
 def _ensure_latest_human_message(
@@ -217,16 +223,22 @@ def _ensure_latest_human_message(
     current_message: str,
     images: list[str] | None = None,
 ) -> None:
-    if not _is_latest_message_matching(converted, current_message, images):
-        content = _build_human_message_content(current_message, images)
-        converted.append(HumanMessage(content=content))
+    if not current_message and not images:
+        return
+    user_turn = _convert_user_turn(current_message, images or [])
+    if not user_turn:
+        return
+    if converted and isinstance(converted[-1], HumanMessage):
+        converted[-1] = user_turn
+    else:
+        converted.append(user_turn)
 
 
 def _build_message_history(
     *,
     transcript: dict[str, Any] | None,
     current_message: str,
-    max_history_messages: int = 40,
+    max_history_messages: int = 10,
     images: list[str] | None = None,
 ) -> list[BaseMessage]:
     """Convert JSONB transcript messages into LangChain BaseMessage objects."""
@@ -245,20 +257,115 @@ def _build_message_history(
 
 
 def _normalize_tool_output(raw_output: Any) -> Any:
-    if hasattr(raw_output, "content"):
-        content = raw_output.content
-        if isinstance(content, str):
-            try:
-                return json.loads(content)
-            except Exception:
-                return content
-        return content
-    if isinstance(raw_output, str):
+    val = getattr(raw_output, "content", raw_output)
+    if isinstance(val, str):
         try:
-            return json.loads(raw_output)
+            return json.loads(val)
         except Exception:
-            return raw_output
-    return raw_output
+            return val
+    return val
+
+
+def _handle_start_event(
+    event: dict[str, Any], thought_buffer: str, in_thought: bool
+) -> tuple[list[tuple[str, dict[str, Any]]], str]:
+    emitted: list[tuple[str, dict[str, Any]]] = []
+    if thought_buffer:
+        emitted.append(
+            ("thought" if in_thought else "text_delta", {"content": thought_buffer})
+        )
+    emitted.append(
+        (
+            "tool_start",
+            {
+                "id": str(event.get("run_id", "")),
+                "name": str(event.get("name", "")),
+                "input": event.get("data", {}).get("input", {}),
+            },
+        )
+    )
+    return emitted, ""
+
+
+def _handle_tool_end_events(
+    event: dict[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    name = str(event.get("name", ""))
+    output_data = _normalize_tool_output(event.get("data", {}).get("output"))
+    events: list[tuple[str, dict[str, Any]]] = [
+        (
+            "tool_output",
+            {"id": str(event.get("run_id", "")), "name": name, "output": output_data},
+        )
+    ]
+    if name in ("save_draft_post", "update_draft_post") and isinstance(
+        output_data, dict
+    ):
+        if output_data.get("post_id"):
+            events.append(("draft_artifact", output_data))
+    return events
+
+
+def _process_model_chunk(
+    chunk: Any, thought_buffer: str, in_thought: bool
+) -> tuple[list[tuple[str, dict[str, Any]]], str, bool]:
+    emitted_events: list[tuple[str, dict[str, Any]]] = []
+    reasoning = (
+        getattr(chunk, "additional_kwargs", {}).get("reasoning_content")
+        if hasattr(chunk, "additional_kwargs")
+        else None
+    )
+    if isinstance(reasoning, str):
+        emitted_events.append(("thought", {"content": reasoning}))
+
+    chunk_content = getattr(chunk, "content", None)
+    if isinstance(chunk_content, str) and chunk_content:
+        thought_buffer += chunk_content
+        while thought_buffer:
+            emitted, is_partial, thought_buffer, in_thought, ev_type = (
+                process_buffer_step(thought_buffer, in_thought)
+            )
+            if emitted:
+                emitted_events.append((ev_type, {"content": emitted}))
+            if is_partial:
+                break
+    return emitted_events, thought_buffer, in_thought
+
+
+def _handle_supervisor_event(
+    event: dict[str, Any], thought_buffer: str, in_thought: bool
+) -> tuple[list[tuple[str, dict[str, Any]]], str, bool]:
+    kind = event.get("event")
+    if kind == "on_tool_start":
+        evs, buf = _handle_start_event(event, thought_buffer, in_thought)
+        return evs, buf, in_thought
+    if kind == "on_tool_end":
+        return _handle_tool_end_events(event), thought_buffer, in_thought
+    if kind == "on_chat_model_stream":
+        return _process_model_chunk(
+            event.get("data", {}).get("chunk"), thought_buffer, in_thought
+        )
+    return [], thought_buffer, in_thought
+
+
+async def _stream_agent_supervisor_events(
+    *,
+    agent: Any,
+    messages: list[Any],
+) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
+    """Process LangGraph agent stream events and yield chat SSE tuples."""
+    in_thought = False
+    thought_buffer = ""
+
+    async for event in agent.astream_events({"messages": messages}, version="v2"):
+        events, thought_buffer, in_thought = _handle_supervisor_event(
+            event, thought_buffer, in_thought
+        )
+        for ev in events:
+            yield ev
+
+    if thought_buffer:
+        yield ("thought" if in_thought else "text_delta", {"content": thought_buffer})
 
 
 async def default_chat_stream_runner(
@@ -266,17 +373,18 @@ async def default_chat_stream_runner(
     message: str,
     transcript: dict[str, Any] | None = None,
     model: str | None = None,
-    images: list[str] | None = None,
-    user_id: str | None = None,
-    session: Session | None = None,
-    thread_id: str | None = None,
+    **kwargs: Any,
 ) -> AsyncGenerator[tuple[str, dict[str, Any]], None]:
     """Stream AI chat conversation tokens, tool executions, and artifacts."""
+    images = kwargs.get("images")
     messages = _build_message_history(
         transcript=transcript,
         current_message=message,
         images=images,
     )
+    user_id = kwargs.get("user_id")
+    session = kwargs.get("session")
+    thread_id = kwargs.get("thread_id")
 
     if user_id and session:
         try:
@@ -288,84 +396,16 @@ async def default_chat_stream_runner(
                 model=model,
                 thread_id=thread_id,
             )
-            # Strip generic SystemMessage so create_react_agent uses its own copilot prompt with thread context
-            conversation_messages = [
-                m for m in messages if not isinstance(m, SystemMessage)
-            ]
-            in_thought = False
-            thought_buffer = ""
-
-            async for event in agent.astream_events(
-                {"messages": conversation_messages}, version="v2"
+            conv_messages = [m for m in messages if not isinstance(m, SystemMessage)]
+            async for ev in _stream_agent_supervisor_events(
+                agent=agent, messages=conv_messages
             ):
-                kind = event.get("event")
-                if kind == "on_tool_start":
-                    if thought_buffer:
-                        final_ev = "thought" if in_thought else "text_delta"
-                        yield (final_ev, {"content": thought_buffer})
-                        thought_buffer = ""
-
-                    run_id = str(event.get("run_id", ""))
-                    name = str(event.get("name", ""))
-                    input_data = event.get("data", {}).get("input", {})
-                    yield (
-                        "tool_start",
-                        {"id": run_id, "name": name, "input": input_data},
-                    )
-                elif kind == "on_tool_end":
-                    run_id = str(event.get("run_id", ""))
-                    name = str(event.get("name", ""))
-                    raw_output = event.get("data", {}).get("output")
-                    output_data = _normalize_tool_output(raw_output)
-                    yield (
-                        "tool_output",
-                        {"id": run_id, "name": name, "output": output_data},
-                    )
-
-                    # Detect and emit rich artifact events for the UI
-                    if name in (
-                        "save_draft_post",
-                        "update_draft_post",
-                    ) and isinstance(output_data, dict):
-                        if output_data.get("post_id"):
-                            yield ("draft_artifact", output_data)
-
-                elif kind == "on_chat_model_stream":
-                    chunk = event.get("data", {}).get("chunk")
-                    # Handle reasoning content if provided by provider in kwargs
-                    reasoning = (
-                        getattr(chunk, "additional_kwargs", {}).get("reasoning_content")
-                        if hasattr(chunk, "additional_kwargs")
-                        else None
-                    )
-                    if reasoning and isinstance(reasoning, str):
-                        yield ("thought", {"content": reasoning})
-
-                    if (
-                        hasattr(chunk, "content")
-                        and isinstance(chunk.content, str)
-                        and chunk.content
-                    ):
-                        thought_buffer += chunk.content
-                        while thought_buffer:
-                            emitted, is_partial, thought_buffer, in_thought, ev_type = (
-                                process_buffer_step(thought_buffer, in_thought)
-                            )
-                            if emitted:
-                                yield (ev_type, {"content": emitted})
-                            if is_partial:
-                                break
-
-            if thought_buffer:
-                final_ev = "thought" if in_thought else "text_delta"
-                yield (final_ev, {"content": thought_buffer})
-                thought_buffer = ""
-
+                yield ev
             yield ("done", {})
             return
         except Exception as exc:
             logger.warning(
-                f"Agent supervisor encountered error, falling back to direct LLM stream: {exc}"
+                "Agent supervisor error, falling back to direct stream: %s", exc
             )
 
     try:
@@ -374,7 +414,6 @@ async def default_chat_stream_runner(
             delay=0.0,
         ):
             yield event
-
     except Exception as exc:
         yield ("error", {"message": f"LLM error: {exc}"})
 

--- a/backend/app/services/ai_completion_client.py
+++ b/backend/app/services/ai_completion_client.py
@@ -83,8 +83,10 @@ def _build_proxy_payload(
     temperature: float,
     max_tokens: int,
 ) -> dict[str, Any]:
+    raw_model = model_name.removeprefix("openai/")
+    clean_model = "gpt-5.4" if raw_model.startswith("gemini") else raw_model
     return {
-        "model": model_name.removeprefix("openai/"),
+        "model": clean_model,
         "messages": messages,
         "temperature": temperature,
         "max_tokens": max_tokens,

--- a/backend/app/services/ai_image_utils.py
+++ b/backend/app/services/ai_image_utils.py
@@ -1,0 +1,92 @@
+import base64
+import io
+import logging
+from typing import Any
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_IMAGE_FORMATS = {"JPEG", "PNG", "GIF", "WEBP"}
+VALID_HTTP_SCHEMES = ("http://", "https://")
+
+
+def normalize_image_url(*, url: Any) -> str | None:
+    """Validate, normalize, and auto-convert image URLs/data-URIs for LLM vision models.
+
+    OpenAI vision endpoints only support: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].
+    If an image is in another format (like AVIF, HEIC, TIFF, BMP) or has mismatched MIME headers
+    (e.g., AVIF disguised as data:image/jpeg), Pillow is used to safely convert it to JPEG.
+    If the image data is completely corrupted or unreadable, returns None.
+    """
+    if not isinstance(url, str):
+        return None
+    trimmed = url.strip()
+    if not trimmed:
+        return None
+
+    if any(trimmed.startswith(scheme) for scheme in VALID_HTTP_SCHEMES):
+        return trimmed
+
+    if not trimmed.startswith("data:image/"):
+        return None
+
+    try:
+        header, _, b64_data = trimmed.partition(",")
+        if not b64_data:
+            return None
+
+        data = base64.b64decode(b64_data)
+        if not data:
+            return None
+
+        with Image.open(io.BytesIO(data)) as im:
+            detected_format = (im.format or "").upper()
+            declared_mime = header.split(";")[0].replace("data:", "").strip().lower()
+
+            # Handle jpg -> jpeg alias
+            if declared_mime == "image/jpg":
+                declared_mime = "image/jpeg"
+
+            expected_mime = f"image/{detected_format.lower()}"
+            if expected_mime == "image/jpg":
+                expected_mime = "image/jpeg"
+
+            # If format is already supported and matches the header, it's valid as-is
+            if (
+                detected_format in SUPPORTED_IMAGE_FORMATS
+                and declared_mime == expected_mime
+            ):
+                return trimmed
+
+            # Otherwise (e.g. AVIF, BMP, TIFF, or mismatched header like AVIF declared as JPEG),
+            # convert to clean standard JPEG
+            logger.info(
+                "Auto-converting image to JPEG for LLM compatibility (detected=%s, declared=%s)",
+                detected_format,
+                declared_mime,
+            )
+            export_im: Image.Image = im
+            if export_im.mode in ("RGBA", "P", "LA"):
+                export_im = export_im.convert("RGB")
+
+            out = io.BytesIO()
+            export_im.save(out, format="JPEG", quality=85)
+            encoded = base64.b64encode(out.getvalue()).decode("ascii")
+            return f"data:image/jpeg;base64,{encoded}"
+
+    except Exception as exc:
+        logger.warning("Failed to parse or convert image data URL: %s", exc)
+        return None
+
+
+def sanitize_image_urls(*, images: list[str] | None) -> list[str]:
+    """Filter, sanitize, and convert valid image URLs or data URLs."""
+    if not images:
+        return []
+    clean: list[str] = []
+    for img in images:
+        normalized = normalize_image_url(url=img)
+        if normalized:
+            clean.append(normalized)
+    return clean

--- a/backend/app/services/ai_image_utils.py
+++ b/backend/app/services/ai_image_utils.py
@@ -11,13 +11,68 @@ SUPPORTED_IMAGE_FORMATS = {"JPEG", "PNG", "GIF", "WEBP"}
 VALID_HTTP_SCHEMES = ("http://", "https://")
 
 
+def _is_supported_match(*, detected_format: str, declared_mime: str) -> bool:
+    """Check if detected image format is supported and matches declared MIME."""
+    normalized_declared = (
+        "image/jpeg" if declared_mime == "image/jpg" else declared_mime
+    )
+    expected_mime = f"image/{detected_format.lower()}"
+    if expected_mime == "image/jpg":
+        expected_mime = "image/jpeg"
+
+    is_supported = detected_format in SUPPORTED_IMAGE_FORMATS
+    return is_supported and normalized_declared == expected_mime
+
+
+def _convert_to_jpeg_b64(*, im: Image.Image) -> str:
+    """Convert any Pillow image to a clean base64 data-URI JPEG."""
+    export_im: Image.Image = im
+    if export_im.mode in ("RGBA", "P", "LA"):
+        export_im = export_im.convert("RGB")
+
+    out = io.BytesIO()
+    export_im.save(out, format="JPEG", quality=85)
+    encoded = base64.b64encode(out.getvalue()).decode("ascii")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+def _process_image_data_uri(*, trimmed: str) -> str | None:
+    """Safely parse base64 data and re-encode to JPEG if necessary."""
+    try:
+        header, _, b64_data = trimmed.partition(",")
+        if not b64_data:
+            return None
+
+        raw_bytes = base64.b64decode(b64_data)
+        if not raw_bytes:
+            return None
+
+        with Image.open(io.BytesIO(raw_bytes)) as im:
+            detected_fmt = (im.format or "").upper()
+            declared_mime = header.split(";")[0].replace("data:", "").strip().lower()
+
+            if _is_supported_match(
+                detected_format=detected_fmt, declared_mime=declared_mime
+            ):
+                return trimmed
+
+            logger.info(
+                "Auto-converting image to JPEG for LLM compatibility (detected=%s, declared=%s)",
+                detected_fmt,
+                declared_mime,
+            )
+            return _convert_to_jpeg_b64(im=im)
+    except Exception as exc:
+        logger.warning("Failed to parse or convert image data URL: %s", exc)
+        return None
+
+
 def normalize_image_url(*, url: Any) -> str | None:
     """Validate, normalize, and auto-convert image URLs/data-URIs for LLM vision models.
 
     OpenAI vision endpoints only support: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].
-    If an image is in another format (like AVIF, HEIC, TIFF, BMP) or has mismatched MIME headers
-    (e.g., AVIF disguised as data:image/jpeg), Pillow is used to safely convert it to JPEG.
-    If the image data is completely corrupted or unreadable, returns None.
+    If an image is in another format (like AVIF, HEIC, TIFF, BMP) or has mismatched MIME headers,
+    Pillow is used to safely convert it to JPEG. Corrupted data returns None.
     """
     if not isinstance(url, str):
         return None
@@ -31,53 +86,7 @@ def normalize_image_url(*, url: Any) -> str | None:
     if not trimmed.startswith("data:image/"):
         return None
 
-    try:
-        header, _, b64_data = trimmed.partition(",")
-        if not b64_data:
-            return None
-
-        data = base64.b64decode(b64_data)
-        if not data:
-            return None
-
-        with Image.open(io.BytesIO(data)) as im:
-            detected_format = (im.format or "").upper()
-            declared_mime = header.split(";")[0].replace("data:", "").strip().lower()
-
-            # Handle jpg -> jpeg alias
-            if declared_mime == "image/jpg":
-                declared_mime = "image/jpeg"
-
-            expected_mime = f"image/{detected_format.lower()}"
-            if expected_mime == "image/jpg":
-                expected_mime = "image/jpeg"
-
-            # If format is already supported and matches the header, it's valid as-is
-            if (
-                detected_format in SUPPORTED_IMAGE_FORMATS
-                and declared_mime == expected_mime
-            ):
-                return trimmed
-
-            # Otherwise (e.g. AVIF, BMP, TIFF, or mismatched header like AVIF declared as JPEG),
-            # convert to clean standard JPEG
-            logger.info(
-                "Auto-converting image to JPEG for LLM compatibility (detected=%s, declared=%s)",
-                detected_format,
-                declared_mime,
-            )
-            export_im: Image.Image = im
-            if export_im.mode in ("RGBA", "P", "LA"):
-                export_im = export_im.convert("RGB")
-
-            out = io.BytesIO()
-            export_im.save(out, format="JPEG", quality=85)
-            encoded = base64.b64encode(out.getvalue()).decode("ascii")
-            return f"data:image/jpeg;base64,{encoded}"
-
-    except Exception as exc:
-        logger.warning("Failed to parse or convert image data URL: %s", exc)
-        return None
+    return _process_image_data_uri(trimmed=trimmed)
 
 
 def sanitize_image_urls(*, images: list[str] | None) -> list[str]:

--- a/backend/app/services/browser/diagnostics.py
+++ b/backend/app/services/browser/diagnostics.py
@@ -137,7 +137,9 @@ async def _check_url_and_title(page: Any) -> str | None:
 
 
 async def _check_error_banners(page: Any) -> str | None:
-    """Check for rate limit or generic error text banners."""
+    """Check for rate limit or generic error text banners that are actively visible."""
+    if not hasattr(page, "locator"):
+        return None
     for text_sel in (
         "text=Something went wrong",
         "text=Rate limit exceeded",
@@ -145,8 +147,11 @@ async def _check_error_banners(page: Any) -> str | None:
         "[data-testid='error-detail']",
     ):
         try:
-            if hasattr(page, "locator") and await page.locator(text_sel).count() > 0:
-                return "rate_limited"
+            loc = page.locator(text_sel)
+            if await loc.count() > 0:
+                first = loc.first
+                if hasattr(first, "is_visible") and await first.is_visible():
+                    return "rate_limited"
         except Exception:
             pass
     return None

--- a/backend/tests/api/routes/test_ai_threads.py
+++ b/backend/tests/api/routes/test_ai_threads.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from langchain_core.messages import AIMessageChunk
 from sqlmodel import Session, select
 
+from app.api.routes.ai_threads import EXCLUDED_MODELS
 from app.core.config import settings
 from app.models import Post, User
 from tests.utils.chat_thread import create_random_chat_thread
@@ -232,6 +233,10 @@ def test_chat_stream_returns_sse_and_persists(
 
     with (
         patch(
+            "app.services.agentic.agent_supervisor.build_copilot_agent",
+            side_effect=RuntimeError("copilot agent disabled for unit fallback test"),
+        ),
+        patch(
             "app.services.ai_completion_client.stream_direct_openai_proxy",
             side_effect=ConnectionError("proxy down"),
         ),
@@ -284,7 +289,7 @@ def test_list_ai_models(
     expected_default = settings.AI_MODEL.removeprefix("openai/")
     assert data["default_model"] == expected_default
     assert any(m["id"] == expected_default for m in data["data"])
-    assert not any("gemini" in m["id"].lower() for m in data["data"])
+    assert not any(m["id"] in EXCLUDED_MODELS for m in data["data"])
 
 
 def test_chat_stream_with_multimodal_images_persists(
@@ -305,6 +310,10 @@ def test_chat_stream_with_multimodal_images_persists(
     tid = t["id"]
 
     with (
+        patch(
+            "app.services.agentic.agent_supervisor.build_copilot_agent",
+            side_effect=RuntimeError("copilot agent disabled for unit fallback test"),
+        ),
         patch(
             "app.services.ai_completion_client.stream_direct_openai_proxy",
             side_effect=ConnectionError("proxy down"),

--- a/backend/tests/chaos/test_rate_limits_bot_chaos.py
+++ b/backend/tests/chaos/test_rate_limits_bot_chaos.py
@@ -52,6 +52,20 @@ class TestRateLimitsAndBotChallenges:
         assert state_locked == "rate_limited"
 
     @pytest.mark.anyio
+    async def test_detect_page_state_ignores_hidden_error_banners(self) -> None:
+        """Attack Vector 2A-b: Hidden/unrendered error banners in SPA bundle do not trigger rate_limited."""
+        page_hidden = AsyncMock(url="https://x.com/home")
+
+        def loc_hidden(selector: str) -> Any:
+            if selector == "text=Something went wrong":
+                return build_mock_locator(count=1, is_visible=False)
+            return build_mock_locator(count=0)
+
+        page_hidden.locator = MagicMock(side_effect=loc_hidden)
+        state = await detect_page_state(page_hidden)
+        assert state == "ok"
+
+    @pytest.mark.anyio
     async def test_detect_page_state_captcha_sizing_heuristics(self) -> None:
         """Attack Vector 2B: Differentiates tracking iframes vs visible CAPTCHA walls."""
         page_tracking = AsyncMock(url="https://x.com/home")

--- a/backend/tests/helpers/mock_browser.py
+++ b/backend/tests/helpers/mock_browser.py
@@ -9,14 +9,15 @@ from unittest.mock import AsyncMock, MagicMock
 def build_mock_locator(
     *,
     count: int = 0,
-    is_visible: bool = False,
+    is_visible: bool | None = None,
     inner_text: str = "",
     all_items: list[Any] | None = None,
 ) -> MagicMock:
     """Helper to construct Playwright-like async locators with <= 4 arguments."""
+    resolved_visible = (count > 0) if is_visible is None else is_visible
     loc = MagicMock()
     loc.count = AsyncMock(return_value=count)
-    loc.is_visible = AsyncMock(return_value=is_visible)
+    loc.is_visible = AsyncMock(return_value=resolved_visible)
     loc.inner_text = AsyncMock(return_value=inner_text)
     loc.first = loc
     loc.nth = MagicMock(return_value=loc)

--- a/backend/tests/services/agentic/test_agent_supervisor.py
+++ b/backend/tests/services/agentic/test_agent_supervisor.py
@@ -1,0 +1,208 @@
+"""Tests for LangGraph Copilot Agent Supervisor draft management and in-place editing."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlmodel import Session, select
+
+from app import crud
+from app.models import ChatThread, ChatThreadCreate, Post, User, UserCreate
+from app.services.agentic.agent_supervisor import (
+    COPILOT_AGENT_SYSTEM_PROMPT,
+    build_copilot_agent,
+    build_copilot_tools,
+)
+from tests.utils.utils import random_email, random_lower_string
+
+
+def _make_user(*, db: Session) -> User:
+    return crud.create_user(
+        session=db,
+        user_create=UserCreate(
+            email=random_email(),
+            password=random_lower_string(),
+        ),
+    )
+
+
+def _make_thread(
+    *, db: Session, user: User, post_id: uuid.UUID | None = None
+) -> ChatThread:
+    thread_in = ChatThreadCreate(
+        title="Test Thread",
+        origin="manual",
+        post_id=post_id,
+    )
+    return crud.create_chat_thread(session=db, thread_in=thread_in, owner_id=user.id)
+
+
+def _get_tool_by_name(tools: list[Any], name: str) -> Any:
+    for t in tools:
+        if t.name == name:
+            return t
+    raise ValueError(f"Tool {name} not found")
+
+
+class TestAgentSupervisorDraftManagement:
+    def test_copilot_agent_system_prompt_rules(self) -> None:
+        """Verify prompt contains strict rules for in-place editing and no repetition."""
+        assert (
+            "IN-PLACE DRAFT EDITING VS CREATING NEW DRAFTS"
+            in COPILOT_AGENT_SYSTEM_PROMPT
+        )
+        assert "update_draft_post" in COPILOT_AGENT_SYSTEM_PROMPT
+        assert (
+            "DO NOT CALL `save_draft_post` WHEN REVISING" in COPILOT_AGENT_SYSTEM_PROMPT
+        )
+        assert "NO POST CONTENT REPETITION" in COPILOT_AGENT_SYSTEM_PROMPT
+        assert "get_latest_draft_post" in COPILOT_AGENT_SYSTEM_PROMPT
+
+    def test_build_copilot_tools_includes_latest_draft_tool(self, db: Session) -> None:
+        user = _make_user(db=db)
+        tools = build_copilot_tools(user_id=str(user.id), session=db)
+        tool_names = [t.name for t in tools]
+        assert "get_latest_draft_post" in tool_names
+        assert "save_draft_post" in tool_names
+        assert "update_draft_post" in tool_names
+        assert "schedule_post_in_db" in tool_names
+
+    def test_get_latest_draft_post_empty(self, db: Session) -> None:
+        user = _make_user(db=db)
+        tools = build_copilot_tools(user_id=str(user.id), session=db)
+        get_tool = _get_tool_by_name(tools, "get_latest_draft_post")
+
+        result = get_tool.invoke({})
+        assert "No active draft post found" in result["message"]
+
+    def test_save_draft_post_links_to_thread(self, db: Session) -> None:
+        user = _make_user(db=db)
+        thread = _make_thread(db=db, user=user)
+        assert thread.post_id is None
+
+        tools = build_copilot_tools(
+            user_id=str(user.id), session=db, thread_id=str(thread.id)
+        )
+        save_tool = _get_tool_by_name(tools, "save_draft_post")
+
+        result = save_tool.invoke(
+            {"content": "A brand new viral tweet!", "platform": "x"}
+        )
+        assert "post_id" in result
+        assert result["content"] == "A brand new viral tweet!"
+        assert result["ui_rendered"] is True
+
+        db.refresh(thread)
+        assert thread.post_id == uuid.UUID(result["post_id"])
+
+    def test_get_latest_draft_post_returns_thread_linked_post(
+        self, db: Session
+    ) -> None:
+        user = _make_user(db=db)
+        thread = _make_thread(db=db, user=user)
+
+        tools = build_copilot_tools(
+            user_id=str(user.id), session=db, thread_id=str(thread.id)
+        )
+        save_tool = _get_tool_by_name(tools, "save_draft_post")
+        save_res = save_tool.invoke(
+            {"content": "Initial thread draft", "platform": "x"}
+        )
+
+        get_tool = _get_tool_by_name(tools, "get_latest_draft_post")
+        get_res = get_tool.invoke({})
+
+        assert get_res["post_id"] == save_res["post_id"]
+        assert get_res["content"] == "Initial thread draft"
+
+    def test_update_draft_post_edits_same_post_in_place(self, db: Session) -> None:
+        user = _make_user(db=db)
+        thread = _make_thread(db=db, user=user)
+
+        tools = build_copilot_tools(
+            user_id=str(user.id), session=db, thread_id=str(thread.id)
+        )
+        save_tool = _get_tool_by_name(tools, "save_draft_post")
+        initial_res = save_tool.invoke({"content": "First draft text", "platform": "x"})
+        initial_post_id = initial_res["post_id"]
+
+        # Now update without specifying post_id (mimicking LLM reacting to user feedback)
+        update_tool = _get_tool_by_name(tools, "update_draft_post")
+        updated_res = update_tool.invoke(
+            {"refined_content": "Second draft text (shorter and punchier)"}
+        )
+
+        assert updated_res["post_id"] == initial_post_id
+        assert updated_res["content"] == "Second draft text (shorter and punchier)"
+        assert updated_res["updated"] is True
+
+        # Ensure NO duplicate post was created in the database
+        posts = db.exec(select(Post).where(Post.owner_id == user.id)).all()
+        assert len(posts) == 1
+        assert posts[0].content == "Second draft text (shorter and punchier)"
+
+    def test_update_draft_post_fallback_when_no_draft_exists(self, db: Session) -> None:
+        user = _make_user(db=db)
+        thread = _make_thread(db=db, user=user)
+
+        tools = build_copilot_tools(
+            user_id=str(user.id), session=db, thread_id=str(thread.id)
+        )
+        update_tool = _get_tool_by_name(tools, "update_draft_post")
+
+        # When no draft exists at all, update_draft_post gracefully saves it as a new draft
+        res = update_tool.invoke(
+            {"refined_content": "Draft created via update fallback"}
+        )
+        assert "post_id" in res
+        assert res["content"] == "Draft created via update fallback"
+
+        db.refresh(thread)
+        assert thread.post_id == uuid.UUID(res["post_id"])
+
+    def test_schedule_post_auto_resolves_active_draft(self, db: Session) -> None:
+        user = _make_user(db=db)
+        thread = _make_thread(db=db, user=user)
+
+        tools = build_copilot_tools(
+            user_id=str(user.id), session=db, thread_id=str(thread.id)
+        )
+        save_tool = _get_tool_by_name(tools, "save_draft_post")
+        saved = save_tool.invoke(
+            {"content": "Post ready for scheduling", "platform": "x"}
+        )
+
+        schedule_tool = _get_tool_by_name(tools, "schedule_post_in_db")
+        sched_res = schedule_tool.invoke({"scheduled_at_iso": "2026-09-05T15:00:00Z"})
+
+        assert sched_res["post_id"] == saved["post_id"]
+        assert sched_res["status"] == "scheduled"
+
+    def test_build_copilot_agent_compilation(self, db: Session) -> None:
+        user = _make_user(db=db)
+        agent = build_copilot_agent(
+            user_id=str(user.id), session=db, thread_id="some-thread-id"
+        )
+        assert agent is not None
+
+    def test_build_copilot_agent_injects_active_draft_context(
+        self, db: Session
+    ) -> None:
+        user = _make_user(db=db)
+        thread = _make_thread(db=db, user=user)
+
+        # Save an active draft
+        tools = build_copilot_tools(
+            user_id=str(user.id), session=db, thread_id=str(thread.id)
+        )
+        save_tool = _get_tool_by_name(tools, "save_draft_post")
+        save_res = save_tool.invoke(
+            {"content": "Draft to be made controversial", "platform": "x"}
+        )
+        assert "post_id" in save_res
+
+        agent = build_copilot_agent(
+            user_id=str(user.id), session=db, thread_id=str(thread.id)
+        )
+        assert agent is not None

--- a/backend/tests/services/test_ai_chat_runner.py
+++ b/backend/tests/services/test_ai_chat_runner.py
@@ -78,6 +78,42 @@ def test_build_message_history_multi_turn() -> None:
     assert messages[3].content == "Make it shorter"
 
 
+def test_build_message_history_preserves_draft_artifact_and_post_id() -> None:
+    transcript = {
+        "messages": [
+            {
+                "role": "user",
+                "parts": [{"type": "text", "text": "Draft a post about LinkX"}],
+            },
+            {
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "draft_artifact",
+                        "artifact": {
+                            "id": "post-uuid-1234",
+                            "postId": "post-uuid-1234",
+                            "content": "Why LinkX is the best tool for founders",
+                            "platform": "x",
+                        },
+                    },
+                    {"type": "text", "text": "I've drafted and saved the post above."},
+                ],
+            },
+        ]
+    }
+    messages = _build_message_history(
+        transcript=transcript,
+        current_message="no make this more contreversial - this post",
+    )
+    assert len(messages) == 4
+    ai_msg = messages[2]
+    assert isinstance(ai_msg, AIMessage)
+    assert "post-uuid-1234" in str(ai_msg.content)
+    assert "Why LinkX is the best tool for founders" in str(ai_msg.content)
+    assert "I've drafted and saved the post above." in str(ai_msg.content)
+
+
 def test_build_message_history_truncates_window() -> None:
     # 50 existing turns -> should truncate to max 10 + 1 system
     long_messages = [
@@ -210,7 +246,8 @@ async def test_generate_ai_thread_title_success() -> None:
 
 
 def test_build_message_history_with_images() -> None:
-    images = ["data:image/png;base64,abc123", "https://example.com/photo.jpg"]
+    valid_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    images = [valid_png, "https://example.com/photo.jpg"]
     messages = _build_message_history(
         transcript=None,
         current_message="Check these charts",
@@ -224,7 +261,7 @@ def test_build_message_history_with_images() -> None:
     assert last_msg.content[0] == {"type": "text", "text": "Check these charts"}
     assert last_msg.content[1] == {
         "type": "image_url",
-        "image_url": {"url": "data:image/png;base64,abc123"},
+        "image_url": {"url": valid_png},
     }
     assert last_msg.content[2] == {
         "type": "image_url",

--- a/backend/tests/services/test_ai_image_utils.py
+++ b/backend/tests/services/test_ai_image_utils.py
@@ -1,0 +1,88 @@
+import base64
+import io
+
+from PIL import Image
+
+from app.services.ai_image_utils import normalize_image_url, sanitize_image_urls
+
+
+def test_normalize_image_url_http_preserved() -> None:
+    assert (
+        normalize_image_url(url="https://example.com/photo.jpg")
+        == "https://example.com/photo.jpg"
+    )
+    assert (
+        normalize_image_url(url="http://example.com/photo.png")
+        == "http://example.com/photo.png"
+    )
+
+
+def test_normalize_image_url_rejects_invalid_inputs() -> None:
+    assert normalize_image_url(url="") is None
+    assert normalize_image_url(url=None) is None
+    assert normalize_image_url(url="ftp://example.com/pic.jpg") is None
+    assert normalize_image_url(url="data:text/plain;base64,aGVsbG8=") is None
+    assert (
+        normalize_image_url(url="data:image/jpeg;base64,not-valid-base64-bytes!!")
+        is None
+    )
+
+
+def test_normalize_image_url_valid_png_preserved() -> None:
+    im = Image.new("RGBA", (10, 10), color="blue")
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    url = f"data:image/png;base64,{b64}"
+
+    normalized = normalize_image_url(url=url)
+    assert normalized == url
+
+
+def test_normalize_image_url_valid_jpeg_preserved() -> None:
+    im = Image.new("RGB", (10, 10), color="red")
+    buf = io.BytesIO()
+    im.save(buf, format="JPEG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    url = f"data:image/jpeg;base64,{b64}"
+
+    normalized = normalize_image_url(url=url)
+    assert normalized == url
+
+
+def test_normalize_image_url_converts_bmp_to_jpeg() -> None:
+    im = Image.new("RGB", (10, 10), color="green")
+    buf = io.BytesIO()
+    im.save(buf, format="BMP")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    url = f"data:image/bmp;base64,{b64}"
+
+    normalized = normalize_image_url(url=url)
+    assert normalized is not None
+    assert normalized.startswith("data:image/jpeg;base64,")
+
+    # Verify result is a readable JPEG
+    _, _, res_b64 = normalized.partition(",")
+    res_bytes = base64.b64decode(res_b64)
+    with Image.open(io.BytesIO(res_bytes)) as res_im:
+        assert res_im.format == "JPEG"
+
+
+def test_sanitize_image_urls_filters_and_converts() -> None:
+    im = Image.new("RGB", (5, 5), color="yellow")
+    buf = io.BytesIO()
+    im.save(buf, format="JPEG")
+    valid_jpeg = (
+        f"data:image/jpeg;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+    )
+
+    input_list = [
+        "https://example.com/valid.png",
+        "data:image/jpeg;base64,bad-data",
+        valid_jpeg,
+        "javascript:alert(1)",
+    ]
+    cleaned = sanitize_image_urls(images=input_list)
+    assert len(cleaned) == 2
+    assert cleaned[0] == "https://example.com/valid.png"
+    assert cleaned[1] == valid_jpeg

--- a/frontend/src/components/Chat/AIChatFeed.tsx
+++ b/frontend/src/components/Chat/AIChatFeed.tsx
@@ -68,6 +68,9 @@ export function AIChatFeed({
                   isStreaming={
                     isStreaming && index === localMessages.length - 1
                   }
+                  onDraftTopic={(title) =>
+                    onSendMessage(`Draft an engaging post about: "${title}"`)
+                  }
                 />
               </MessageScrollerItem>
             ))}

--- a/frontend/src/components/Chat/AIThreadsSidebar.tsx
+++ b/frontend/src/components/Chat/AIThreadsSidebar.tsx
@@ -18,6 +18,8 @@ function ThreadListSection({
   openMenuThreadId,
   isLoading,
   emptyMessage,
+  streamingThreadId,
+  queuedThreadIds,
   actions,
 }: {
   threads: ChatThreadPublic[]
@@ -25,6 +27,8 @@ function ThreadListSection({
   openMenuThreadId: string | null
   isLoading: boolean
   emptyMessage: string
+  streamingThreadId?: string | null
+  queuedThreadIds?: string[]
   actions: ThreadItemActions
 }) {
   if (isLoading) {
@@ -51,6 +55,10 @@ function ThreadListSection({
           thread={thread}
           isActive={thread.id === activeThreadId}
           isMenuOpen={openMenuThreadId === thread.id}
+          isStreaming={Boolean(
+            streamingThreadId && streamingThreadId === thread.id,
+          )}
+          isQueued={Boolean(queuedThreadIds?.includes(thread.id))}
           actions={actions}
         />
       ))}
@@ -85,6 +93,8 @@ export interface AIThreadsSidebarProps {
   isLoading: boolean
   filters: SidebarFilterState
   filterHandlers: SidebarFilterHandlers
+  streamingThreadId?: string | null
+  queuedThreadIds?: string[]
   actions: ThreadItemActions
 }
 
@@ -96,12 +106,14 @@ export function AIThreadsSidebar({
   isLoading,
   filters,
   filterHandlers,
+  streamingThreadId,
+  queuedThreadIds,
   actions,
 }: AIThreadsSidebarProps) {
   return (
-    <div className="hidden w-80 md:block shrink-0">
-      <div className="sticky top-0 self-start p-4 flex flex-col gap-4">
-        <div className="flex flex-col gap-1">
+    <aside className="hidden w-80 md:block shrink-0 h-full overflow-y-auto overscroll-contain scrollbar-thin border-l border-border/40">
+      <div className="p-4 pb-20 space-y-6">
+        <section className="space-y-1.5">
           <SidebarControlsHeader
             isOpen={filters.recentsOpen}
             isSearchOpen={filters.isSearchOpen}
@@ -129,12 +141,14 @@ export function AIThreadsSidebar({
               openMenuThreadId={openMenuThreadId}
               isLoading={isLoading}
               emptyMessage="No recent chats"
+              streamingThreadId={streamingThreadId}
+              queuedThreadIds={queuedThreadIds}
               actions={actions}
             />
           )}
-        </div>
+        </section>
 
-        <div className="flex flex-col gap-1 border-t border-border/40 pt-2.5">
+        <section className="space-y-1.5 border-t border-border/40 pt-4">
           <div className="flex items-center justify-between px-2 py-1">
             <button
               type="button"
@@ -158,11 +172,13 @@ export function AIThreadsSidebar({
               openMenuThreadId={openMenuThreadId}
               isLoading={isLoading}
               emptyMessage="No archived chats"
+              streamingThreadId={streamingThreadId}
+              queuedThreadIds={queuedThreadIds}
               actions={actions}
             />
           )}
-        </div>
+        </section>
       </div>
-    </div>
+    </aside>
   )
 }

--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -272,19 +272,82 @@ function deduplicateDraftContentFromTextParts(
     })
 }
 
-export function ChatMessage({
-  message,
-  isStreaming = false,
-  onDraftTopic,
-}: ChatMessageProps) {
-  if (message.role === "user") {
-    return <UserMessageBubble message={message} />
-  }
+const EXCLUDED_PART_TYPES = new Set([
+  "thought",
+  "tool-call",
+  "tool_call",
+  "source-url",
+])
 
+function isOtherPart(
+  p: ChatUIMessage["parts"][number],
+  hasThoughtOrTools: boolean,
+): boolean {
+  if (EXCLUDED_PART_TYPES.has(p.type)) return false
+  if (p.type === "tool-web_search" && hasThoughtOrTools) return false
+  return true
+}
+
+function collectTools(parts: ChatUIMessage["parts"]): ToolCallItem[] {
+  const toolCallParts = parts.filter(
+    (p) => p.type === "tool-call" || p.type === "tool_call",
+  ) as ToolCallPart[]
+
+  return toolCallParts.map((tp, idx) => {
+    return (
+      tp.tool ?? {
+        id: tp.toolCallId || `tool-${idx}`,
+        name: tp.name || "tool",
+        state: tp.state || "completed",
+        input: tp.input,
+        output: tp.output,
+      }
+    )
+  })
+}
+
+function AssistantQueuedNotice({ status }: { status?: string }) {
+  if (status !== "queued") return null
+  return (
+    <div className="flex items-center gap-2 px-3.5 py-2 rounded-2xl bg-muted/40 border border-border/50 text-xs text-muted-foreground animate-pulse select-none">
+      <Clock className="size-3.5 text-muted-foreground/80 shrink-0" />
+      <span>Queued &bull; Waiting for active generation to finish...</span>
+    </div>
+  )
+}
+
+function AssistantMessageActions({
+  isStreaming,
+  assistantText,
+  createdAt,
+}: {
+  isStreaming: boolean
+  assistantText: string
+  createdAt?: string
+}) {
+  if (isStreaming || !assistantText) return null
+  return (
+    <ChatMessageActions
+      textToCopy={assistantText}
+      createdAt={createdAt}
+      align="start"
+      className="pl-2 pt-0.5"
+    />
+  )
+}
+
+function AssistantMessageBubble({
+  message,
+  isStreaming,
+  onDraftTopic,
+}: {
+  message: ChatUIMessage
+  isStreaming: boolean
+  onDraftTopic?: (topicTitle: string) => void
+}) {
   const { cleanedParts, extractedThought } = extractThoughtFromTextParts(
     message.parts,
   )
-
   const dedupedParts = deduplicateDraftContentFromTextParts(cleanedParts)
 
   const sources = dedupedParts.filter(
@@ -302,22 +365,7 @@ export function ChatMessage({
     extractedThought ||
     ""
 
-  const toolCallParts = cleanedParts.filter(
-    (p) => p.type === "tool-call" || p.type === "tool_call",
-  ) as ToolCallPart[]
-
-  const collectedTools: ToolCallItem[] = toolCallParts.map((tp, idx) => {
-    return (
-      tp.tool ?? {
-        id: tp.toolCallId || `tool-${idx}`,
-        name: tp.name || "tool",
-        state: tp.state || "completed",
-        input: tp.input,
-        output: tp.output,
-      }
-    )
-  })
-
+  const collectedTools = collectTools(cleanedParts)
   const webSearchPart = dedupedParts.find(
     (p): p is WebSearchToolPart => p.type === "tool-web_search",
   )
@@ -333,27 +381,15 @@ export function ChatMessage({
 
   const assistantText = extractTextParts(dedupedParts)
   const createdAt = getMessageTimestamp(message)
-
-  const otherParts = dedupedParts.filter((p) => {
-    if (p.type === "thought") return false
-    if (p.type === "tool-call" || p.type === "tool_call") return false
-    if (p.type === "source-url") return false
-    if (p.type === "tool-web_search" && hasThoughtOrTools) return false
-    return true
-  })
+  const otherParts = dedupedParts.filter((p) =>
+    isOtherPart(p, hasThoughtOrTools),
+  )
 
   return (
     <div className="group relative flex flex-col items-start w-full">
       <Message align="start">
         <MessageContent>
-          {message.status === "queued" && (
-            <div className="flex items-center gap-2 px-3.5 py-2 rounded-2xl bg-muted/40 border border-border/50 text-xs text-muted-foreground animate-pulse select-none">
-              <Clock className="size-3.5 text-muted-foreground/80 shrink-0" />
-              <span>
-                Queued &bull; Waiting for active generation to finish...
-              </span>
-            </div>
-          )}
+          <AssistantQueuedNotice status={message.status} />
 
           {hasThoughtOrTools && (
             <ThoughtPart
@@ -379,14 +415,29 @@ export function ChatMessage({
           ))}
         </MessageContent>
       </Message>
-      {!isStreaming && assistantText && (
-        <ChatMessageActions
-          textToCopy={assistantText}
-          createdAt={createdAt}
-          align="start"
-          className="pl-2 pt-0.5"
-        />
-      )}
+      <AssistantMessageActions
+        isStreaming={isStreaming}
+        assistantText={assistantText}
+        createdAt={createdAt}
+      />
     </div>
+  )
+}
+
+export function ChatMessage({
+  message,
+  isStreaming = false,
+  onDraftTopic,
+}: ChatMessageProps) {
+  if (message.role === "user") {
+    return <UserMessageBubble message={message} />
+  }
+
+  return (
+    <AssistantMessageBubble
+      message={message}
+      isStreaming={isStreaming}
+      onDraftTopic={onDraftTopic}
+    />
   )
 }

--- a/frontend/src/components/Chat/ChatMessage.tsx
+++ b/frontend/src/components/Chat/ChatMessage.tsx
@@ -1,16 +1,26 @@
+import { Clock } from "lucide-react"
 import { ChatMessageActions } from "@/components/Chat/ChatMessageActions"
 import { DraftArtifactCard } from "@/components/Chat/DraftArtifactCard"
 import { TextPart } from "@/components/Chat/parts/TextPart"
 import { ThoughtPart } from "@/components/Chat/parts/ThoughtPart"
 import { WebSearchPart } from "@/components/Chat/parts/WebSearchPart"
 import { ToolCallAccordion } from "@/components/Chat/ToolCallAccordion"
-import type { ChatUIMessage, SourceUrlPart } from "@/components/Chat/types"
+import { TrendingArtifactCard } from "@/components/Chat/TrendingArtifactCard"
+import type {
+  ChatUIMessage,
+  SourceUrlPart,
+  ThoughtPart as ThoughtPartType,
+  ToolCallItem,
+  ToolCallPart,
+  WebSearchToolPart,
+} from "@/components/Chat/types"
 import { Bubble, BubbleContent } from "@/components/ui/bubble"
 import { Message, MessageContent } from "@/components/ui/message"
 
 export interface ChatMessageProps {
   message: ChatUIMessage
   isStreaming?: boolean
+  onDraftTopic?: (topicTitle: string) => void
 }
 
 function extractTextParts(parts: ChatUIMessage["parts"]): string {
@@ -112,6 +122,7 @@ function renderToolOrDraftPart(
   part: ChatUIMessage["parts"][number],
   index: number,
   sources: SourceUrlPart[],
+  onDraftTopic?: (topicTitle: string) => void,
 ) {
   if (part.type === "tool-web_search") {
     return (
@@ -122,11 +133,19 @@ function renderToolOrDraftPart(
       />
     )
   }
-  if (part.type === "tool-call") {
+  if (part.type === "tool-call" || part.type === "tool_call") {
+    const toolPart = part as ToolCallPart
+    const toolItem: ToolCallItem = toolPart.tool ?? {
+      id: toolPart.toolCallId || `tool-${index}`,
+      name: toolPart.name || "tool",
+      state: toolPart.state || "completed",
+      input: toolPart.input,
+      output: toolPart.output,
+    }
     return (
       <ToolCallAccordion
-        key={part.toolCallId || `tool-${index}`}
-        toolCalls={[part.tool]}
+        key={toolItem.id || `tool-${index}`}
+        toolCalls={[toolItem]}
       />
     )
   }
@@ -135,6 +154,15 @@ function renderToolOrDraftPart(
       <DraftArtifactCard
         key={part.artifact.id || `draft-${index}`}
         artifact={part.artifact}
+      />
+    )
+  }
+  if (part.type === "trending_artifact") {
+    return (
+      <TrendingArtifactCard
+        key={`trending-${index}`}
+        artifact={part.artifact}
+        onDraftTopic={onDraftTopic}
       />
     )
   }
@@ -147,12 +175,14 @@ function AssistantPartRenderer({
   isStreaming,
   hasResponseStarted,
   sources,
+  onDraftTopic,
 }: {
   part: ChatUIMessage["parts"][number]
   index: number
   isStreaming: boolean
   hasResponseStarted: boolean
   sources: SourceUrlPart[]
+  onDraftTopic?: (topicTitle: string) => void
 }) {
   if (part.type === "thought") {
     return (
@@ -167,41 +197,176 @@ function AssistantPartRenderer({
   if (part.type === "text") {
     return <TextPart key={`text-${index}`} part={part} />
   }
-  return renderToolOrDraftPart(part, index, sources)
+  return renderToolOrDraftPart(part, index, sources, onDraftTopic)
+}
+
+function extractThoughtFromTextParts(parts: ChatUIMessage["parts"]): {
+  cleanedParts: ChatUIMessage["parts"]
+  extractedThought: string | null
+} {
+  let extractedThought: string | null = null
+  const cleanedParts = parts.map((part) => {
+    if (part.type === "text" && part.text) {
+      const match = /<thought>([\s\S]*?)<\/thought>/i.exec(part.text)
+      if (match) {
+        extractedThought = match[1].trim()
+        const cleanedText = part.text
+          .replace(/<thought>[\s\S]*?<\/thought>/gi, "")
+          .trim()
+        return { ...part, text: cleanedText }
+      }
+    }
+    return part
+  })
+  return { cleanedParts, extractedThought }
+}
+
+function deduplicateDraftContentFromTextParts(
+  parts: ChatUIMessage["parts"],
+): ChatUIMessage["parts"] {
+  const draftContents: string[] = []
+  for (const part of parts) {
+    if (part.type === "draft_artifact") {
+      const c = (part as any).artifact?.content || (part as any).content
+      if (typeof c === "string" && c.trim()) {
+        draftContents.push(c.trim())
+      }
+    }
+  }
+
+  if (draftContents.length === 0) return parts
+
+  return parts
+    .map((part) => {
+      if (part.type === "text" && part.text) {
+        let cleaned = part.text
+        for (const draftContent of draftContents) {
+          if (!draftContent) continue
+          if (cleaned.includes(draftContent)) {
+            cleaned = cleaned.split(draftContent).join("").trim()
+          } else {
+            const unquoted = draftContent.replace(/^["']|["']$/g, "").trim()
+            if (unquoted && cleaned.includes(unquoted)) {
+              cleaned = cleaned.split(unquoted).join("").trim()
+            }
+          }
+        }
+        cleaned = cleaned
+          .replace(
+            /^(?:Here(?:'s| is) (?:a|the) (?:polished )?(?:X|LinkedIn|draft|post)[\w\s]*:?)/i,
+            "",
+          )
+          .replace(/^(?:Saved as (?:a )?draft\.?)/i, "")
+          .replace(/(?:Saved as (?:a )?draft\.?)$/i, "")
+          .replace(/^["'\s]+|["'\s]+$/g, "")
+          .trim()
+        return { ...part, text: cleaned }
+      }
+      return part
+    })
+    .filter((part) => {
+      if (part.type === "text") {
+        return Boolean(part.text?.trim())
+      }
+      return true
+    })
 }
 
 export function ChatMessage({
   message,
   isStreaming = false,
+  onDraftTopic,
 }: ChatMessageProps) {
   if (message.role === "user") {
     return <UserMessageBubble message={message} />
   }
 
-  const sources = message.parts.filter(
+  const { cleanedParts, extractedThought } = extractThoughtFromTextParts(
+    message.parts,
+  )
+
+  const dedupedParts = deduplicateDraftContentFromTextParts(cleanedParts)
+
+  const sources = dedupedParts.filter(
     (part): part is SourceUrlPart => part.type === "source-url",
   )
 
-  const hasThoughtPart = message.parts.some((p) => p.type === "thought")
-  const hasResponseStarted = message.parts.some(
+  const thoughtParts = dedupedParts.filter(
+    (p): p is ThoughtPartType => p.type === "thought",
+  )
+  const combinedThought =
+    thoughtParts
+      .map((p) => p.content)
+      .filter(Boolean)
+      .join("\n\n") ||
+    extractedThought ||
+    ""
+
+  const toolCallParts = cleanedParts.filter(
+    (p) => p.type === "tool-call" || p.type === "tool_call",
+  ) as ToolCallPart[]
+
+  const collectedTools: ToolCallItem[] = toolCallParts.map((tp, idx) => {
+    return (
+      tp.tool ?? {
+        id: tp.toolCallId || `tool-${idx}`,
+        name: tp.name || "tool",
+        state: tp.state || "completed",
+        input: tp.input,
+        output: tp.output,
+      }
+    )
+  })
+
+  const webSearchPart = dedupedParts.find(
+    (p): p is WebSearchToolPart => p.type === "tool-web_search",
+  )
+
+  const hasResponseStarted = dedupedParts.some(
     (p) => p.type === "text" && Boolean(p.text?.trim()),
   )
-  const assistantText = extractTextParts(message.parts)
+
+  const hasThoughtOrTools =
+    Boolean(combinedThought) ||
+    collectedTools.length > 0 ||
+    (isStreaming && !hasResponseStarted)
+
+  const assistantText = extractTextParts(dedupedParts)
   const createdAt = getMessageTimestamp(message)
+
+  const otherParts = dedupedParts.filter((p) => {
+    if (p.type === "thought") return false
+    if (p.type === "tool-call" || p.type === "tool_call") return false
+    if (p.type === "source-url") return false
+    if (p.type === "tool-web_search" && hasThoughtOrTools) return false
+    return true
+  })
 
   return (
     <div className="group relative flex flex-col items-start w-full">
       <Message align="start">
         <MessageContent>
-          {isStreaming && !hasThoughtPart && !hasResponseStarted && (
+          {message.status === "queued" && (
+            <div className="flex items-center gap-2 px-3.5 py-2 rounded-2xl bg-muted/40 border border-border/50 text-xs text-muted-foreground animate-pulse select-none">
+              <Clock className="size-3.5 text-muted-foreground/80 shrink-0" />
+              <span>
+                Queued &bull; Waiting for active generation to finish...
+              </span>
+            </div>
+          )}
+
+          {hasThoughtOrTools && (
             <ThoughtPart
-              part={{ type: "thought", content: "" }}
-              isStreaming={true}
-              hasResponseStarted={false}
+              content={combinedThought}
+              toolCalls={collectedTools}
+              webSearchPart={webSearchPart}
+              sources={sources}
+              isStreaming={isStreaming}
+              hasResponseStarted={hasResponseStarted}
             />
           )}
 
-          {message.parts.map((part, index) => (
+          {otherParts.map((part, index) => (
             <AssistantPartRenderer
               key={index}
               part={part}
@@ -209,6 +374,7 @@ export function ChatMessage({
               isStreaming={isStreaming}
               hasResponseStarted={hasResponseStarted}
               sources={sources}
+              onDraftTopic={onDraftTopic}
             />
           ))}
         </MessageContent>

--- a/frontend/src/components/Chat/DraftArtifactCard.tsx
+++ b/frontend/src/components/Chat/DraftArtifactCard.tsx
@@ -1,189 +1,157 @@
-import {
-  CalendarIcon,
-  CheckIcon,
-  CopyIcon,
-  PenToolIcon,
-  SendIcon,
-} from "lucide-react"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import * as React from "react"
+import { PostsService } from "@/client"
 import type { DraftArtifact } from "@/components/Chat/types"
-import { Button } from "@/components/ui/button"
+import type { Platform } from "@/components/Common/PlatformSelector"
+import { DraftPost, type DraftPostData } from "@/components/Post/DraftPost"
+import { PostPreviewDialog } from "@/components/Post/Previews"
+import type { PreviewPostData } from "@/components/Post/Previews/LinkedInPostPreview"
+import useAuth from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import { cn } from "@/lib/utils"
 
 export interface DraftArtifactCardProps {
   artifact: DraftArtifact
+  author?: { name: string; username: string; avatarUrl?: string | null }
   onSchedule?: (artifact: DraftArtifact) => void
   onSendToComposer?: (artifact: DraftArtifact) => void
   onPublish?: (artifact: DraftArtifact) => void
+  onDelete?: (artifact: DraftArtifact) => void
+  onPreview?: (artifact: DraftArtifact) => void
   className?: string
-}
-
-function PlatformTabs({
-  selected,
-  onSelect,
-}: {
-  selected: "x" | "linkedin" | "linkx" | "all"
-  onSelect: (p: "x" | "linkedin" | "linkx" | "all") => void
-}) {
-  return (
-    <div className="flex items-center rounded-lg bg-muted/40 p-0.5 border border-border/50">
-      {(["linkx", "x", "linkedin"] as const).map((p) => (
-        <button
-          key={p}
-          type="button"
-          onClick={() => onSelect(p)}
-          className={`px-2 py-0.5 rounded-md text-[11px] font-medium transition-colors cursor-pointer uppercase ${
-            selected === p
-              ? "bg-background text-foreground shadow-2xs font-semibold"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          {p === "linkx" ? "Both" : p}
-        </button>
-      ))}
-    </div>
-  )
-}
-
-function DraftActions({
-  artifact,
-  copied,
-  onCopy,
-  onSendToComposer,
-  onSchedule,
-  onPublish,
-}: {
-  artifact: DraftArtifact
-  copied: boolean
-  onCopy: () => void
-  onSendToComposer?: (artifact: DraftArtifact) => void
-  onSchedule?: (artifact: DraftArtifact) => void
-  onPublish?: (artifact: DraftArtifact) => void
-}) {
-  return (
-    <div className="flex items-center gap-1.5">
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={onCopy}
-        className="h-7 px-2 text-[11px] rounded-lg cursor-pointer"
-        aria-label="Copy text"
-      >
-        {copied ? (
-          <CheckIcon className="h-3 w-3 text-emerald-500 mr-1" />
-        ) : (
-          <CopyIcon className="h-3 w-3 mr-1" />
-        )}
-        {copied ? "Copied" : "Copy"}
-      </Button>
-
-      {onSendToComposer && (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => onSendToComposer(artifact)}
-          className="h-7 px-2 text-[11px] rounded-lg cursor-pointer"
-          aria-label="Send to Composer"
-        >
-          Send to Composer
-        </Button>
-      )}
-
-      {onSchedule && (
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => onSchedule(artifact)}
-          className="h-7 px-2 text-[11px] rounded-lg cursor-pointer"
-          aria-label="Schedule"
-        >
-          <CalendarIcon className="h-3 w-3 mr-1 text-primary" />
-          Schedule
-        </Button>
-      )}
-
-      {onPublish && (
-        <Button
-          type="button"
-          size="sm"
-          onClick={() => onPublish(artifact)}
-          className="h-7 px-2.5 text-[11px] rounded-lg bg-primary text-primary-foreground font-semibold cursor-pointer hover:bg-primary/90"
-          aria-label="Publish"
-        >
-          <SendIcon className="h-3 w-3 mr-1" />
-          Publish
-        </Button>
-      )}
-    </div>
-  )
 }
 
 export function DraftArtifactCard({
   artifact,
-  onSchedule,
+  author,
+  onSchedule: _onSchedule,
   onSendToComposer,
   onPublish,
+  onDelete,
+  onPreview,
   className,
 }: DraftArtifactCardProps) {
-  const [copied, setCopied] = React.useState(false)
-  const [selectedPlatform, setSelectedPlatform] = React.useState<
-    "x" | "linkedin" | "linkx" | "all"
-  >(artifact.platform || "linkx")
+  const { user } = useAuth()
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const [previewOpen, setPreviewOpen] = React.useState(false)
 
-  const charCount = artifact.content ? artifact.content.length : 0
-  const maxLimit = selectedPlatform === "x" ? 280 : 3000
+  const [currentPlatform, setCurrentPlatform] = React.useState<Platform>(
+    (artifact.platform === "all"
+      ? "linkx"
+      : artifact.platform || "linkx") as Platform,
+  )
 
-  const handleCopy = async () => {
-    if (!artifact.content) return
-    await navigator.clipboard.writeText(artifact.content)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
+  React.useEffect(() => {
+    if (artifact.platform) {
+      setCurrentPlatform(
+        (artifact.platform === "all" ? "linkx" : artifact.platform) as Platform,
+      )
+    }
+  }, [artifact.platform])
+
+  const postAuthor = React.useMemo(() => {
+    if (author) return author
+    const name =
+      user?.full_name || (user?.email ? user.email.split("@")[0] : "Ashwath N")
+    const username = user?.email ? user.email.split("@")[0] : "admin"
+    return {
+      name,
+      username,
+    }
+  }, [author, user])
+
+  const publishMutation = useMutation({
+    mutationFn: async (postId: string) =>
+      PostsService.publishExistingPost({ postId }),
+    onSuccess: () => {
+      showSuccessToast("Post published successfully!")
+      queryClient.invalidateQueries({ queryKey: ["posts"] })
+    },
+    onError: () => {
+      showErrorToast("Failed to publish post")
+    },
+  })
+
+  const handlePublish = React.useCallback(
+    (postId: string) => {
+      if (onPublish) {
+        onPublish(artifact)
+      } else if (postId && postId !== "draft-artifact") {
+        publishMutation.mutate(postId)
+      }
+    },
+    [artifact, onPublish, publishMutation],
+  )
+
+  const handlePreview = React.useCallback(
+    (_postId?: string) => {
+      setPreviewOpen(true)
+      onPreview?.(artifact)
+    },
+    [artifact, onPreview],
+  )
+
+  const handleEdit = React.useCallback(
+    (_postId: string) => {
+      onSendToComposer?.(artifact)
+    },
+    [artifact, onSendToComposer],
+  )
+
+  const handleDelete = React.useCallback(
+    (_postId: string) => {
+      onDelete?.(artifact)
+    },
+    [artifact, onDelete],
+  )
+
+  const postData: DraftPostData = React.useMemo(() => {
+    return {
+      id: artifact.id || artifact.postId || "draft-artifact",
+      author: postAuthor,
+      content: artifact.content,
+      createdAt: new Date().toISOString(),
+      platform: currentPlatform,
+      status: "draft",
+      type: "draft",
+    }
+  }, [artifact, postAuthor, currentPlatform])
+
+  const previewData: PreviewPostData = React.useMemo(() => {
+    return {
+      id: postData.id,
+      author: {
+        name: postData.author.name,
+        username: postData.author.username,
+        avatarUrl: postData.author.avatarUrl ?? undefined,
+      },
+      content: postData.content,
+      imageUrl: postData.imageUrl ?? undefined,
+      createdAt: postData.createdAt,
+      likes: postData.likes,
+      reposts: postData.reposts,
+      comments: postData.comments,
+    }
+  }, [postData])
 
   return (
-    <div
-      className={`w-full max-w-xl mx-auto my-3 rounded-2xl border border-primary/30 bg-card p-4 shadow-sm text-xs flex flex-col gap-3 transition-all ${
-        className || ""
-      }`}
-    >
-      <div className="flex items-center justify-between border-b border-border/60 pb-2.5">
-        <div className="flex items-center gap-1.5 font-semibold text-foreground">
-          <PenToolIcon className="h-3.5 w-3.5 text-primary" />
-          <span>Drafted Post</span>
-        </div>
-        <PlatformTabs
-          selected={selectedPlatform}
-          onSelect={setSelectedPlatform}
-        />
-      </div>
-
-      <div className="rounded-xl bg-muted/20 border border-border/40 p-3 text-foreground text-xs leading-relaxed whitespace-pre-wrap font-sans">
-        {artifact.content}
-      </div>
-
-      <div className="flex items-center justify-between pt-1 text-muted-foreground">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-[11px]">
-            {charCount} / {maxLimit} chars
-          </span>
-          {charCount > maxLimit && (
-            <span className="text-destructive font-semibold">
-              Exceeds limit
-            </span>
-          )}
-        </div>
-
-        <DraftActions
-          artifact={artifact}
-          copied={copied}
-          onCopy={handleCopy}
-          onSendToComposer={onSendToComposer}
-          onSchedule={onSchedule}
-          onPublish={onPublish}
-        />
-      </div>
+    <div className={cn("w-full", className)}>
+      <DraftPost
+        post={postData}
+        onPlatformChange={(_, p) => setCurrentPlatform(p)}
+        onPublish={handlePublish}
+        onPreview={handlePreview}
+        onEdit={onSendToComposer ? handleEdit : undefined}
+        onDelete={onDelete ? handleDelete : undefined}
+        isPublishing={publishMutation.isPending}
+      />
+      <PostPreviewDialog
+        open={previewOpen}
+        onOpenChange={setPreviewOpen}
+        post={previewData}
+        platform={currentPlatform}
+      />
     </div>
   )
 }

--- a/frontend/src/components/Chat/DraftArtifactCard.tsx
+++ b/frontend/src/components/Chat/DraftArtifactCard.tsx
@@ -21,6 +21,76 @@ export interface DraftArtifactCardProps {
   className?: string
 }
 
+function resolveInitialPlatform(platform?: string): Platform {
+  if (!platform || platform === "all") return "linkx"
+  return platform as Platform
+}
+
+function resolvePostAuthor(
+  author?: { name: string; username: string; avatarUrl?: string | null },
+  user?: { full_name?: string | null; email?: string | null } | null,
+) {
+  if (author) return author
+  const emailPrefix = user?.email ? user.email.split("@")[0] : ""
+  const name = user?.full_name || emailPrefix || "Ashwath N"
+  const username = emailPrefix || "admin"
+  return { name, username }
+}
+
+function createDraftPostData({
+  artifact,
+  author,
+  platform,
+}: {
+  artifact: DraftArtifact
+  author: { name: string; username: string; avatarUrl?: string | null }
+  platform: Platform
+}): DraftPostData {
+  return {
+    id: artifact.id || artifact.postId || "draft-artifact",
+    author,
+    content: artifact.content,
+    createdAt: new Date().toISOString(),
+    platform,
+    status: "draft",
+    type: "draft",
+  }
+}
+
+function createPreviewPostData(post: DraftPostData): PreviewPostData {
+  return {
+    id: post.id,
+    author: {
+      name: post.author.name,
+      username: post.author.username,
+      avatarUrl: post.author.avatarUrl ?? undefined,
+    },
+    content: post.content,
+    imageUrl: post.imageUrl ?? undefined,
+    createdAt: post.createdAt,
+    likes: post.likes,
+    reposts: post.reposts,
+    comments: post.comments,
+  }
+}
+
+function usePublishPostMutation() {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (postId: string) =>
+      PostsService.publishExistingPost({ postId }),
+    onSuccess: () => {
+      showSuccessToast("Post published successfully!")
+      queryClient.invalidateQueries({ queryKey: ["posts"] })
+    },
+    onError: () => {
+      showErrorToast("Failed to publish post")
+    },
+  })
+}
+
 export function DraftArtifactCard({
   artifact,
   author,
@@ -32,108 +102,56 @@ export function DraftArtifactCard({
   className,
 }: DraftArtifactCardProps) {
   const { user } = useAuth()
-  const queryClient = useQueryClient()
-  const { showSuccessToast, showErrorToast } = useCustomToast()
   const [previewOpen, setPreviewOpen] = React.useState(false)
-
-  const [currentPlatform, setCurrentPlatform] = React.useState<Platform>(
-    (artifact.platform === "all"
-      ? "linkx"
-      : artifact.platform || "linkx") as Platform,
+  const [currentPlatform, setCurrentPlatform] = React.useState<Platform>(() =>
+    resolveInitialPlatform(artifact.platform),
   )
 
   React.useEffect(() => {
     if (artifact.platform) {
-      setCurrentPlatform(
-        (artifact.platform === "all" ? "linkx" : artifact.platform) as Platform,
-      )
+      setCurrentPlatform(resolveInitialPlatform(artifact.platform))
     }
   }, [artifact.platform])
 
-  const postAuthor = React.useMemo(() => {
-    if (author) return author
-    const name =
-      user?.full_name || (user?.email ? user.email.split("@")[0] : "Ashwath N")
-    const username = user?.email ? user.email.split("@")[0] : "admin"
-    return {
-      name,
-      username,
-    }
-  }, [author, user])
+  const postAuthor = React.useMemo(
+    () => resolvePostAuthor(author, user),
+    [author, user],
+  )
 
-  const publishMutation = useMutation({
-    mutationFn: async (postId: string) =>
-      PostsService.publishExistingPost({ postId }),
-    onSuccess: () => {
-      showSuccessToast("Post published successfully!")
-      queryClient.invalidateQueries({ queryKey: ["posts"] })
-    },
-    onError: () => {
-      showErrorToast("Failed to publish post")
-    },
-  })
+  const publishMutation = usePublishPostMutation()
 
   const handlePublish = React.useCallback(
     (postId: string) => {
       if (onPublish) {
         onPublish(artifact)
-      } else if (postId && postId !== "draft-artifact") {
+        return
+      }
+      if (postId && postId !== "draft-artifact") {
         publishMutation.mutate(postId)
       }
     },
     [artifact, onPublish, publishMutation],
   )
 
-  const handlePreview = React.useCallback(
-    (_postId?: string) => {
-      setPreviewOpen(true)
-      onPreview?.(artifact)
-    },
-    [artifact, onPreview],
+  const handlePreview = React.useCallback(() => {
+    setPreviewOpen(true)
+    onPreview?.(artifact)
+  }, [artifact, onPreview])
+
+  const postData = React.useMemo(
+    () =>
+      createDraftPostData({
+        artifact,
+        author: postAuthor,
+        platform: currentPlatform,
+      }),
+    [artifact, postAuthor, currentPlatform],
   )
 
-  const handleEdit = React.useCallback(
-    (_postId: string) => {
-      onSendToComposer?.(artifact)
-    },
-    [artifact, onSendToComposer],
+  const previewData = React.useMemo(
+    () => createPreviewPostData(postData),
+    [postData],
   )
-
-  const handleDelete = React.useCallback(
-    (_postId: string) => {
-      onDelete?.(artifact)
-    },
-    [artifact, onDelete],
-  )
-
-  const postData: DraftPostData = React.useMemo(() => {
-    return {
-      id: artifact.id || artifact.postId || "draft-artifact",
-      author: postAuthor,
-      content: artifact.content,
-      createdAt: new Date().toISOString(),
-      platform: currentPlatform,
-      status: "draft",
-      type: "draft",
-    }
-  }, [artifact, postAuthor, currentPlatform])
-
-  const previewData: PreviewPostData = React.useMemo(() => {
-    return {
-      id: postData.id,
-      author: {
-        name: postData.author.name,
-        username: postData.author.username,
-        avatarUrl: postData.author.avatarUrl ?? undefined,
-      },
-      content: postData.content,
-      imageUrl: postData.imageUrl ?? undefined,
-      createdAt: postData.createdAt,
-      likes: postData.likes,
-      reposts: postData.reposts,
-      comments: postData.comments,
-    }
-  }, [postData])
 
   return (
     <div className={cn("w-full", className)}>
@@ -142,8 +160,8 @@ export function DraftArtifactCard({
         onPlatformChange={(_, p) => setCurrentPlatform(p)}
         onPublish={handlePublish}
         onPreview={handlePreview}
-        onEdit={onSendToComposer ? handleEdit : undefined}
-        onDelete={onDelete ? handleDelete : undefined}
+        onEdit={onSendToComposer ? () => onSendToComposer(artifact) : undefined}
+        onDelete={onDelete ? () => onDelete(artifact) : undefined}
         isPublishing={publishMutation.isPending}
       />
       <PostPreviewDialog

--- a/frontend/src/components/Chat/ToolCallAccordion.tsx
+++ b/frontend/src/components/Chat/ToolCallAccordion.tsx
@@ -5,6 +5,7 @@ import {
   XCircleIcon,
 } from "lucide-react"
 import * as React from "react"
+import { getToolIcon } from "@/components/Chat/parts/ThoughtPart"
 import type { ToolCallItem } from "@/components/Chat/types"
 
 export interface ToolCallAccordionProps {
@@ -31,24 +32,28 @@ function ToolStatusIcon({ state }: { state: ToolCallItem["state"] }) {
 
 function ToolCallDetails({ tool }: { tool: ToolCallItem }) {
   return (
-    <div className="border-t border-border/60 bg-muted/20 p-3 flex flex-col gap-2 font-mono text-[11px] overflow-x-auto">
+    <div className="border-t border-border/60 bg-zinc-950 dark:bg-black text-zinc-200 p-3 flex flex-col gap-2 font-mono text-[11px] overflow-x-auto">
       {tool.input && (
         <div>
-          <span className="font-semibold text-muted-foreground block mb-0.5">
-            Input:
-          </span>
-          <pre className="text-foreground bg-background/80 rounded-lg p-2 border border-border/50 overflow-x-auto">
-            {JSON.stringify(tool.input, null, 2)}
+          <div className="text-zinc-500 text-[10px] uppercase tracking-wider mb-1 flex items-center gap-1.5 font-mono">
+            <span className="text-emerald-400">$</span> input:
+          </div>
+          <pre className="text-zinc-300 pl-2.5 border-l border-zinc-800 whitespace-pre-wrap break-words overflow-x-auto">
+            {typeof tool.input === "string"
+              ? tool.input
+              : JSON.stringify(tool.input, null, 2)}
           </pre>
         </div>
       )}
       {tool.output && (
         <div>
-          <span className="font-semibold text-muted-foreground block mb-0.5">
-            Output:
-          </span>
-          <pre className="text-foreground bg-background/80 rounded-lg p-2 border border-border/50 overflow-x-auto">
-            {JSON.stringify(tool.output, null, 2)}
+          <div className="text-zinc-500 text-[10px] uppercase tracking-wider mb-1 flex items-center gap-1.5 font-mono">
+            <span className="text-blue-400">➜</span> output:
+          </div>
+          <pre className="text-zinc-300 pl-2.5 border-l border-zinc-800 whitespace-pre-wrap break-words overflow-x-auto">
+            {typeof tool.output === "string"
+              ? tool.output
+              : JSON.stringify(tool.output, null, 2)}
           </pre>
         </div>
       )}
@@ -65,8 +70,10 @@ function ToolCallCard({
   isExpanded: boolean
   onToggle: () => void
 }) {
+  const IconComponent = getToolIcon(tool.name)
+
   return (
-    <div className="rounded-xl border border-border/80 bg-card/60 overflow-hidden text-xs transition-all shadow-2xs">
+    <div className="rounded-xl border border-border/80 bg-zinc-950/5 dark:bg-zinc-950/40 overflow-hidden text-xs transition-all shadow-2xs font-mono">
       <button
         type="button"
         onClick={onToggle}
@@ -74,6 +81,7 @@ function ToolCallCard({
         className="flex w-full items-center justify-between px-3 py-2 text-left hover:bg-muted/40 transition-colors cursor-pointer"
       >
         <div className="flex items-center gap-2 min-w-0">
+          <IconComponent className="size-3.5 text-muted-foreground/80 shrink-0" />
           <ToolStatusIcon state={tool.state} />
           <span className="font-semibold text-foreground truncate">
             {tool.state === "running" ? `Executing ${tool.name}…` : tool.name}

--- a/frontend/src/components/Chat/TrendingArtifactCard.tsx
+++ b/frontend/src/components/Chat/TrendingArtifactCard.tsx
@@ -1,0 +1,144 @@
+import { ExternalLink, Flame, Sparkles } from "lucide-react"
+import type {
+  TrendingArtifact,
+  TrendingTopicItem,
+} from "@/components/Chat/types"
+import { Button } from "@/components/ui/button"
+
+export interface TrendingArtifactCardProps {
+  artifact: TrendingArtifact
+  onDraftTopic?: (topicTitle: string) => void
+  className?: string
+}
+
+function formatPostCount(count?: number | null): string {
+  if (!count) return ""
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1)}M posts`
+  }
+  if (count >= 1_000) {
+    return `${count.toLocaleString()} posts`
+  }
+  return `${count} posts`
+}
+
+function formatCategory(category?: string | null): string {
+  if (!category) return "Trending"
+  const cat = category.trim()
+  if (cat.toLowerCase().includes("trending")) return cat
+  return `${cat} · Trending`
+}
+
+function TopicRow({
+  topic,
+  index,
+  onDraft,
+}: {
+  topic: TrendingTopicItem
+  index: number
+  onDraft?: () => void
+}) {
+  const postCount = formatPostCount(topic.post_count)
+
+  return (
+    <div className="flex flex-col gap-1.5 p-3 rounded-xl border border-border/40 bg-background/50 hover:bg-muted/30 transition-colors">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+          #{index + 1} · {formatCategory(topic.category)}
+        </span>
+        {postCount && (
+          <span className="text-[11px] text-muted-foreground font-mono">
+            {postCount}
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          {topic.topic_url ? (
+            <a
+              href={topic.topic_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 font-semibold text-sm text-foreground hover:text-primary transition-colors line-clamp-2"
+            >
+              <span>{topic.topic_title}</span>
+              <ExternalLink className="h-3 w-3 shrink-0 opacity-60" />
+            </a>
+          ) : (
+            <span className="font-semibold text-sm text-foreground line-clamp-2">
+              {topic.topic_title}
+            </span>
+          )}
+
+          {topic.summary && (
+            <p className="text-xs text-muted-foreground mt-1 line-clamp-2 leading-relaxed">
+              {topic.summary}
+            </p>
+          )}
+        </div>
+
+        {onDraft && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onDraft}
+            className="shrink-0 h-7 text-xs gap-1.5 rounded-lg border-primary/30 hover:border-primary hover:bg-primary/10 hover:text-primary transition-colors cursor-pointer"
+            title={`Draft post about "${topic.topic_title}"`}
+          >
+            <Sparkles className="h-3 w-3 text-primary" />
+            <span>Draft</span>
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function TrendingArtifactCard({
+  artifact,
+  onDraftTopic,
+  className = "",
+}: TrendingArtifactCardProps) {
+  const topics = artifact?.topics ?? []
+  if (topics.length === 0) return null
+
+  return (
+    <div
+      className={`w-full max-w-2xl rounded-2xl border border-border/80 bg-card p-4 shadow-sm flex flex-col gap-3 my-2 ${className}`}
+    >
+      <div className="flex items-center justify-between border-b border-border/40 pb-2.5">
+        <div className="flex items-center gap-2">
+          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-orange-500/10 text-orange-500">
+            <Flame className="h-4 w-4" />
+          </div>
+          <div>
+            <h3 className="text-sm font-bold text-foreground">
+              Trending Topics from X
+            </h3>
+            <p className="text-[11px] text-muted-foreground">
+              Freshly extracted live from Explore
+            </p>
+          </div>
+        </div>
+        <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-primary/10 text-primary">
+          {topics.length} trends
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {topics.map((topic, idx) => (
+          <TopicRow
+            key={topic.id || `topic-${idx}`}
+            topic={topic}
+            index={idx}
+            onDraft={
+              onDraftTopic ? () => onDraftTopic(topic.topic_title) : undefined
+            }
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Chat/__tests__/ChatMessage.test.tsx
+++ b/frontend/src/components/Chat/__tests__/ChatMessage.test.tsx
@@ -1,7 +1,21 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 import { ChatMessage } from "../ChatMessage"
 import type { ChatUIMessage } from "../types"
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  )
+}
 
 describe("ChatMessage component", () => {
   it("renders user message in an end-aligned bubble", () => {
@@ -138,5 +152,75 @@ describe("ChatMessage component", () => {
     // Trigger image loading error
     fireEvent.error(img)
     expect(img).toHaveStyle({ display: "none" })
+  })
+
+  it("extracts thought tags embedded in text and renders thinking accordion", () => {
+    const message: ChatUIMessage = {
+      id: "msg-thought-tags",
+      role: "assistant",
+      parts: [
+        {
+          type: "text",
+          text: "<thought>Keep the response brief, friendly, and establish role.</thought>\n\nI'm LinkX Copilot — your AI assistant.",
+        },
+      ],
+    }
+
+    render(<ChatMessage message={message} />)
+    // Thought content is in the thinking accordion, not rendered as raw tags
+    expect(screen.queryByText(/<thought>/)).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/I'm LinkX Copilot — your AI assistant\./),
+    ).toBeInTheDocument()
+    // Thinking summary button is visible
+    expect(
+      screen.getByRole("button", { name: /toggle thinking details/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/thought for 2 seconds/i)).toBeInTheDocument()
+  })
+
+  it("deduplicates draft post text repeated in assistant text parts", () => {
+    const postText =
+      "Raghav Chadha has accused Punjab AAP of a 'voter roll vendetta' after his electoral shift."
+    const message: ChatUIMessage = {
+      id: "msg-draft-duplicate",
+      role: "assistant",
+      parts: [
+        {
+          type: "draft_artifact",
+          artifact: {
+            id: "draft-1",
+            content: postText,
+            platform: "x",
+            status: "draft",
+          },
+        },
+        {
+          type: "text",
+          text: `Here's a polished X draft:\n\n${postText}\n\nSaved as a draft.`,
+        },
+      ],
+    }
+
+    renderWithClient(<ChatMessage message={message} />)
+    const matches = screen.getAllByText(new RegExp(postText))
+    expect(matches).toHaveLength(1)
+    expect(
+      screen.queryByText(/Here's a polished X draft/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders queued indicator when assistant message status is queued", () => {
+    const message: ChatUIMessage = {
+      id: "msg-queued",
+      role: "assistant",
+      parts: [],
+      status: "queued",
+    }
+
+    renderWithClient(<ChatMessage message={message} />)
+    expect(
+      screen.getByText(/Queued • Waiting for active generation to finish.../i),
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/Chat/__tests__/DraftArtifactCard.test.tsx
+++ b/frontend/src/components/Chat/__tests__/DraftArtifactCard.test.tsx
@@ -1,7 +1,21 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { DraftArtifactCard } from "../DraftArtifactCard"
 import type { DraftArtifact } from "../types"
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  )
+}
 
 describe("DraftArtifactCard component", () => {
   const artifact: DraftArtifact = {
@@ -13,40 +27,45 @@ describe("DraftArtifactCard component", () => {
     characterCount: 92,
   }
 
-  it("renders drafted post content and character count", () => {
-    render(<DraftArtifactCard artifact={artifact} />)
+  it("renders drafted post content and default user author", () => {
+    renderWithClient(<DraftArtifactCard artifact={artifact} />)
     expect(
       screen.getByText(/Excited to announce the new LinkX AI Copilot release!/),
     ).toBeInTheDocument()
-    expect(screen.getByText(/92 \/ 3000 chars/)).toBeInTheDocument()
+    expect(screen.getByText(/Ashwath N/)).toBeInTheDocument()
+    expect(screen.getByText(/@admin/)).toBeInTheDocument()
   })
 
-  it("fires action button callbacks when clicked", () => {
-    const handleSchedule = vi.fn()
-    const handleSendToComposer = vi.fn()
-    const handlePublish = vi.fn()
-
-    render(
+  it("renders custom author when provided", () => {
+    renderWithClient(
       <DraftArtifactCard
         artifact={artifact}
-        onSchedule={handleSchedule}
-        onSendToComposer={handleSendToComposer}
-        onPublish={handlePublish}
+        author={{ name: "Jane Doe", username: "janedoe" }}
       />,
     )
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument()
+    expect(screen.getByText(/@janedoe/)).toBeInTheDocument()
+  })
 
-    const scheduleBtn = screen.getByRole("button", { name: /schedule/i })
-    fireEvent.click(scheduleBtn)
-    expect(handleSchedule).toHaveBeenCalledWith(artifact)
+  it("renders more options and platform selector buttons", () => {
+    renderWithClient(<DraftArtifactCard artifact={artifact} />)
 
-    const composerBtn = screen.getByRole("button", {
-      name: /send to composer/i,
-    })
-    fireEvent.click(composerBtn)
-    expect(handleSendToComposer).toHaveBeenCalledWith(artifact)
+    const moreBtn = screen.getByRole("button", { name: /more options/i })
+    expect(moreBtn).toBeInTheDocument()
 
-    const publishBtn = screen.getByRole("button", { name: /publish/i })
-    fireEvent.click(publishBtn)
-    expect(handlePublish).toHaveBeenCalledWith(artifact)
+    const selectXBtn = screen.getByRole("button", { name: /select x/i })
+    expect(selectXBtn).toBeInTheDocument()
+    fireEvent.click(selectXBtn)
+    expect(selectXBtn).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("supports onPreview callback", () => {
+    const handlePreview = vi.fn()
+    renderWithClient(
+      <DraftArtifactCard artifact={artifact} onPreview={handlePreview} />,
+    )
+
+    const moreBtn = screen.getByRole("button", { name: /more options/i })
+    expect(moreBtn).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/Chat/__tests__/ThoughtPart.test.tsx
+++ b/frontend/src/components/Chat/__tests__/ThoughtPart.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
-import { ThoughtPart } from "../parts/ThoughtPart"
+import { getToolIcon, ThoughtPart } from "../parts/ThoughtPart"
 
 describe("ThoughtPart component", () => {
   it("renders thinking state when streaming", () => {
@@ -23,7 +23,7 @@ describe("ThoughtPart component", () => {
         isStreaming={false}
       />,
     )
-    expect(screen.getByText("Thinking…")).toBeInTheDocument()
+    expect(screen.getByText(/thought for|worked for/i)).toBeInTheDocument()
     // Collapsed by default
     expect(
       screen.queryByText(/Selected LinkedIn hook pattern/),
@@ -43,20 +43,73 @@ describe("ThoughtPart component", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("renders markdown formatting inside expanded thought content", () => {
-    const { container } = render(
+  it("renders worked for X seconds with tool calls and allows viewing tool payload", () => {
+    render(
       <ThoughtPart
-        part={{
-          type: "thought",
-          content: "Here is **critical reasoning** step.",
-        }}
-        isStreaming={true}
-        hasResponseStarted={false}
+        content="Analyzed the database state"
+        toolCalls={[
+          {
+            id: "t-1",
+            name: "get_latest_scraped_trends",
+            state: "completed",
+            durationMs: 180,
+            input: { limit: 10 },
+            output: { count: 8 },
+          },
+        ]}
+        isStreaming={false}
+        durationSeconds={3}
       />,
     )
 
-    const strongEl = container.querySelector("strong")
-    expect(strongEl).toBeDefined()
-    expect(strongEl?.textContent).toBe("critical reasoning")
+    expect(screen.getByText("Worked for 3 seconds")).toBeInTheDocument()
+
+    // Click toggle to expand dropdown
+    const toggleButton = screen.getByRole("button", {
+      name: /toggle thinking details/i,
+    })
+    fireEvent.click(toggleButton)
+
+    expect(screen.getByText("get_latest_scraped_trends")).toBeInTheDocument()
+    expect(screen.getByText("(180ms)")).toBeInTheDocument()
+    expect(screen.getByText(/Analyzed the database state/)).toBeInTheDocument()
+
+    // Expand tool payload details
+    const viewDetailsBtn = screen.getByRole("button", {
+      name: /toggle tool payload details/i,
+    })
+    fireEvent.click(viewDetailsBtn)
+    expect(screen.getByText(/"limit": 10/)).toBeInTheDocument()
+    expect(screen.getByText(/"count": 8/)).toBeInTheDocument()
+  })
+
+  it("maps tool calls to appropriate icons using the icon dictionary", () => {
+    // Database
+    expect(getToolIcon("get_latest_scraped_trends")).toBeDefined()
+    expect(getToolIcon("get_topic_tweets_and_summary")).toBeDefined()
+    expect(getToolIcon("save_draft_post")).toBeDefined()
+    expect(getToolIcon("update_draft_post")).toBeDefined()
+    // Validation
+    expect(getToolIcon("validate_post_constraints")).toBeDefined()
+    // Web / Scraper
+    expect(getToolIcon("scrape_live_explore_trends")).toBeDefined()
+    expect(getToolIcon("web_search")).toBeDefined()
+    // Draft
+    expect(getToolIcon("draft_social_post")).toBeDefined()
+    // Fallback
+    expect(getToolIcon("unknown_tool")).toBeDefined()
+
+    // Validate that validation icon is distinct from draft icon
+    expect(getToolIcon("validate_post_constraints")).not.toBe(
+      getToolIcon("draft_social_post"),
+    )
+    // Validate database icon (save_draft_post) is distinct from draft authoring icon (draft_social_post)
+    expect(getToolIcon("save_draft_post")).not.toBe(
+      getToolIcon("draft_social_post"),
+    )
+    // Validate save_draft_post shares the Database icon with get_latest_scraped_trends
+    expect(getToolIcon("save_draft_post")).toBe(
+      getToolIcon("get_latest_scraped_trends"),
+    )
   })
 })

--- a/frontend/src/components/Chat/__tests__/TrendingArtifactCard.test.tsx
+++ b/frontend/src/components/Chat/__tests__/TrendingArtifactCard.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { TrendingArtifactCard } from "../TrendingArtifactCard"
+import type { TrendingArtifact } from "../types"
+
+describe("TrendingArtifactCard component", () => {
+  const artifact: TrendingArtifact = {
+    topics: [
+      {
+        id: "trend-1",
+        topic_title: "AI Agents Revolutionize Social Media",
+        category: "Technology",
+        post_count: 45200,
+        summary:
+          "Autonomous multi-agent systems are managing content pipelines.",
+        topic_url: "https://x.com/search?q=AI%20Agents",
+      },
+      {
+        id: "trend-2",
+        topic_title: "Solo FNCS Kickoff",
+        category: "Gaming",
+        post_count: 12000,
+      },
+    ],
+    count: 2,
+  }
+
+  it("renders trending topics list with titles and post count badges", () => {
+    render(<TrendingArtifactCard artifact={artifact} />)
+
+    expect(
+      screen.getByText("AI Agents Revolutionize Social Media"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Solo FNCS Kickoff")).toBeInTheDocument()
+    expect(screen.getByText("45,200 posts")).toBeInTheDocument()
+    expect(screen.getByText("12,000 posts")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Autonomous multi-agent systems are managing content pipelines.",
+      ),
+    ).toBeInTheDocument()
+    expect(screen.getByText("2 trends")).toBeInTheDocument()
+  })
+
+  it("fires onDraftTopic callback when Draft button is clicked", () => {
+    const handleDraft = vi.fn()
+    render(
+      <TrendingArtifactCard artifact={artifact} onDraftTopic={handleDraft} />,
+    )
+
+    const draftButtons = screen.getAllByRole("button", { name: /draft/i })
+    expect(draftButtons.length).toBe(2)
+
+    fireEvent.click(draftButtons[0])
+    expect(handleDraft).toHaveBeenCalledWith(
+      "AI Agents Revolutionize Social Media",
+    )
+  })
+
+  it("renders null if topics array is empty", () => {
+    const { container } = render(
+      <TrendingArtifactCard artifact={{ topics: [] }} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/components/Chat/parts/ThoughtPart.tsx
+++ b/frontend/src/components/Chat/parts/ThoughtPart.tsx
@@ -1,17 +1,38 @@
-import { ChevronDown, Loader2 } from "lucide-react"
+import {
+  Calendar,
+  CheckCheck,
+  ChevronDown,
+  Database,
+  Globe,
+  Loader2,
+  Search,
+  ShieldCheck,
+  SquarePen,
+  SquareTerminal,
+} from "lucide-react"
 import * as React from "react"
 import ReactMarkdown from "react-markdown"
 import remarkBreaks from "remark-breaks"
 import remarkGfm from "remark-gfm"
 
-import type { ThoughtPart as ThoughtPartType } from "@/components/Chat/types"
+import type {
+  SourceUrlPart,
+  ThoughtPart as ThoughtPartType,
+  ToolCallItem,
+  WebSearchToolPart,
+} from "@/components/Chat/types"
 import { completeStreamingMarkdown } from "@/lib/markdown-stream"
 import { cn } from "@/lib/utils"
 
 export interface ThoughtPartProps {
-  part: ThoughtPartType
+  part?: ThoughtPartType
+  content?: string
+  toolCalls?: ToolCallItem[]
+  webSearchPart?: WebSearchToolPart
+  sources?: SourceUrlPart[]
   isStreaming?: boolean
   hasResponseStarted?: boolean
+  durationSeconds?: number
   className?: string
 }
 
@@ -44,50 +65,344 @@ function ThoughtContent({ content }: { content?: string }) {
   )
 }
 
-function shouldRenderThought(
-  hasContent: boolean,
-  isStreaming: boolean,
-  hasResponseStarted: boolean,
-): boolean {
-  if (hasContent) {
-    return true
+/**
+ * Explicit dictionary mapping tool names and categories to their dedicated icons.
+ */
+export const TOOL_ICON_DICTIONARY: Record<
+  string,
+  React.ComponentType<{ className?: string }>
+> = {
+  // Database / Data Store tools
+  get_latest_scraped_trends: Database,
+  get_topic_tweets_and_summary: Database,
+  get_recent_post_history: Database,
+  save_draft_post: Database,
+  update_draft_post: Database,
+  database: Database,
+  db: Database,
+
+  // Validation / Constraints / Rules tools
+  validate_post_constraints: CheckCheck,
+  validate: CheckCheck,
+  validation: CheckCheck,
+  constraints: CheckCheck,
+
+  // Web / Scraper tools
+  scrape_live_explore_trends: Globe,
+  scrape_topic_timeline: Globe,
+  web_search: Search,
+  web: Globe,
+  scrape: Globe,
+  browser: Globe,
+
+  // Draft / Post authoring tools
+  draft_social_post: SquarePen,
+  draft: SquarePen,
+  composer: SquarePen,
+
+  // Scheduling tools
+  schedule_post_in_db: Calendar,
+  schedule: Calendar,
+
+  // Account / Authentication tools
+  get_social_account_status: ShieldCheck,
+  account: ShieldCheck,
+
+  // Terminal / Execution / CLI tools
+  terminal: SquareTerminal,
+  bash: SquareTerminal,
+  exec: SquareTerminal,
+}
+
+export function getToolIcon(
+  name: string,
+): React.ComponentType<{ className?: string }> {
+  const normalized = name.trim().toLowerCase()
+
+  // 1. Direct dictionary match
+  if (TOOL_ICON_DICTIONARY[normalized]) {
+    return TOOL_ICON_DICTIONARY[normalized]
   }
-  return isStreaming && !hasResponseStarted
+
+  // 2. Exact match on prefixes/categories in precedence order:
+  // Validation must be checked before "post" so "validate_post_constraints" gets CheckCheck
+  if (
+    normalized.includes("validate") ||
+    normalized.includes("constraint") ||
+    normalized.includes("rule") ||
+    normalized.includes("check")
+  ) {
+    return CheckCheck
+  }
+
+  // Database / Data Store tools (saving, storing, or querying DB)
+  if (
+    normalized.includes("save") ||
+    normalized.includes("store") ||
+    normalized.includes("db") ||
+    normalized.includes("trend") ||
+    normalized.includes("topic") ||
+    normalized.includes("history") ||
+    normalized.includes("query")
+  ) {
+    return Database
+  }
+
+  // Web & scraping tools
+  if (
+    normalized.includes("scrape") ||
+    normalized.includes("web") ||
+    normalized.includes("search") ||
+    normalized.includes("explore")
+  ) {
+    return Globe
+  }
+
+  // Schedule tools
+  if (normalized.includes("schedule") || normalized.includes("calendar")) {
+    return Calendar
+  }
+
+  // Account tools
+  if (
+    normalized.includes("account") ||
+    normalized.includes("auth") ||
+    normalized.includes("login")
+  ) {
+    return ShieldCheck
+  }
+
+  // Draft tools
+  if (
+    normalized.includes("draft") ||
+    normalized.includes("compose") ||
+    normalized.includes("post")
+  ) {
+    return SquarePen
+  }
+
+  return SquareTerminal
+}
+
+function TerminalToolCallRow({ tool }: { tool: ToolCallItem }) {
+  const [detailsExpanded, setDetailsExpanded] = React.useState(false)
+  const hasPayload = Boolean(tool.input || tool.output)
+  const IconComponent = getToolIcon(tool.name)
+
+  return (
+    <div className="flex flex-col w-full text-xs">
+      <button
+        type="button"
+        onClick={() => hasPayload && setDetailsExpanded((prev) => !prev)}
+        disabled={!hasPayload}
+        aria-label="Toggle tool payload details"
+        className={cn(
+          "group flex w-full items-center justify-between gap-3 px-2 py-1.5 rounded-md text-muted-foreground transition-colors text-left",
+          hasPayload
+            ? "hover:bg-muted/40 hover:text-foreground cursor-pointer select-none"
+            : "cursor-default",
+        )}
+      >
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <IconComponent className="size-3.5 shrink-0 text-muted-foreground/80 group-hover:text-foreground transition-colors" />
+          <span className="text-foreground/90 font-normal truncate">
+            {tool.name}
+          </span>
+          {tool.state === "running" && (
+            <Loader2 className="size-3 animate-spin text-muted-foreground shrink-0" />
+          )}
+          {tool.durationMs !== undefined && (
+            <span className="text-[11px] text-muted-foreground/60 font-mono shrink-0">
+              ({tool.durationMs}ms)
+            </span>
+          )}
+        </div>
+
+        {hasPayload && (
+          <div className="flex items-center justify-center shrink-0 pr-0.5">
+            <ChevronDown
+              className={cn(
+                "size-4 text-muted-foreground/80 group-hover:text-foreground transition-transform duration-200 shrink-0",
+                detailsExpanded && "rotate-180",
+              )}
+            />
+          </div>
+        )}
+      </button>
+
+      {hasPayload && detailsExpanded && (
+        <div className="mt-1 ml-4 rounded-md bg-muted/30 border border-border/40 p-2 font-mono text-[11px] text-muted-foreground space-y-1.5 animate-in fade-in-0 duration-150 overflow-x-auto">
+          {tool.input && (
+            <div>
+              <div className="text-[10px] text-muted-foreground/70 uppercase tracking-wider mb-0.5 font-mono">
+                Input
+              </div>
+              <pre className="text-foreground/80 pl-2 border-l border-border/60 whitespace-pre-wrap break-words">
+                {typeof tool.input === "string"
+                  ? tool.input
+                  : JSON.stringify(tool.input, null, 2)}
+              </pre>
+            </div>
+          )}
+          {tool.output && (
+            <div>
+              <div className="text-[10px] text-muted-foreground/70 uppercase tracking-wider mb-0.5 font-mono">
+                Output
+              </div>
+              <pre className="text-foreground/80 pl-2 border-l border-border/60 whitespace-pre-wrap break-words">
+                {typeof tool.output === "string"
+                  ? tool.output
+                  : JSON.stringify(tool.output, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function WebSearchSection({
+  query,
+  sources,
+  errorText,
+}: {
+  query?: string
+  sources: SourceUrlPart[]
+  errorText?: string
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 text-xs w-full">
+      {query && (
+        <div className="flex items-start gap-2 text-xs text-muted-foreground leading-relaxed break-words">
+          <Globe className="size-3.5 mt-0.5 shrink-0 text-muted-foreground/80" />
+          <div className="flex-1 break-words">
+            Ran search{" "}
+            <span className="text-foreground font-medium">"{query}"</span>
+          </div>
+        </div>
+      )}
+      {sources.map((src, i) => {
+        let hostname = ""
+        try {
+          hostname = new URL(src.url).hostname
+        } catch {
+          hostname = src.url
+        }
+        return (
+          <a
+            key={src.sourceId || i}
+            href={src.url}
+            target="_blank"
+            rel="noreferrer"
+            className="group flex items-start gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors leading-relaxed break-words"
+          >
+            <Globe className="size-3.5 mt-0.5 shrink-0 text-muted-foreground/80 group-hover:text-primary transition-colors" />
+            <div className="flex-1 break-words">
+              Ran fetch{" "}
+              <span className="text-foreground font-medium group-hover:text-primary group-hover:underline underline-offset-2 transition-colors">
+                {hostname}
+              </span>
+              {src.title ? ` · ${src.title}` : ""}
+            </div>
+          </a>
+        )
+      })}
+      {errorText && (
+        <p className="py-0.5 text-xs text-destructive break-words">
+          Command failed: {errorText}
+        </p>
+      )}
+    </div>
+  )
 }
 
 export function ThoughtPart({
   part,
+  content: directContent,
+  toolCalls = [],
+  webSearchPart,
+  sources = [],
   isStreaming = false,
   hasResponseStarted = false,
+  durationSeconds,
   className,
 }: ThoughtPartProps) {
   const [manualExpanded, setManualExpanded] = React.useState<boolean | null>(
     null,
   )
 
+  const isThinking = isStreaming && !hasResponseStarted
+  const rawContent = directContent ?? part?.content ?? ""
+  const hasContent = Boolean(rawContent.trim())
+  const hasTools = toolCalls.length > 0
+  const hasWebSearch = Boolean(webSearchPart)
+
+  // Live elapsed timer for thinking/working phase
+  const [startTime] = React.useState<number>(() => Date.now())
+  const [elapsedSeconds, setElapsedSeconds] = React.useState<number>(
+    () => durationSeconds ?? 0,
+  )
+
+  React.useEffect(() => {
+    if (!isThinking) return
+    const interval = setInterval(() => {
+      setElapsedSeconds(
+        Math.max(1, Math.round((Date.now() - startTime) / 1000)),
+      )
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [isThinking, startTime])
+
+  const totalToolMs = React.useMemo(
+    () => toolCalls.reduce((acc, t) => acc + (t.durationMs || 0), 0),
+    [toolCalls],
+  )
+
+  const finalDuration = React.useMemo(() => {
+    if (durationSeconds !== undefined && durationSeconds > 0) {
+      return durationSeconds
+    }
+    if (elapsedSeconds > 0) {
+      return elapsedSeconds
+    }
+    if (totalToolMs > 0) {
+      return Math.max(1, Math.round(totalToolMs / 1000))
+    }
+    return 2
+  }, [durationSeconds, elapsedSeconds, totalToolMs])
+
   const isExpanded = resolveExpandedState(
     manualExpanded,
     isStreaming,
     hasResponseStarted,
   )
-  const hasContent = Boolean(part.content?.trim())
 
-  if (!shouldRenderThought(hasContent, isStreaming, hasResponseStarted)) {
+  const shouldRender = hasContent || hasTools || hasWebSearch || isThinking
+
+  if (!shouldRender) {
     return null
   }
 
+  const unit = finalDuration === 1 ? "second" : "seconds"
+  const labelText = isThinking
+    ? "Thinking…"
+    : hasTools
+      ? `Worked for ${finalDuration} ${unit}`
+      : `Thought for ${finalDuration} ${unit}`
+
   return (
-    <div className={cn("my-1 flex flex-col items-start w-full", className)}>
+    <div className={cn("my-1.5 flex flex-col items-start w-full", className)}>
       <button
         type="button"
         onClick={() => setManualExpanded(!isExpanded)}
         aria-label="Toggle thinking details"
         className="flex items-center gap-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer font-medium select-none"
       >
-        {isStreaming && (
+        {isThinking && (
           <Loader2 className="size-3.5 animate-spin text-muted-foreground shrink-0" />
         )}
-        <span>Thinking…</span>
+        <span>{labelText}</span>
         <ChevronDown
           className={cn(
             "size-3.5 text-muted-foreground transition-transform duration-200 shrink-0",
@@ -97,8 +412,49 @@ export function ThoughtPart({
       </button>
 
       {isExpanded && (
-        <div className="mt-1 ml-1.5 flex flex-col gap-1.5 border-l border-border/50 pl-3 py-1 text-xs w-full animate-in fade-in-0 duration-150">
-          <ThoughtContent content={part.content} />
+        <div className="mt-1.5 ml-1.5 flex flex-col gap-2.5 border-l border-border/50 pl-3 py-1 text-xs w-full animate-in fade-in-0 duration-150">
+          {/* Tool call command executions */}
+          {hasTools && (
+            <div className="flex flex-col gap-2 w-full">
+              {toolCalls.map((tool, idx) => (
+                <TerminalToolCallRow
+                  key={tool.id || `${tool.name}-${idx}`}
+                  tool={tool}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Web search section */}
+          {hasWebSearch && (
+            <WebSearchSection
+              query={webSearchPart?.input?.query}
+              sources={sources}
+              errorText={
+                webSearchPart?.state === "output-error"
+                  ? webSearchPart.errorText || "Web search failed"
+                  : undefined
+              }
+            />
+          )}
+
+          {/* Markdown Thought Reasoning */}
+          {hasContent && (
+            <div
+              className={cn(
+                "text-xs w-full",
+                (hasTools || hasWebSearch) &&
+                  "pt-1.5 border-t border-border/30",
+              )}
+            >
+              {(hasTools || hasWebSearch) && (
+                <div className="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-wider mb-1 font-mono">
+                  Reasoning
+                </div>
+              )}
+              <ThoughtContent content={rawContent} />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/Chat/parts/ThoughtPart.tsx
+++ b/frontend/src/components/Chat/parts/ThoughtPart.tsx
@@ -36,11 +36,17 @@ export interface ThoughtPartProps {
   className?: string
 }
 
-function resolveExpandedState(
-  manualExpanded: boolean | null,
-  isStreaming: boolean,
-  hasResponseStarted: boolean,
-): boolean {
+interface ResolveExpandedOptions {
+  manualExpanded: boolean | null
+  isStreaming: boolean
+  hasResponseStarted: boolean
+}
+
+function resolveExpandedState({
+  manualExpanded,
+  isStreaming,
+  hasResponseStarted,
+}: ResolveExpandedOptions): boolean {
   if (manualExpanded !== null) {
     return manualExpanded
   }
@@ -64,6 +70,21 @@ function ThoughtContent({ content }: { content?: string }) {
     </div>
   )
 }
+
+const CATEGORY_MATCHERS: Array<{
+  keywords: string[]
+  icon: React.ComponentType<{ className?: string }>
+}> = [
+  { keywords: ["validate", "constraint", "rule", "check"], icon: CheckCheck },
+  {
+    keywords: ["save", "store", "db", "trend", "topic", "history", "query"],
+    icon: Database,
+  },
+  { keywords: ["scrape", "web", "search", "explore"], icon: Globe },
+  { keywords: ["schedule", "calendar"], icon: Calendar },
+  { keywords: ["account", "auth", "login"], icon: ShieldCheck },
+  { keywords: ["draft", "compose", "post"], icon: SquarePen },
+]
 
 /**
  * Explicit dictionary mapping tool names and categories to their dedicated icons.
@@ -118,147 +139,159 @@ export function getToolIcon(
   name: string,
 ): React.ComponentType<{ className?: string }> {
   const normalized = name.trim().toLowerCase()
-
-  // 1. Direct dictionary match
   if (TOOL_ICON_DICTIONARY[normalized]) {
     return TOOL_ICON_DICTIONARY[normalized]
   }
+  const matched = CATEGORY_MATCHERS.find((cat) =>
+    cat.keywords.some((kw) => normalized.includes(kw)),
+  )
+  return matched ? matched.icon : SquareTerminal
+}
 
-  // 2. Exact match on prefixes/categories in precedence order:
-  // Validation must be checked before "post" so "validate_post_constraints" gets CheckCheck
-  if (
-    normalized.includes("validate") ||
-    normalized.includes("constraint") ||
-    normalized.includes("rule") ||
-    normalized.includes("check")
-  ) {
-    return CheckCheck
-  }
+function ToolPayloadSection({
+  label,
+  value,
+}: {
+  label: string
+  value: unknown
+}) {
+  if (!value) return null
+  const content =
+    typeof value === "string" ? value : JSON.stringify(value, null, 2)
+  return (
+    <div>
+      <div className="text-[10px] text-muted-foreground/70 uppercase tracking-wider mb-0.5 font-mono">
+        {label}
+      </div>
+      <pre className="text-foreground/80 pl-2 border-l border-border/60 whitespace-pre-wrap break-words">
+        {content}
+      </pre>
+    </div>
+  )
+}
 
-  // Database / Data Store tools (saving, storing, or querying DB)
-  if (
-    normalized.includes("save") ||
-    normalized.includes("store") ||
-    normalized.includes("db") ||
-    normalized.includes("trend") ||
-    normalized.includes("topic") ||
-    normalized.includes("history") ||
-    normalized.includes("query")
-  ) {
-    return Database
-  }
+function ToolPayloadViewer({
+  input,
+  output,
+}: {
+  input?: unknown
+  output?: unknown
+}) {
+  return (
+    <div className="mt-1 ml-4 rounded-md bg-muted/30 border border-border/40 p-2 font-mono text-[11px] text-muted-foreground space-y-1.5 animate-in fade-in-0 duration-150 overflow-x-auto">
+      <ToolPayloadSection label="Input" value={input} />
+      <ToolPayloadSection label="Output" value={output} />
+    </div>
+  )
+}
 
-  // Web & scraping tools
-  if (
-    normalized.includes("scrape") ||
-    normalized.includes("web") ||
-    normalized.includes("search") ||
-    normalized.includes("explore")
-  ) {
-    return Globe
-  }
+function TerminalToolHeader({
+  name,
+  hasPayload,
+  detailsExpanded,
+  state,
+  durationMs,
+  onToggle,
+}: {
+  name: string
+  hasPayload: boolean
+  detailsExpanded: boolean
+  state?: string
+  durationMs?: number
+  onToggle: () => void
+}) {
+  const IconComponent = getToolIcon(name)
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={!hasPayload}
+      aria-label="Toggle tool payload details"
+      className={cn(
+        "group flex w-full items-center justify-between gap-3 px-2 py-1.5 rounded-md text-muted-foreground transition-colors text-left",
+        hasPayload
+          ? "hover:bg-muted/40 hover:text-foreground cursor-pointer select-none"
+          : "cursor-default",
+      )}
+    >
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <IconComponent className="size-3.5 shrink-0 text-muted-foreground/80 group-hover:text-foreground transition-colors" />
+        <span className="text-foreground/90 font-normal truncate">{name}</span>
+        {state === "running" && (
+          <Loader2 className="size-3 animate-spin text-muted-foreground shrink-0" />
+        )}
+        {durationMs !== undefined && (
+          <span className="text-[11px] text-muted-foreground/60 font-mono shrink-0">
+            ({durationMs}ms)
+          </span>
+        )}
+      </div>
 
-  // Schedule tools
-  if (normalized.includes("schedule") || normalized.includes("calendar")) {
-    return Calendar
-  }
-
-  // Account tools
-  if (
-    normalized.includes("account") ||
-    normalized.includes("auth") ||
-    normalized.includes("login")
-  ) {
-    return ShieldCheck
-  }
-
-  // Draft tools
-  if (
-    normalized.includes("draft") ||
-    normalized.includes("compose") ||
-    normalized.includes("post")
-  ) {
-    return SquarePen
-  }
-
-  return SquareTerminal
+      {hasPayload && (
+        <div className="flex items-center justify-center shrink-0 pr-0.5">
+          <ChevronDown
+            className={cn(
+              "size-4 text-muted-foreground/80 group-hover:text-foreground transition-transform duration-200 shrink-0",
+              detailsExpanded && "rotate-180",
+            )}
+          />
+        </div>
+      )}
+    </button>
+  )
 }
 
 function TerminalToolCallRow({ tool }: { tool: ToolCallItem }) {
   const [detailsExpanded, setDetailsExpanded] = React.useState(false)
   const hasPayload = Boolean(tool.input || tool.output)
-  const IconComponent = getToolIcon(tool.name)
+
+  const handleToggle = React.useCallback(() => {
+    if (hasPayload) {
+      setDetailsExpanded((prev) => !prev)
+    }
+  }, [hasPayload])
 
   return (
     <div className="flex flex-col w-full text-xs">
-      <button
-        type="button"
-        onClick={() => hasPayload && setDetailsExpanded((prev) => !prev)}
-        disabled={!hasPayload}
-        aria-label="Toggle tool payload details"
-        className={cn(
-          "group flex w-full items-center justify-between gap-3 px-2 py-1.5 rounded-md text-muted-foreground transition-colors text-left",
-          hasPayload
-            ? "hover:bg-muted/40 hover:text-foreground cursor-pointer select-none"
-            : "cursor-default",
-        )}
-      >
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <IconComponent className="size-3.5 shrink-0 text-muted-foreground/80 group-hover:text-foreground transition-colors" />
-          <span className="text-foreground/90 font-normal truncate">
-            {tool.name}
-          </span>
-          {tool.state === "running" && (
-            <Loader2 className="size-3 animate-spin text-muted-foreground shrink-0" />
-          )}
-          {tool.durationMs !== undefined && (
-            <span className="text-[11px] text-muted-foreground/60 font-mono shrink-0">
-              ({tool.durationMs}ms)
-            </span>
-          )}
-        </div>
-
-        {hasPayload && (
-          <div className="flex items-center justify-center shrink-0 pr-0.5">
-            <ChevronDown
-              className={cn(
-                "size-4 text-muted-foreground/80 group-hover:text-foreground transition-transform duration-200 shrink-0",
-                detailsExpanded && "rotate-180",
-              )}
-            />
-          </div>
-        )}
-      </button>
-
+      <TerminalToolHeader
+        name={tool.name}
+        hasPayload={hasPayload}
+        detailsExpanded={detailsExpanded}
+        state={tool.state}
+        durationMs={tool.durationMs}
+        onToggle={handleToggle}
+      />
       {hasPayload && detailsExpanded && (
-        <div className="mt-1 ml-4 rounded-md bg-muted/30 border border-border/40 p-2 font-mono text-[11px] text-muted-foreground space-y-1.5 animate-in fade-in-0 duration-150 overflow-x-auto">
-          {tool.input && (
-            <div>
-              <div className="text-[10px] text-muted-foreground/70 uppercase tracking-wider mb-0.5 font-mono">
-                Input
-              </div>
-              <pre className="text-foreground/80 pl-2 border-l border-border/60 whitespace-pre-wrap break-words">
-                {typeof tool.input === "string"
-                  ? tool.input
-                  : JSON.stringify(tool.input, null, 2)}
-              </pre>
-            </div>
-          )}
-          {tool.output && (
-            <div>
-              <div className="text-[10px] text-muted-foreground/70 uppercase tracking-wider mb-0.5 font-mono">
-                Output
-              </div>
-              <pre className="text-foreground/80 pl-2 border-l border-border/60 whitespace-pre-wrap break-words">
-                {typeof tool.output === "string"
-                  ? tool.output
-                  : JSON.stringify(tool.output, null, 2)}
-              </pre>
-            </div>
-          )}
-        </div>
+        <ToolPayloadViewer input={tool.input} output={tool.output} />
       )}
     </div>
+  )
+}
+
+function WebSearchItem({ src, index }: { src: SourceUrlPart; index: number }) {
+  let hostname = ""
+  try {
+    hostname = new URL(src.url).hostname
+  } catch {
+    hostname = src.url
+  }
+  return (
+    <a
+      key={src.sourceId || index}
+      href={src.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group flex items-start gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors leading-relaxed break-words"
+    >
+      <Globe className="size-3.5 mt-0.5 shrink-0 text-muted-foreground/80 group-hover:text-primary transition-colors" />
+      <div className="flex-1 break-words">
+        Ran fetch{" "}
+        <span className="text-foreground font-medium group-hover:text-primary group-hover:underline underline-offset-2 transition-colors">
+          {hostname}
+        </span>
+        {src.title ? ` · ${src.title}` : ""}
+      </div>
+    </a>
   )
 }
 
@@ -282,38 +315,221 @@ function WebSearchSection({
           </div>
         </div>
       )}
-      {sources.map((src, i) => {
-        let hostname = ""
-        try {
-          hostname = new URL(src.url).hostname
-        } catch {
-          hostname = src.url
-        }
-        return (
-          <a
-            key={src.sourceId || i}
-            href={src.url}
-            target="_blank"
-            rel="noreferrer"
-            className="group flex items-start gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors leading-relaxed break-words"
-          >
-            <Globe className="size-3.5 mt-0.5 shrink-0 text-muted-foreground/80 group-hover:text-primary transition-colors" />
-            <div className="flex-1 break-words">
-              Ran fetch{" "}
-              <span className="text-foreground font-medium group-hover:text-primary group-hover:underline underline-offset-2 transition-colors">
-                {hostname}
-              </span>
-              {src.title ? ` · ${src.title}` : ""}
-            </div>
-          </a>
-        )
-      })}
+      {sources.map((src, i) => (
+        <WebSearchItem key={src.sourceId || i} src={src} index={i} />
+      ))}
       {errorText && (
         <p className="py-0.5 text-xs text-destructive break-words">
           Command failed: {errorText}
         </p>
       )}
     </div>
+  )
+}
+
+function computeFinalDuration({
+  durationSeconds,
+  elapsedSeconds,
+  totalToolMs,
+}: {
+  durationSeconds?: number
+  elapsedSeconds: number
+  totalToolMs: number
+}): number {
+  if (durationSeconds !== undefined && durationSeconds > 0) {
+    return durationSeconds
+  }
+  if (elapsedSeconds > 0) {
+    return elapsedSeconds
+  }
+  if (totalToolMs > 0) {
+    return Math.max(1, Math.round(totalToolMs / 1000))
+  }
+  return 2
+}
+
+interface DurationLabelOptions {
+  isThinking: boolean
+  hasTools: boolean
+  finalDuration: number
+}
+
+function getDurationLabel({
+  isThinking,
+  hasTools,
+  finalDuration,
+}: DurationLabelOptions): string {
+  if (isThinking) return "Thinking…"
+  const unit = finalDuration === 1 ? "second" : "seconds"
+  return hasTools
+    ? `Worked for ${finalDuration} ${unit}`
+    : `Thought for ${finalDuration} ${unit}`
+}
+
+interface CanRenderOptions {
+  hasContent: boolean
+  hasTools: boolean
+  hasWebSearch: boolean
+  isThinking: boolean
+}
+
+function canRenderThought({
+  hasContent,
+  hasTools,
+  hasWebSearch,
+  isThinking,
+}: CanRenderOptions): boolean {
+  if (isThinking) return true
+  if (hasContent) return true
+  if (hasTools) return true
+  return hasWebSearch
+}
+
+function ThoughtReasoningSection({
+  hasContent,
+  hasPriorSection,
+  rawContent,
+}: {
+  hasContent: boolean
+  hasPriorSection: boolean
+  rawContent: string
+}) {
+  if (!hasContent) return null
+  return (
+    <div
+      className={cn(
+        "text-xs w-full",
+        hasPriorSection && "pt-1.5 border-t border-border/30",
+      )}
+    >
+      {hasPriorSection && (
+        <div className="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-wider mb-1 font-mono">
+          Reasoning
+        </div>
+      )}
+      <ThoughtContent content={rawContent} />
+    </div>
+  )
+}
+
+function ThoughtToolList({ toolCalls }: { toolCalls: ToolCallItem[] }) {
+  if (toolCalls.length === 0) return null
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      {toolCalls.map((tool, idx) => (
+        <TerminalToolCallRow
+          key={tool.id || `${tool.name}-${idx}`}
+          tool={tool}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ThoughtExpandedBody({
+  toolCalls,
+  webSearchPart,
+  sources,
+  hasContent,
+  rawContent,
+}: {
+  toolCalls: ToolCallItem[]
+  webSearchPart?: WebSearchToolPart
+  sources: SourceUrlPart[]
+  hasContent: boolean
+  rawContent: string
+}) {
+  const hasWebSearch = Boolean(webSearchPart)
+  const hasTools = toolCalls.length > 0
+  const hasPriorSection = hasTools || hasWebSearch
+  const searchError =
+    webSearchPart?.state === "output-error"
+      ? webSearchPart.errorText || "Web search failed"
+      : undefined
+
+  return (
+    <div className="mt-1.5 ml-1.5 flex flex-col gap-2.5 border-l border-border/50 pl-3 py-1 text-xs w-full animate-in fade-in-0 duration-150">
+      <ThoughtToolList toolCalls={toolCalls} />
+      {hasWebSearch && (
+        <WebSearchSection
+          query={webSearchPart?.input?.query}
+          sources={sources}
+          errorText={searchError}
+        />
+      )}
+      <ThoughtReasoningSection
+        hasContent={hasContent}
+        hasPriorSection={hasPriorSection}
+        rawContent={rawContent}
+      />
+    </div>
+  )
+}
+
+function useThinkingTimer({
+  isThinking,
+  durationSeconds,
+}: {
+  isThinking: boolean
+  durationSeconds?: number
+}): number {
+  const [startTime] = React.useState<number>(() => Date.now())
+  const [elapsedSeconds, setElapsedSeconds] = React.useState<number>(
+    () => durationSeconds ?? 0,
+  )
+
+  React.useEffect(() => {
+    if (!isThinking) return
+    const interval = setInterval(() => {
+      setElapsedSeconds(
+        Math.max(1, Math.round((Date.now() - startTime) / 1000)),
+      )
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [isThinking, startTime])
+
+  return elapsedSeconds
+}
+
+function useTotalToolDuration(toolCalls: ToolCallItem[]): number {
+  return React.useMemo(() => {
+    let sum = 0
+    for (const t of toolCalls) {
+      sum += t.durationMs || 0
+    }
+    return sum
+  }, [toolCalls])
+}
+
+function ThoughtHeaderButton({
+  isThinking,
+  labelText,
+  isExpanded,
+  onToggle,
+}: {
+  isThinking: boolean
+  labelText: string
+  isExpanded: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label="Toggle thinking details"
+      className="flex items-center gap-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer font-medium select-none"
+    >
+      {isThinking && (
+        <Loader2 className="size-3.5 animate-spin text-muted-foreground shrink-0" />
+      )}
+      <span>{labelText}</span>
+      <ChevronDown
+        className={cn(
+          "size-3.5 text-muted-foreground transition-transform duration-200 shrink-0",
+          !isExpanded && "-rotate-90",
+        )}
+      />
+    </button>
   )
 }
 
@@ -338,124 +554,52 @@ export function ThoughtPart({
   const hasTools = toolCalls.length > 0
   const hasWebSearch = Boolean(webSearchPart)
 
-  // Live elapsed timer for thinking/working phase
-  const [startTime] = React.useState<number>(() => Date.now())
-  const [elapsedSeconds, setElapsedSeconds] = React.useState<number>(
-    () => durationSeconds ?? 0,
+  const elapsedSeconds = useThinkingTimer({ isThinking, durationSeconds })
+  const totalToolMs = useTotalToolDuration(toolCalls)
+
+  const finalDuration = React.useMemo(
+    () =>
+      computeFinalDuration({
+        durationSeconds,
+        elapsedSeconds,
+        totalToolMs,
+      }),
+    [durationSeconds, elapsedSeconds, totalToolMs],
   )
 
-  React.useEffect(() => {
-    if (!isThinking) return
-    const interval = setInterval(() => {
-      setElapsedSeconds(
-        Math.max(1, Math.round((Date.now() - startTime) / 1000)),
-      )
-    }, 1000)
-    return () => clearInterval(interval)
-  }, [isThinking, startTime])
-
-  const totalToolMs = React.useMemo(
-    () => toolCalls.reduce((acc, t) => acc + (t.durationMs || 0), 0),
-    [toolCalls],
-  )
-
-  const finalDuration = React.useMemo(() => {
-    if (durationSeconds !== undefined && durationSeconds > 0) {
-      return durationSeconds
-    }
-    if (elapsedSeconds > 0) {
-      return elapsedSeconds
-    }
-    if (totalToolMs > 0) {
-      return Math.max(1, Math.round(totalToolMs / 1000))
-    }
-    return 2
-  }, [durationSeconds, elapsedSeconds, totalToolMs])
-
-  const isExpanded = resolveExpandedState(
+  const isExpanded = resolveExpandedState({
     manualExpanded,
     isStreaming,
     hasResponseStarted,
-  )
+  })
 
-  const shouldRender = hasContent || hasTools || hasWebSearch || isThinking
-
-  if (!shouldRender) {
+  if (!canRenderThought({ hasContent, hasTools, hasWebSearch, isThinking })) {
     return null
   }
 
-  const unit = finalDuration === 1 ? "second" : "seconds"
-  const labelText = isThinking
-    ? "Thinking…"
-    : hasTools
-      ? `Worked for ${finalDuration} ${unit}`
-      : `Thought for ${finalDuration} ${unit}`
+  const labelText = getDurationLabel({
+    isThinking,
+    hasTools,
+    finalDuration,
+  })
 
   return (
     <div className={cn("my-1.5 flex flex-col items-start w-full", className)}>
-      <button
-        type="button"
-        onClick={() => setManualExpanded(!isExpanded)}
-        aria-label="Toggle thinking details"
-        className="flex items-center gap-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer font-medium select-none"
-      >
-        {isThinking && (
-          <Loader2 className="size-3.5 animate-spin text-muted-foreground shrink-0" />
-        )}
-        <span>{labelText}</span>
-        <ChevronDown
-          className={cn(
-            "size-3.5 text-muted-foreground transition-transform duration-200 shrink-0",
-            !isExpanded && "-rotate-90",
-          )}
-        />
-      </button>
+      <ThoughtHeaderButton
+        isThinking={isThinking}
+        labelText={labelText}
+        isExpanded={isExpanded}
+        onToggle={() => setManualExpanded(!isExpanded)}
+      />
 
       {isExpanded && (
-        <div className="mt-1.5 ml-1.5 flex flex-col gap-2.5 border-l border-border/50 pl-3 py-1 text-xs w-full animate-in fade-in-0 duration-150">
-          {/* Tool call command executions */}
-          {hasTools && (
-            <div className="flex flex-col gap-2 w-full">
-              {toolCalls.map((tool, idx) => (
-                <TerminalToolCallRow
-                  key={tool.id || `${tool.name}-${idx}`}
-                  tool={tool}
-                />
-              ))}
-            </div>
-          )}
-
-          {/* Web search section */}
-          {hasWebSearch && (
-            <WebSearchSection
-              query={webSearchPart?.input?.query}
-              sources={sources}
-              errorText={
-                webSearchPart?.state === "output-error"
-                  ? webSearchPart.errorText || "Web search failed"
-                  : undefined
-              }
-            />
-          )}
-
-          {/* Markdown Thought Reasoning */}
-          {hasContent && (
-            <div
-              className={cn(
-                "text-xs w-full",
-                (hasTools || hasWebSearch) &&
-                  "pt-1.5 border-t border-border/30",
-              )}
-            >
-              {(hasTools || hasWebSearch) && (
-                <div className="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-wider mb-1 font-mono">
-                  Reasoning
-                </div>
-              )}
-              <ThoughtContent content={rawContent} />
-            </div>
-          )}
-        </div>
+        <ThoughtExpandedBody
+          toolCalls={toolCalls}
+          webSearchPart={webSearchPart}
+          sources={sources}
+          hasContent={hasContent}
+          rawContent={rawContent}
+        />
       )}
     </div>
   )

--- a/frontend/src/components/Chat/sidebar/ThreadListItem.tsx
+++ b/frontend/src/components/Chat/sidebar/ThreadListItem.tsx
@@ -1,4 +1,4 @@
-import { Archive, MoreHorizontal, Trash2 } from "lucide-react"
+import { Archive, Clock, Loader2, MoreHorizontal, Trash2 } from "lucide-react"
 import type { ChatThreadPublic } from "@/client"
 import { ThreadActionsMenu } from "@/components/Chat/sidebar/ThreadActionsMenu"
 import { Button } from "@/components/ui/button"
@@ -16,11 +16,15 @@ export function ThreadListItem({
   thread,
   isActive,
   isMenuOpen,
+  isStreaming,
+  isQueued,
   actions,
 }: {
   thread: ChatThreadPublic
   isActive: boolean
   isMenuOpen: boolean
+  isStreaming?: boolean
+  isQueued?: boolean
   actions: ThreadItemActions
 }) {
   const isArchived = Boolean(thread.is_archived)
@@ -46,7 +50,7 @@ export function ThreadListItem({
       >
         <span
           className={cn(
-            "truncate w-full",
+            "truncate",
             isArchived
               ? "text-xs text-muted-foreground font-normal group-hover:text-foreground"
               : "text-xs text-foreground font-medium",
@@ -54,6 +58,24 @@ export function ThreadListItem({
         >
           {thread.title}
         </span>
+        {isStreaming && (
+          <span
+            data-testid="thread-generating-badge"
+            className="ml-1.5 flex items-center gap-1 text-[10px] font-medium text-primary px-1.5 py-0.5 rounded-md bg-primary/10 shrink-0"
+          >
+            <Loader2 className="size-2.5 animate-spin" />
+            <span className="hidden sm:inline">Generating</span>
+          </span>
+        )}
+        {isQueued && (
+          <span
+            data-testid="thread-queued-badge"
+            className="ml-1.5 flex items-center gap-1 text-[10px] font-medium text-muted-foreground px-1.5 py-0.5 rounded-md bg-muted/60 shrink-0"
+          >
+            <Clock className="size-2.5" />
+            <span className="hidden sm:inline">Queued</span>
+          </span>
+        )}
       </button>
 
       <div className="flex items-center gap-0.5 shrink-0">

--- a/frontend/src/components/Chat/sidebar/ThreadListItem.tsx
+++ b/frontend/src/components/Chat/sidebar/ThreadListItem.tsx
@@ -12,6 +12,117 @@ export interface ThreadItemActions {
   onToggleMenu: (id: string) => void
 }
 
+function getThreadItemClassName({
+  isActive,
+  isArchived,
+}: {
+  isActive: boolean
+  isArchived: boolean
+}): string {
+  if (isActive && isArchived) {
+    return "bg-muted/30 text-foreground/80 font-normal"
+  }
+  if (isActive) {
+    return "bg-muted/50 text-foreground font-medium"
+  }
+  if (isArchived) {
+    return "text-muted-foreground/70 hover:bg-muted/20 hover:text-muted-foreground"
+  }
+  return "text-muted-foreground hover:bg-muted/30 hover:text-foreground"
+}
+
+function ThreadStatusBadges({
+  isStreaming,
+  isQueued,
+}: {
+  isStreaming?: boolean
+  isQueued?: boolean
+}) {
+  if (isStreaming) {
+    return (
+      <span
+        data-testid="thread-generating-badge"
+        className="ml-1.5 flex items-center gap-1 text-[10px] font-medium text-primary px-1.5 py-0.5 rounded-md bg-primary/10 shrink-0"
+      >
+        <Loader2 className="size-2.5 animate-spin" />
+        <span className="hidden sm:inline">Generating</span>
+      </span>
+    )
+  }
+  if (isQueued) {
+    return (
+      <span
+        data-testid="thread-queued-badge"
+        className="ml-1.5 flex items-center gap-1 text-[10px] font-medium text-muted-foreground px-1.5 py-0.5 rounded-md bg-muted/60 shrink-0"
+      >
+        <Clock className="size-2.5" />
+        <span className="hidden sm:inline">Queued</span>
+      </span>
+    )
+  }
+  return null
+}
+
+function ThreadQuickActionButton({
+  isArchived,
+  onDelete,
+  onArchive,
+}: {
+  isArchived: boolean
+  onDelete: (e: React.MouseEvent) => void
+  onArchive: (e: React.MouseEvent) => void
+}) {
+  if (isArchived) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Delete thread"
+        className="size-6 opacity-0 group-hover:opacity-100 hover:bg-destructive/10 rounded-full shrink-0 transition-opacity text-muted-foreground hover:text-destructive cursor-pointer"
+        onClick={onDelete}
+      >
+        <Trash2 className="size-3" />
+      </Button>
+    )
+  }
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Archive thread"
+      className="size-6 opacity-0 group-hover:opacity-100 hover:bg-muted/60 rounded-full shrink-0 transition-opacity text-muted-foreground hover:text-foreground cursor-pointer"
+      onClick={onArchive}
+    >
+      <Archive className="size-3" />
+    </Button>
+  )
+}
+
+function ThreadOptionsMenuTrigger({
+  isMenuOpen,
+  onToggle,
+}: {
+  isMenuOpen: boolean
+  onToggle: (e: React.MouseEvent) => void
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      aria-label="Thread options"
+      className={cn(
+        "size-6 hover:bg-muted/60 rounded-full shrink-0 transition-opacity cursor-pointer text-muted-foreground hover:text-foreground",
+        isMenuOpen
+          ? "opacity-100 bg-muted/60 text-foreground"
+          : "opacity-0 group-hover:opacity-100",
+      )}
+      onClick={onToggle}
+    >
+      <MoreHorizontal className="size-3" />
+    </Button>
+  )
+}
+
 export function ThreadListItem({
   thread,
   isActive,
@@ -28,19 +139,14 @@ export function ThreadListItem({
   actions: ThreadItemActions
 }) {
   const isArchived = Boolean(thread.is_archived)
+  const itemStyle = getThreadItemClassName({ isActive, isArchived })
 
   return (
     <div
       data-slot="thread-item"
       className={cn(
         "group relative flex items-center justify-between rounded-xl px-3 py-1.5 text-xs transition-colors cursor-pointer",
-        isActive
-          ? isArchived
-            ? "bg-muted/30 text-foreground/80 font-normal"
-            : "bg-muted/50 text-foreground font-medium"
-          : isArchived
-            ? "text-muted-foreground/70 hover:bg-muted/20 hover:text-muted-foreground"
-            : "text-muted-foreground hover:bg-muted/30 hover:text-foreground",
+        itemStyle,
       )}
     >
       <button
@@ -50,81 +156,38 @@ export function ThreadListItem({
       >
         <span
           className={cn(
-            "truncate",
+            "truncate text-xs",
             isArchived
-              ? "text-xs text-muted-foreground font-normal group-hover:text-foreground"
-              : "text-xs text-foreground font-medium",
+              ? "text-muted-foreground font-normal group-hover:text-foreground"
+              : "text-foreground font-medium",
           )}
         >
           {thread.title}
         </span>
-        {isStreaming && (
-          <span
-            data-testid="thread-generating-badge"
-            className="ml-1.5 flex items-center gap-1 text-[10px] font-medium text-primary px-1.5 py-0.5 rounded-md bg-primary/10 shrink-0"
-          >
-            <Loader2 className="size-2.5 animate-spin" />
-            <span className="hidden sm:inline">Generating</span>
-          </span>
-        )}
-        {isQueued && (
-          <span
-            data-testid="thread-queued-badge"
-            className="ml-1.5 flex items-center gap-1 text-[10px] font-medium text-muted-foreground px-1.5 py-0.5 rounded-md bg-muted/60 shrink-0"
-          >
-            <Clock className="size-2.5" />
-            <span className="hidden sm:inline">Queued</span>
-          </span>
-        )}
+        <ThreadStatusBadges isStreaming={isStreaming} isQueued={isQueued} />
       </button>
 
       <div className="flex items-center gap-0.5 shrink-0">
-        {isArchived ? (
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Delete thread"
-            className="size-6 opacity-0 group-hover:opacity-100 hover:bg-destructive/10 rounded-full shrink-0 transition-opacity text-muted-foreground hover:text-destructive cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation()
-              actions.onDelete(thread)
-            }}
-          >
-            <Trash2 className="size-3" />
-          </Button>
-        ) : (
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Archive thread"
-            className="size-6 opacity-0 group-hover:opacity-100 hover:bg-muted/60 rounded-full shrink-0 transition-opacity text-muted-foreground hover:text-foreground cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation()
-              actions.onToggleArchive(thread)
-            }}
-          >
-            <Archive className="size-3" />
-          </Button>
-        )}
+        <ThreadQuickActionButton
+          isArchived={isArchived}
+          onDelete={(e) => {
+            e.stopPropagation()
+            actions.onDelete(thread)
+          }}
+          onArchive={(e) => {
+            e.stopPropagation()
+            actions.onToggleArchive(thread)
+          }}
+        />
 
         <div className="relative">
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Thread options"
-            className={cn(
-              "size-6 hover:bg-muted/60 rounded-full shrink-0 transition-opacity cursor-pointer text-muted-foreground hover:text-foreground",
-              isMenuOpen
-                ? "opacity-100 bg-muted/60 text-foreground"
-                : "opacity-0 group-hover:opacity-100",
-            )}
-            onClick={(e) => {
+          <ThreadOptionsMenuTrigger
+            isMenuOpen={isMenuOpen}
+            onToggle={(e) => {
               e.stopPropagation()
               actions.onToggleMenu(thread.id)
             }}
-          >
-            <MoreHorizontal className="size-3" />
-          </Button>
+          />
 
           {isMenuOpen && (
             <ThreadActionsMenu

--- a/frontend/src/components/Chat/types.ts
+++ b/frontend/src/components/Chat/types.ts
@@ -61,9 +61,32 @@ export interface ToolCallItem {
 }
 
 export interface ToolCallPart {
-  type: "tool-call"
-  toolCallId: string
-  tool: ToolCallItem
+  type: "tool-call" | "tool_call"
+  toolCallId?: string
+  name?: string
+  state?: "running" | "completed" | "failed"
+  tool?: ToolCallItem
+  input?: Record<string, unknown>
+  output?: Record<string, unknown>
+}
+
+export interface TrendingTopicItem {
+  id?: string
+  topic_title: string
+  category?: string | null
+  post_count?: number | null
+  summary?: string | null
+  topic_url?: string
+}
+
+export interface TrendingArtifact {
+  topics: TrendingTopicItem[]
+  count?: number
+}
+
+export interface TrendingArtifactPart {
+  type: "trending_artifact"
+  artifact: TrendingArtifact
 }
 
 export interface DraftArtifact {
@@ -102,6 +125,7 @@ export type ChatMessagePart =
   | WebSearchToolPart
   | ToolCallPart
   | DraftArtifactPart
+  | TrendingArtifactPart
   | ThoughtPart
 
 export interface ChatUIMessage {
@@ -109,4 +133,14 @@ export interface ChatUIMessage {
   role: "user" | "assistant" | "system"
   parts: ChatMessagePart[]
   createdAt?: string
+  status?: "queued" | "streaming" | "done" | "error"
+}
+
+export interface QueuedTurn {
+  id: string
+  threadId: string
+  promptText: string
+  base64Images?: string[]
+  selectedModelId: string
+  assistantMsgId: string
 }

--- a/frontend/src/components/Chat/usePromptFormState.ts
+++ b/frontend/src/components/Chat/usePromptFormState.ts
@@ -28,6 +28,47 @@ function isPlainEnterPress(
   return true
 }
 
+function shouldBlockSubmit({
+  text,
+  imageCount,
+  isBusy,
+}: {
+  text: string
+  imageCount: number
+  isBusy: boolean
+}): boolean {
+  if (isBusy) return true
+  if (text.length > 0) return false
+  return imageCount === 0
+}
+
+function usePromptModelSelection({
+  selectedModelId,
+  onSelectModel,
+}: {
+  selectedModelId?: string
+  onSelectModel?: (modelId: string) => void
+}) {
+  const [localModelId, setLocalModelId] = React.useState(selectedModelId || "")
+
+  React.useEffect(() => {
+    if (selectedModelId) {
+      setLocalModelId(selectedModelId)
+    }
+  }, [selectedModelId])
+
+  const handleSelectModel = React.useCallback(
+    (mId: string) => {
+      setLocalModelId(mId)
+      onSelectModel?.(mId)
+    },
+    [onSelectModel],
+  )
+
+  const activeModelId = selectedModelId || localModelId
+  return { activeModelId, handleSelectModel }
+}
+
 export interface UsePromptFormStateProps {
   initialValue?: string
   selectedModelId?: string
@@ -52,17 +93,14 @@ export function usePromptFormState({
   inputRef,
 }: UsePromptFormStateProps) {
   const [input, setInput] = React.useState(initialValue)
-  const [localModelId, setLocalModelId] = React.useState(selectedModelId || "")
+  const { activeModelId, handleSelectModel } = usePromptModelSelection({
+    selectedModelId,
+    onSelectModel,
+  })
 
   React.useEffect(() => {
     setInput((prev) => (prev !== initialValue ? initialValue : prev))
   }, [initialValue])
-
-  React.useEffect(() => {
-    if (selectedModelId) {
-      setLocalModelId(selectedModelId)
-    }
-  }, [selectedModelId])
 
   const internalInputRef = React.useRef<HTMLTextAreaElement>(null)
   const effectiveInputRef = inputRef || internalInputRef
@@ -93,7 +131,6 @@ export function usePromptFormState({
     stopAndReset,
   } = usePromptVoiceInput({ input, updateInput })
 
-  const activeModelId = selectedModelId || localModelId
   const normalizedModels = React.useMemo(
     () => normalizeModels(models),
     [models],
@@ -105,16 +142,19 @@ export function usePromptFormState({
     }
   }, [autoFocus, effectiveInputRef])
 
-  function handleSelectModel(mId: string) {
-    setLocalModelId(mId)
-    onSelectModel?.(mId)
-  }
-
   function handleSubmit(event?: React.FormEvent) {
     event?.preventDefault()
     stopAndReset()
     const text = input.trim()
-    if ((!text && selectedImages.length === 0) || isBusy) return
+    if (
+      shouldBlockSubmit({
+        text,
+        imageCount: selectedImages.length,
+        isBusy,
+      })
+    ) {
+      return
+    }
 
     if (selectedImages.length > 0) {
       onSubmit(

--- a/frontend/src/components/Chat/usePromptFormState.ts
+++ b/frontend/src/components/Chat/usePromptFormState.ts
@@ -55,6 +55,10 @@ export function usePromptFormState({
   const [localModelId, setLocalModelId] = React.useState(selectedModelId || "")
 
   React.useEffect(() => {
+    setInput((prev) => (prev !== initialValue ? initialValue : prev))
+  }, [initialValue])
+
+  React.useEffect(() => {
     if (selectedModelId) {
       setLocalModelId(selectedModelId)
     }

--- a/frontend/src/components/PostInput/usePostForm.ts
+++ b/frontend/src/components/PostInput/usePostForm.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
 import { useCallback, useState } from "react"
 
 import { PostsService } from "@/client"
@@ -238,7 +239,7 @@ function useAiDraftMutation(
 }
 
 export function usePostForm(options?: UsePostFormOptions) {
-  const { showSuccessToast, showErrorToast, showInfoToast } = useCustomToast()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
   const core = useComposerCoreState(options)
   const media = useComposerMedia(showErrorToast, options?.initialImageUrl)
 
@@ -259,34 +260,25 @@ export function usePostForm(options?: UsePostFormOptions) {
 
   const aiDraftMutation = useAiDraftMutation(showSuccessToast, showErrorToast)
 
+  const navigate = useNavigate()
+
   const handleAiDraft = useCallback(() => {
     const prompt = core.content.trim()
     if (!prompt) return
-
-    const draftId = `draft-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
-
-    // Add to in-flight drafting list immediately
-    draftingStore.addDraft({
-      id: draftId,
-      prompt,
-      platform: core.channel,
-      startedAt: new Date(),
-    })
 
     // Immediately free the input box for the user's next post
     core.setContent("")
     core.setIsAiMode(false)
 
-    // Show initial notification toast
-    showInfoToast("Drafting post in background with AI...", "Drafting...")
-
-    // Trigger background generation
-    aiDraftMutation.mutate({
-      draftId,
-      prompt,
-      platform: core.channel,
+    // Route to AI chat thread
+    navigate({
+      to: "/ai",
+      search: {
+        prompt: `Draft a ${core.channel !== "linkx" ? core.channel : "social"} post about: "${prompt}"`,
+        autoRun: true,
+      },
     })
-  }, [core, showInfoToast, aiDraftMutation])
+  }, [core, navigate])
 
   const handleSubmit = useCallback(
     (action: "draft" | "schedule" | "post") => {

--- a/frontend/src/components/Timeline/TrendingTopics.tsx
+++ b/frontend/src/components/Timeline/TrendingTopics.tsx
@@ -1,11 +1,9 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
 import { Bot, Loader2, RefreshCw } from "lucide-react"
 import * as React from "react"
-import { TrendingService, type TrendingTopicPublic } from "@/client"
+import type { TrendingTopicPublic } from "@/client"
 import { Button } from "@/components/ui/button"
-import useCustomToast from "@/hooks/useCustomToast"
-import { draftingStore } from "@/hooks/useDraftingStore"
-import { formatRelativeTime, handleError } from "@/utils"
+import { formatRelativeTime } from "@/utils"
 
 export type TrendingTopic = TrendingTopicPublic
 
@@ -174,70 +172,28 @@ export function TrendingTopics({
   lastScrapedAt,
   onTopicDraft,
 }: TrendingTopicsProps) {
-  const queryClient = useQueryClient()
-  const { showSuccessToast, showErrorToast, showInfoToast } = useCustomToast()
-  const [draftingTopicId, setDraftingTopicId] = React.useState<string | null>(
-    null,
-  )
+  const navigate = useNavigate()
 
-  const extractMutation = useMutation({
-    mutationFn: async () =>
-      TrendingService.extractTrendingTopics({ maxTopics: 3 }),
-    onSuccess: (res) => {
-      showSuccessToast(
-        res.count > 0
-          ? `Successfully refreshed ${res.count} trending topics from X!`
-          : "Checked X: No new trending topics found.",
-      )
-      queryClient.setQueryData(["trending"], res)
-      queryClient.invalidateQueries({ queryKey: ["trending"] })
-    },
-    onError: handleError.bind(showErrorToast),
-  })
-
-  const draftMutation = useMutation({
-    mutationFn: async ({
-      topicId,
-    }: {
-      topicId: string
-      topicTitle: string
-    }) => {
-      setDraftingTopicId(topicId)
-      return TrendingService.draftFromTrendingTopic({ topicId })
-    },
-    onSuccess: (_, variables) => {
-      draftingStore.removeDraft(`trend-${variables.topicId}`)
-      showSuccessToast(
-        `Draft created from trending topic: "${variables.topicTitle}"`,
-      )
-      queryClient.invalidateQueries({ queryKey: ["posts"] })
-    },
-    onError: (err, variables) => {
-      draftingStore.removeDraft(`trend-${variables.topicId}`)
-      handleError.call(showErrorToast, err as any)
-    },
-    onSettled: () => {
-      setDraftingTopicId(null)
-    },
-  })
+  const handleRefresh = () => {
+    navigate({
+      to: "/ai",
+      search: {
+        prompt: "Refresh trending topics from X",
+        autoRun: true,
+      },
+    })
+  }
 
   const handleDraftClick = (topic: TrendingTopicPublic) => {
     if (onTopicDraft) {
       onTopicDraft(topic.topic_title)
     } else {
-      draftingStore.addDraft({
-        id: `trend-${topic.id}`,
-        prompt: topic.topic_title,
-        platform: "both",
-        startedAt: new Date(),
-      })
-      showInfoToast(
-        `Drafting post from "${topic.topic_title}" in background...`,
-        "Drafting...",
-      )
-      draftMutation.mutate({
-        topicId: topic.id,
-        topicTitle: topic.topic_title,
+      navigate({
+        to: "/ai",
+        search: {
+          prompt: `Draft an engaging post about: "${topic.topic_title}"`,
+          autoRun: true,
+        },
       })
     }
   }
@@ -252,22 +208,19 @@ export function TrendingTopics({
       <TrendingHeader
         title={title}
         relativeTime={relativeTime}
-        isPending={extractMutation.isPending}
-        onRefresh={() => extractMutation.mutate()}
+        isPending={false}
+        onRefresh={handleRefresh}
       />
 
       {topics.length === 0 ? (
-        <TrendingEmptyState
-          isPending={extractMutation.isPending}
-          onRefresh={() => extractMutation.mutate()}
-        />
+        <TrendingEmptyState isPending={false} onRefresh={handleRefresh} />
       ) : (
         <div className="w-full divide-y divide-border/30">
           {topics.slice(0, 3).map((topic) => (
             <TrendingTopicRow
               key={topic.id}
               topic={topic}
-              isDrafting={draftingTopicId === topic.id}
+              isDrafting={false}
               onDraft={() => handleDraftClick(topic)}
             />
           ))}

--- a/frontend/src/hooks/useAIChatFeedState.ts
+++ b/frontend/src/hooks/useAIChatFeedState.ts
@@ -13,6 +13,38 @@ import {
   useChatTurnSender,
 } from "@/hooks/useChatTurnSender"
 
+function shouldSkipTranscriptSync({
+  activeThreadId,
+  streamingThreadId,
+  queuedThreadIds,
+}: {
+  activeThreadId: string | null
+  streamingThreadId: string | null
+  queuedThreadIds: string[]
+}): boolean {
+  if (!activeThreadId) return true
+  if (activeThreadId === streamingThreadId) return true
+  return queuedThreadIds.includes(activeThreadId)
+}
+
+function resolveMergedTranscriptMessages({
+  current,
+  transcriptMessages,
+}: {
+  current: ChatUIMessage[]
+  transcriptMessages: ChatUIMessage[]
+}): ChatUIMessage[] {
+  const hasOptimistic = current.some(
+    (m) => m.id.startsWith("local_") || m.status === "queued",
+  )
+  if (hasOptimistic && transcriptMessages.length === 0) {
+    return current
+  }
+  return transcriptMessages.length >= current.length
+    ? transcriptMessages
+    : current
+}
+
 function useThreadTranscript({
   activeThreadId,
   streamingThreadId,
@@ -33,9 +65,15 @@ function useThreadTranscript({
   })
 
   React.useEffect(() => {
-    if (!activeThreadId) return
-    if (activeThreadId === streamingThreadId) return
-    if (queuedThreadIds.includes(activeThreadId)) return
+    if (
+      shouldSkipTranscriptSync({
+        activeThreadId,
+        streamingThreadId,
+        queuedThreadIds,
+      })
+    ) {
+      return
+    }
 
     const transcriptMessages =
       (activeThreadDetail?.transcript as { messages?: ChatUIMessage[] })
@@ -43,22 +81,13 @@ function useThreadTranscript({
 
     if (!transcriptMessages) return
 
-    setMessagesByThread((prev) => {
-      const current = prev[activeThreadId] ?? []
-      const hasOptimistic = current.some(
-        (m) => m.id.startsWith("local_") || m.status === "queued",
-      )
-      if (hasOptimistic && transcriptMessages.length === 0) {
-        return prev
-      }
-      return {
-        ...prev,
-        [activeThreadId]:
-          transcriptMessages.length >= current.length
-            ? transcriptMessages
-            : current,
-      }
-    })
+    setMessagesByThread((prev) => ({
+      ...prev,
+      [activeThreadId!]: resolveMergedTranscriptMessages({
+        current: prev[activeThreadId!] ?? [],
+        transcriptMessages,
+      }),
+    }))
   }, [
     activeThreadDetail,
     activeThreadId,
@@ -129,52 +158,39 @@ function useCreateThreadMutation(
   })
 }
 
-export function useAIChatFeedState({
-  threads,
-  selectedModelId,
-  initialThreadId,
+function filterOutCancelledTurnMessages(
+  msgs: ChatUIMessage[],
+  cancelled: QueuedTurn[],
+): ChatUIMessage[] {
+  const cancelledAssistantIds = new Set(cancelled.map((c) => c.assistantMsgId))
+  const cancelledPrompts = new Set(cancelled.map((c) => c.promptText))
+  return msgs.filter((m) => {
+    if (cancelledAssistantIds.has(m.id)) return false
+    if (m.role === "user") {
+      const matchesPrompt = m.parts.some(
+        (p) => p.type === "text" && cancelledPrompts.has(p.text),
+      )
+      if (matchesPrompt) return false
+    }
+    return true
+  })
+}
+
+function useTurnQueue({
+  setThreadDraft,
+  setMessagesByThread,
 }: {
-  threads: ChatThreadPublic[]
-  selectedModelId: string
-  initialThreadId?: string
+  setThreadDraft: (threadId: string | null, text: string) => void
+  setMessagesByThread: React.Dispatch<
+    React.SetStateAction<Record<string, ChatUIMessage[]>>
+  >
 }) {
-  const queryClient = useQueryClient()
-  const {
-    isStreaming,
-    streamingThreadId,
-    startStream,
-    stop: stopStream,
-  } = useAIChatStream()
-  const { threadDrafts, setThreadDraft, clearThreadDraft } = useThreadDrafts()
-
-  const [activeThreadId, setActiveThreadId] = React.useState<string | null>(
-    initialThreadId ?? null,
-  )
-  const [messagesByThread, setMessagesByThread] = React.useState<
-    Record<string, ChatUIMessage[]>
-  >({})
-  const [pendingQuestion, setPendingQuestion] =
-    React.useState<AskUserToolPart | null>(null)
-
   const turnQueueRef = React.useRef<QueuedTurn[]>([])
   const [turnQueue, setTurnQueue] = React.useState<QueuedTurn[]>([])
-  const isProcessingQueueRef = React.useRef(false)
 
   const queuedThreadIds = React.useMemo(
     () => turnQueue.map((t) => t.threadId),
     [turnQueue],
-  )
-
-  const isThreadStreaming = React.useCallback(
-    (threadId: string | null) =>
-      Boolean(threadId && streamingThreadId === threadId),
-    [streamingThreadId],
-  )
-
-  const isThreadQueued = React.useCallback(
-    (threadId: string | null) =>
-      Boolean(threadId && queuedThreadIds.includes(threadId)),
-    [queuedThreadIds],
   )
 
   const enqueueTurn = React.useCallback((turn: QueuedTurn) => {
@@ -199,50 +215,85 @@ export function useAIChatFeedState({
       )
       setTurnQueue(turnQueueRef.current)
 
-      // Restore prompt text to draft if available
       if (cancelled.length > 0 && cancelled[0].promptText) {
         setThreadDraft(threadId, cancelled[0].promptText)
       }
 
       setMessagesByThread((prev) => {
         const msgs = prev[threadId] ?? []
-        const cancelledAssistantIds = new Set(
-          cancelled.map((c) => c.assistantMsgId),
-        )
-        const cancelledPrompts = new Set(cancelled.map((c) => c.promptText))
-        const filtered = msgs.filter((m) => {
-          if (cancelledAssistantIds.has(m.id)) return false
-          if (
-            m.role === "user" &&
-            m.parts.some(
-              (p) => p.type === "text" && cancelledPrompts.has(p.text),
-            )
-          ) {
-            return false
-          }
-          return true
-        })
-        return { ...prev, [threadId]: filtered }
+        return {
+          ...prev,
+          [threadId]: filterOutCancelledTurnMessages(msgs, cancelled),
+        }
       })
     },
-    [setThreadDraft],
+    [setThreadDraft, setMessagesByThread],
   )
 
-  const handleThreadDeleted = React.useCallback(
-    (deletedId: string) => {
-      if (streamingThreadId === deletedId) {
-        stopStream(deletedId)
-      }
-      cancelQueuedTurn(deletedId)
-      setMessagesByThread((prev) => {
-        if (!(deletedId in prev)) return prev
-        const copy = { ...prev }
-        delete copy[deletedId]
-        return copy
-      })
-    },
-    [streamingThreadId, stopStream, cancelQueuedTurn],
-  )
+  return {
+    turnQueue,
+    turnQueueRef,
+    queuedThreadIds,
+    enqueueTurn,
+    dequeueTurn,
+    cancelQueuedTurn,
+  }
+}
+
+function executeStopAction({
+  activeThreadId,
+  streamingThreadId,
+  queuedThreadIds,
+  stopStream,
+  cancelQueuedTurn,
+}: {
+  activeThreadId: string | null
+  streamingThreadId: string | null
+  queuedThreadIds: string[]
+  stopStream: (id?: string) => void
+  cancelQueuedTurn: (id: string) => void
+}) {
+  if (!activeThreadId) {
+    stopStream()
+    return
+  }
+  if (activeThreadId === streamingThreadId) {
+    stopStream(activeThreadId)
+    return
+  }
+  if (queuedThreadIds.includes(activeThreadId)) {
+    cancelQueuedTurn(activeThreadId)
+    return
+  }
+  stopStream()
+}
+
+function removeThreadMessages(
+  prev: Record<string, ChatUIMessage[]>,
+  deletedId: string,
+): Record<string, ChatUIMessage[]> {
+  if (!(deletedId in prev)) return prev
+  const copy = { ...prev }
+  delete copy[deletedId]
+  return copy
+}
+
+function useQueueProcessor({
+  turnQueueRef,
+  dequeueTurn,
+  setMessagesByThread,
+  queryClient,
+  startStream,
+}: {
+  turnQueueRef: React.MutableRefObject<QueuedTurn[]>
+  dequeueTurn: () => QueuedTurn | undefined
+  setMessagesByThread: React.Dispatch<
+    React.SetStateAction<Record<string, ChatUIMessage[]>>
+  >
+  queryClient: ReturnType<typeof useQueryClient>
+  startStream: ReturnType<typeof useAIChatStream>["startStream"]
+}) {
+  const isProcessingQueueRef = React.useRef(false)
 
   const processQueue = React.useCallback(async () => {
     if (isProcessingQueueRef.current) return
@@ -293,34 +344,120 @@ export function useAIChatFeedState({
         }, 0)
       }
     }
-  }, [dequeueTurn, queryClient, startStream])
+  }, [dequeueTurn, queryClient, startStream, turnQueueRef, setMessagesByThread])
 
-  useInitialActiveThread(threads, initialThreadId, setActiveThreadId)
-  useThreadTranscript({
-    activeThreadId,
-    streamingThreadId,
-    queuedThreadIds,
-    setMessagesByThread,
-  })
+  return processQueue
+}
 
-  const createThreadMutation = useCreateThreadMutation(
-    queryClient,
-    setActiveThreadId,
+function useActiveThreadMessages({
+  activeThreadId,
+  messagesByThread,
+  setMessagesByThread,
+}: {
+  activeThreadId: string | null
+  messagesByThread: Record<string, ChatUIMessage[]>
+  setMessagesByThread: React.Dispatch<
+    React.SetStateAction<Record<string, ChatUIMessage[]>>
+  >
+}) {
+  const activeKey = activeThreadId ?? "new-chat"
+  const localMessages = messagesByThread[activeKey] ?? []
+
+  const setLocalMessages = React.useCallback(
+    (updater: React.SetStateAction<ChatUIMessage[]>) => {
+      const key = activeThreadId ?? "new-chat"
+      setMessagesByThread((prev) => {
+        const current = prev[key] ?? []
+        const updated =
+          typeof updater === "function" ? updater(current) : updater
+        return { ...prev, [key]: updated }
+      })
+    },
+    [activeThreadId, setMessagesByThread],
   )
 
-  const handleSendMessage = useChatTurnSender({
+  return { localMessages, setLocalMessages }
+}
+
+function useThreadStreamingStatus({
+  streamingThreadId,
+  queuedThreadIds,
+}: {
+  streamingThreadId: string | null
+  queuedThreadIds: string[]
+}) {
+  const isThreadStreaming = React.useCallback(
+    (threadId: string | null) =>
+      Boolean(threadId && streamingThreadId === threadId),
+    [streamingThreadId],
+  )
+
+  const isThreadQueued = React.useCallback(
+    (threadId: string | null) =>
+      Boolean(threadId && queuedThreadIds.includes(threadId)),
+    [queuedThreadIds],
+  )
+
+  return { isThreadStreaming, isThreadQueued }
+}
+
+function useChatFeedCore(initialThreadId?: string) {
+  const queryClient = useQueryClient()
+  const streamState = useAIChatStream()
+  const draftState = useThreadDrafts()
+  const [activeThreadId, setActiveThreadId] = React.useState<string | null>(
+    initialThreadId ?? null,
+  )
+  const [messagesByThread, setMessagesByThread] = React.useState<
+    Record<string, ChatUIMessage[]>
+  >({})
+  const [pendingQuestion, setPendingQuestion] =
+    React.useState<AskUserToolPart | null>(null)
+
+  return {
+    queryClient,
+    streamState,
+    draftState,
     activeThreadId,
-    selectedModelId,
-    isStreaming,
-    streamingThreadId,
+    setActiveThreadId,
+    messagesByThread,
+    setMessagesByThread,
+    pendingQuestion,
+    setPendingQuestion,
+  }
+}
+
+type ChatFeedCore = ReturnType<typeof useChatFeedCore>
+type TurnQueueState = ReturnType<typeof useTurnQueue>
+
+function useThreadActions({
+  core,
+  queueState,
+  handleSendMessage,
+}: {
+  core: ChatFeedCore
+  queueState: TurnQueueState
+  handleSendMessage: (text: string, attachedImages?: File[]) => Promise<void>
+}) {
+  const { streamingThreadId, stop: stopStream } = core.streamState
+  const {
+    activeThreadId,
     setActiveThreadId,
     setMessagesByThread,
     setPendingQuestion,
-    clearThreadDraft,
-    createThreadMutation,
-    enqueueTurn,
-    processQueue,
-  })
+  } = core
+  const { queuedThreadIds, cancelQueuedTurn } = queueState
+
+  const handleThreadDeleted = React.useCallback(
+    (deletedId: string) => {
+      if (streamingThreadId === deletedId) {
+        stopStream(deletedId)
+      }
+      cancelQueuedTurn(deletedId)
+      setMessagesByThread((prev) => removeThreadMessages(prev, deletedId))
+    },
+    [streamingThreadId, stopStream, cancelQueuedTurn, setMessagesByThread],
+  )
 
   const handleQuestionAnswer = React.useCallback(
     (_toolCallId: string, answers: AskUserAnswer[]) => {
@@ -339,20 +476,16 @@ export function useAIChatFeedState({
     setActiveThreadId(null)
     setMessagesByThread((prev) => ({ ...prev, "new-chat": [] }))
     setPendingQuestion(null)
-  }, [])
+  }, [setActiveThreadId, setMessagesByThread, setPendingQuestion])
 
   const handleStop = React.useCallback(() => {
-    if (!activeThreadId) {
-      stopStream()
-      return
-    }
-    if (activeThreadId === streamingThreadId) {
-      stopStream(activeThreadId)
-    } else if (queuedThreadIds.includes(activeThreadId)) {
-      cancelQueuedTurn(activeThreadId)
-    } else {
-      stopStream()
-    }
+    executeStopAction({
+      activeThreadId,
+      streamingThreadId,
+      queuedThreadIds,
+      stopStream,
+      cancelQueuedTurn,
+    })
   }, [
     activeThreadId,
     cancelQueuedTurn,
@@ -361,44 +494,146 @@ export function useAIChatFeedState({
     streamingThreadId,
   ])
 
-  const activeKey = activeThreadId ?? "new-chat"
-  const localMessages = messagesByThread[activeKey] ?? []
-
-  const setLocalMessages = React.useCallback(
-    (updater: React.SetStateAction<ChatUIMessage[]>) => {
-      const key = activeThreadId ?? "new-chat"
-      setMessagesByThread((prev) => {
-        const current = prev[key] ?? []
-        const updated =
-          typeof updater === "function" ? updater(current) : updater
-        return { ...prev, [key]: updated }
-      })
-    },
-    [activeThreadId],
-  )
-
   return {
-    activeThreadId,
-    setActiveThreadId,
-    localMessages,
-    setLocalMessages,
-    messagesByThread,
-    setMessagesByThread,
-    pendingQuestion,
-    threadDrafts,
-    setThreadDraft,
-    clearThreadDraft,
-    isStreaming,
-    streamingThreadId,
-    queuedThreadIds,
-    isThreadStreaming,
-    isThreadQueued,
-    turnQueue,
-    cancelQueuedTurn,
     handleThreadDeleted,
-    stopStream: handleStop,
-    handleSendMessage,
     handleQuestionAnswer,
     handleNewChat,
+    handleStop,
   }
+}
+
+function useChatEngine({
+  threads,
+  initialThreadId,
+  selectedModelId,
+  core,
+  queueState,
+}: {
+  threads: ChatThreadPublic[]
+  initialThreadId?: string
+  selectedModelId: string
+  core: ChatFeedCore
+  queueState: TurnQueueState
+}) {
+  const processQueue = useQueueProcessor({
+    turnQueueRef: queueState.turnQueueRef,
+    dequeueTurn: queueState.dequeueTurn,
+    setMessagesByThread: core.setMessagesByThread,
+    queryClient: core.queryClient,
+    startStream: core.streamState.startStream,
+  })
+
+  useInitialActiveThread(threads, initialThreadId, core.setActiveThreadId)
+  useThreadTranscript({
+    activeThreadId: core.activeThreadId,
+    streamingThreadId: core.streamState.streamingThreadId,
+    queuedThreadIds: queueState.queuedThreadIds,
+    setMessagesByThread: core.setMessagesByThread,
+  })
+
+  const createThreadMutation = useCreateThreadMutation(
+    core.queryClient,
+    core.setActiveThreadId,
+  )
+
+  const handleSendMessage = useChatTurnSender({
+    activeThreadId: core.activeThreadId,
+    selectedModelId,
+    isStreaming: core.streamState.isStreaming,
+    streamingThreadId: core.streamState.streamingThreadId,
+    setActiveThreadId: core.setActiveThreadId,
+    setMessagesByThread: core.setMessagesByThread,
+    setPendingQuestion: core.setPendingQuestion,
+    clearThreadDraft: core.draftState.clearThreadDraft,
+    createThreadMutation,
+    enqueueTurn: queueState.enqueueTurn,
+    processQueue,
+  })
+
+  return { handleSendMessage }
+}
+
+function assembleFeedState({
+  core,
+  queueState,
+  streamingStatus,
+  threadActions,
+  activeMessages,
+  handleSendMessage,
+}: {
+  core: ChatFeedCore
+  queueState: TurnQueueState
+  streamingStatus: ReturnType<typeof useThreadStreamingStatus>
+  threadActions: ReturnType<typeof useThreadActions>
+  activeMessages: ReturnType<typeof useActiveThreadMessages>
+  handleSendMessage: (text: string, attachedImages?: File[]) => Promise<void>
+}) {
+  return {
+    activeThreadId: core.activeThreadId,
+    setActiveThreadId: core.setActiveThreadId,
+    localMessages: activeMessages.localMessages,
+    setLocalMessages: activeMessages.setLocalMessages,
+    messagesByThread: core.messagesByThread,
+    setMessagesByThread: core.setMessagesByThread,
+    pendingQuestion: core.pendingQuestion,
+    threadDrafts: core.draftState.threadDrafts,
+    setThreadDraft: core.draftState.setThreadDraft,
+    clearThreadDraft: core.draftState.clearThreadDraft,
+    isStreaming: core.streamState.isStreaming,
+    streamingThreadId: core.streamState.streamingThreadId,
+    queuedThreadIds: queueState.queuedThreadIds,
+    isThreadStreaming: streamingStatus.isThreadStreaming,
+    isThreadQueued: streamingStatus.isThreadQueued,
+    turnQueue: queueState.turnQueue,
+    cancelQueuedTurn: queueState.cancelQueuedTurn,
+    handleThreadDeleted: threadActions.handleThreadDeleted,
+    stopStream: threadActions.handleStop,
+    handleSendMessage,
+    handleQuestionAnswer: threadActions.handleQuestionAnswer,
+    handleNewChat: threadActions.handleNewChat,
+  }
+}
+
+export interface UseAIChatFeedStateProps {
+  threads: ChatThreadPublic[]
+  selectedModelId: string
+  initialThreadId?: string
+}
+
+export function useAIChatFeedState(options: UseAIChatFeedStateProps) {
+  const core = useChatFeedCore(options.initialThreadId)
+  const queueState = useTurnQueue({
+    setThreadDraft: core.draftState.setThreadDraft,
+    setMessagesByThread: core.setMessagesByThread,
+  })
+  const streamingStatus = useThreadStreamingStatus({
+    streamingThreadId: core.streamState.streamingThreadId,
+    queuedThreadIds: queueState.queuedThreadIds,
+  })
+  const { handleSendMessage } = useChatEngine({
+    threads: options.threads,
+    initialThreadId: options.initialThreadId,
+    selectedModelId: options.selectedModelId,
+    core,
+    queueState,
+  })
+  const threadActions = useThreadActions({
+    core,
+    queueState,
+    handleSendMessage,
+  })
+  const activeMessages = useActiveThreadMessages({
+    activeThreadId: core.activeThreadId,
+    messagesByThread: core.messagesByThread,
+    setMessagesByThread: core.setMessagesByThread,
+  })
+
+  return assembleFeedState({
+    core,
+    queueState,
+    streamingStatus,
+    threadActions,
+    activeMessages,
+    handleSendMessage,
+  })
 }

--- a/frontend/src/hooks/useAIChatFeedState.ts
+++ b/frontend/src/hooks/useAIChatFeedState.ts
@@ -5,47 +5,27 @@ import type {
   AskUserAnswer,
   AskUserToolPart,
   ChatUIMessage,
+  QueuedTurn,
 } from "@/components/Chat/types"
 import { useAIChatStream } from "@/hooks/useAIChatStream"
-import { useChatTurnSender } from "@/hooks/useChatTurnSender"
-
-function syncThreadMessages({
-  activeThreadId,
-  transcriptMessages,
-  threadChanged,
-  setLocalMessages,
-}: {
-  activeThreadId: string | null
-  transcriptMessages: ChatUIMessage[] | null
-  threadChanged: boolean
-  setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>
-}) {
-  if (!activeThreadId) {
-    setLocalMessages([])
-    return
-  }
-  if (!transcriptMessages) return
-
-  if (threadChanged) {
-    setLocalMessages(transcriptMessages)
-    return
-  }
-
-  setLocalMessages((current) =>
-    transcriptMessages.length >= current.length ? transcriptMessages : current,
-  )
-}
+import {
+  buildStreamHandlers,
+  useChatTurnSender,
+} from "@/hooks/useChatTurnSender"
 
 function useThreadTranscript({
   activeThreadId,
-  isStreaming,
-  setLocalMessages,
+  streamingThreadId,
+  queuedThreadIds,
+  setMessagesByThread,
 }: {
   activeThreadId: string | null
-  isStreaming: boolean
-  setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>
+  streamingThreadId: string | null
+  queuedThreadIds: string[]
+  setMessagesByThread: React.Dispatch<
+    React.SetStateAction<Record<string, ChatUIMessage[]>>
+  >
 }) {
-  const previousThreadIdRef = React.useRef<string | null>(null)
   const { data: activeThreadDetail } = useQuery({
     queryKey: ["ai-thread", activeThreadId],
     queryFn: () => AiThreadsService.getChatThread({ id: activeThreadId! }),
@@ -53,22 +33,39 @@ function useThreadTranscript({
   })
 
   React.useEffect(() => {
-    if (isStreaming) return
-
-    const threadChanged = previousThreadIdRef.current !== activeThreadId
-    previousThreadIdRef.current = activeThreadId
+    if (!activeThreadId) return
+    if (activeThreadId === streamingThreadId) return
+    if (queuedThreadIds.includes(activeThreadId)) return
 
     const transcriptMessages =
       (activeThreadDetail?.transcript as { messages?: ChatUIMessage[] })
         ?.messages || null
 
-    syncThreadMessages({
-      activeThreadId,
-      transcriptMessages,
-      threadChanged,
-      setLocalMessages,
+    if (!transcriptMessages) return
+
+    setMessagesByThread((prev) => {
+      const current = prev[activeThreadId] ?? []
+      const hasOptimistic = current.some(
+        (m) => m.id.startsWith("local_") || m.status === "queued",
+      )
+      if (hasOptimistic && transcriptMessages.length === 0) {
+        return prev
+      }
+      return {
+        ...prev,
+        [activeThreadId]:
+          transcriptMessages.length >= current.length
+            ? transcriptMessages
+            : current,
+      }
     })
-  }, [activeThreadDetail, isStreaming, activeThreadId, setLocalMessages])
+  }, [
+    activeThreadDetail,
+    activeThreadId,
+    streamingThreadId,
+    queuedThreadIds,
+    setMessagesByThread,
+  ])
 }
 
 function useThreadDrafts() {
@@ -99,15 +96,21 @@ function useThreadDrafts() {
 
 function useInitialActiveThread(
   threads: ChatThreadPublic[],
+  initialThreadId: string | undefined,
   setActiveThreadId: (id: string) => void,
 ) {
   const initialLoadedRef = React.useRef(false)
   React.useEffect(() => {
+    if (initialThreadId) {
+      setActiveThreadId(initialThreadId)
+      initialLoadedRef.current = true
+      return
+    }
     if (threads.length > 0 && !initialLoadedRef.current) {
       setActiveThreadId(threads[0].id)
       initialLoadedRef.current = true
     }
-  }, [threads, setActiveThreadId])
+  }, [threads, initialThreadId, setActiveThreadId])
 }
 
 function useCreateThreadMutation(
@@ -129,23 +132,177 @@ function useCreateThreadMutation(
 export function useAIChatFeedState({
   threads,
   selectedModelId,
+  initialThreadId,
 }: {
   threads: ChatThreadPublic[]
   selectedModelId: string
+  initialThreadId?: string
 }) {
   const queryClient = useQueryClient()
-  const { isStreaming, startStream, stop: stopStream } = useAIChatStream()
+  const {
+    isStreaming,
+    streamingThreadId,
+    startStream,
+    stop: stopStream,
+  } = useAIChatStream()
   const { threadDrafts, setThreadDraft, clearThreadDraft } = useThreadDrafts()
 
   const [activeThreadId, setActiveThreadId] = React.useState<string | null>(
-    null,
+    initialThreadId ?? null,
   )
-  const [localMessages, setLocalMessages] = React.useState<ChatUIMessage[]>([])
+  const [messagesByThread, setMessagesByThread] = React.useState<
+    Record<string, ChatUIMessage[]>
+  >({})
   const [pendingQuestion, setPendingQuestion] =
     React.useState<AskUserToolPart | null>(null)
 
-  useInitialActiveThread(threads, setActiveThreadId)
-  useThreadTranscript({ activeThreadId, isStreaming, setLocalMessages })
+  const turnQueueRef = React.useRef<QueuedTurn[]>([])
+  const [turnQueue, setTurnQueue] = React.useState<QueuedTurn[]>([])
+  const isProcessingQueueRef = React.useRef(false)
+
+  const queuedThreadIds = React.useMemo(
+    () => turnQueue.map((t) => t.threadId),
+    [turnQueue],
+  )
+
+  const isThreadStreaming = React.useCallback(
+    (threadId: string | null) =>
+      Boolean(threadId && streamingThreadId === threadId),
+    [streamingThreadId],
+  )
+
+  const isThreadQueued = React.useCallback(
+    (threadId: string | null) =>
+      Boolean(threadId && queuedThreadIds.includes(threadId)),
+    [queuedThreadIds],
+  )
+
+  const enqueueTurn = React.useCallback((turn: QueuedTurn) => {
+    turnQueueRef.current = [...turnQueueRef.current, turn]
+    setTurnQueue(turnQueueRef.current)
+  }, [])
+
+  const dequeueTurn = React.useCallback((): QueuedTurn | undefined => {
+    const [next, ...rest] = turnQueueRef.current
+    turnQueueRef.current = rest
+    setTurnQueue(rest)
+    return next
+  }, [])
+
+  const cancelQueuedTurn = React.useCallback(
+    (threadId: string) => {
+      const cancelled = turnQueueRef.current.filter(
+        (t) => t.threadId === threadId,
+      )
+      turnQueueRef.current = turnQueueRef.current.filter(
+        (t) => t.threadId !== threadId,
+      )
+      setTurnQueue(turnQueueRef.current)
+
+      // Restore prompt text to draft if available
+      if (cancelled.length > 0 && cancelled[0].promptText) {
+        setThreadDraft(threadId, cancelled[0].promptText)
+      }
+
+      setMessagesByThread((prev) => {
+        const msgs = prev[threadId] ?? []
+        const cancelledAssistantIds = new Set(
+          cancelled.map((c) => c.assistantMsgId),
+        )
+        const cancelledPrompts = new Set(cancelled.map((c) => c.promptText))
+        const filtered = msgs.filter((m) => {
+          if (cancelledAssistantIds.has(m.id)) return false
+          if (
+            m.role === "user" &&
+            m.parts.some(
+              (p) => p.type === "text" && cancelledPrompts.has(p.text),
+            )
+          ) {
+            return false
+          }
+          return true
+        })
+        return { ...prev, [threadId]: filtered }
+      })
+    },
+    [setThreadDraft],
+  )
+
+  const handleThreadDeleted = React.useCallback(
+    (deletedId: string) => {
+      if (streamingThreadId === deletedId) {
+        stopStream(deletedId)
+      }
+      cancelQueuedTurn(deletedId)
+      setMessagesByThread((prev) => {
+        if (!(deletedId in prev)) return prev
+        const copy = { ...prev }
+        delete copy[deletedId]
+        return copy
+      })
+    },
+    [streamingThreadId, stopStream, cancelQueuedTurn],
+  )
+
+  const processQueue = React.useCallback(async () => {
+    if (isProcessingQueueRef.current) return
+    if (turnQueueRef.current.length === 0) return
+
+    isProcessingQueueRef.current = true
+    const nextTurn = dequeueTurn()
+    if (!nextTurn) {
+      isProcessingQueueRef.current = false
+      return
+    }
+
+    setMessagesByThread((prev) => {
+      const msgs = prev[nextTurn.threadId] ?? []
+      return {
+        ...prev,
+        [nextTurn.threadId]: msgs.map((m) =>
+          m.id === nextTurn.assistantMsgId ? { ...m, status: "streaming" } : m,
+        ),
+      }
+    })
+
+    const handlers = buildStreamHandlers({
+      assistantMsgId: nextTurn.assistantMsgId,
+      targetThreadId: nextTurn.threadId,
+      setMessagesByThread,
+      queryClient,
+    })
+
+    const imagesPayload =
+      nextTurn.base64Images && nextTurn.base64Images.length > 0
+        ? nextTurn.base64Images
+        : undefined
+
+    try {
+      await startStream(
+        nextTurn.threadId,
+        nextTurn.promptText,
+        handlers,
+        nextTurn.selectedModelId,
+        imagesPayload,
+      )
+    } finally {
+      isProcessingQueueRef.current = false
+      if (turnQueueRef.current.length > 0) {
+        setTimeout(() => {
+          processQueue()
+        }, 0)
+      }
+    }
+  }, [dequeueTurn, queryClient, startStream])
+
+  useInitialActiveThread(threads, initialThreadId, setActiveThreadId)
+  useThreadTranscript({
+    activeThreadId,
+    streamingThreadId,
+    queuedThreadIds,
+    setMessagesByThread,
+  })
+
   const createThreadMutation = useCreateThreadMutation(
     queryClient,
     setActiveThreadId,
@@ -155,13 +312,14 @@ export function useAIChatFeedState({
     activeThreadId,
     selectedModelId,
     isStreaming,
+    streamingThreadId,
     setActiveThreadId,
-    setLocalMessages,
+    setMessagesByThread,
     setPendingQuestion,
     clearThreadDraft,
     createThreadMutation,
-    startStream,
-    queryClient,
+    enqueueTurn,
+    processQueue,
   })
 
   const handleQuestionAnswer = React.useCallback(
@@ -178,23 +336,67 @@ export function useAIChatFeedState({
   )
 
   const handleNewChat = React.useCallback(() => {
-    stopStream()
     setActiveThreadId(null)
-    setLocalMessages([])
+    setMessagesByThread((prev) => ({ ...prev, "new-chat": [] }))
     setPendingQuestion(null)
-  }, [stopStream])
+  }, [])
+
+  const handleStop = React.useCallback(() => {
+    if (!activeThreadId) {
+      stopStream()
+      return
+    }
+    if (activeThreadId === streamingThreadId) {
+      stopStream(activeThreadId)
+    } else if (queuedThreadIds.includes(activeThreadId)) {
+      cancelQueuedTurn(activeThreadId)
+    } else {
+      stopStream()
+    }
+  }, [
+    activeThreadId,
+    cancelQueuedTurn,
+    queuedThreadIds,
+    stopStream,
+    streamingThreadId,
+  ])
+
+  const activeKey = activeThreadId ?? "new-chat"
+  const localMessages = messagesByThread[activeKey] ?? []
+
+  const setLocalMessages = React.useCallback(
+    (updater: React.SetStateAction<ChatUIMessage[]>) => {
+      const key = activeThreadId ?? "new-chat"
+      setMessagesByThread((prev) => {
+        const current = prev[key] ?? []
+        const updated =
+          typeof updater === "function" ? updater(current) : updater
+        return { ...prev, [key]: updated }
+      })
+    },
+    [activeThreadId],
+  )
 
   return {
     activeThreadId,
     setActiveThreadId,
     localMessages,
     setLocalMessages,
+    messagesByThread,
+    setMessagesByThread,
     pendingQuestion,
     threadDrafts,
     setThreadDraft,
     clearThreadDraft,
     isStreaming,
-    stopStream,
+    streamingThreadId,
+    queuedThreadIds,
+    isThreadStreaming,
+    isThreadQueued,
+    turnQueue,
+    cancelQueuedTurn,
+    handleThreadDeleted,
+    stopStream: handleStop,
     handleSendMessage,
     handleQuestionAnswer,
     handleNewChat,

--- a/frontend/src/hooks/useAIChatStream.ts
+++ b/frontend/src/hooks/useAIChatStream.ts
@@ -1,5 +1,5 @@
 import * as React from "react"
-import type { DraftArtifact } from "@/components/Chat/types"
+import type { DraftArtifact, TrendingArtifact } from "@/components/Chat/types"
 
 export interface StreamEventHandlers {
   onThought?: (content: string) => void
@@ -7,8 +7,10 @@ export interface StreamEventHandlers {
   onToolStart?: (name: string, input: unknown) => void
   onToolOutput?: (name: string, output: unknown) => void
   onDraftArtifact?: (artifact: DraftArtifact) => void
+  onTrendingArtifact?: (artifact: TrendingArtifact) => void
   onDone?: () => void
   onError?: (error: string) => void
+  onAbort?: () => void
 }
 
 interface ParsedEventData {
@@ -19,6 +21,7 @@ interface ParsedEventData {
   post_id?: string
   platform?: string
   message?: string
+  topics?: unknown[]
 }
 
 type EventAction = (
@@ -32,6 +35,8 @@ const EVENT_ACTIONS: Record<string, EventAction> = {
   tool_start: (d, h) => d.name && h.onToolStart?.(d.name, d.input),
   tool_output: (d, h) => d.name && h.onToolOutput?.(d.name, d.output),
   draft_artifact: (d, h) => h.onDraftArtifact?.(d as unknown as DraftArtifact),
+  trending_artifact: (d, h) =>
+    h.onTrendingArtifact?.(d as unknown as TrendingArtifact),
   done: (_, h) => h.onDone?.(),
   error: (d, h) => h.onError?.(d.message || "Unknown stream error"),
 }
@@ -133,14 +138,23 @@ async function executeChatStreamRequest({
 
 export function useAIChatStream() {
   const [isStreaming, setIsStreaming] = React.useState(false)
+  const [streamingThreadId, setStreamingThreadId] = React.useState<
+    string | null
+  >(null)
+  const streamingThreadIdRef = React.useRef<string | null>(null)
   const abortControllerRef = React.useRef<AbortController | null>(null)
 
-  const stop = React.useCallback(() => {
+  const stop = React.useCallback((targetThreadId?: string) => {
+    if (targetThreadId && streamingThreadIdRef.current !== targetThreadId) {
+      return
+    }
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()
       abortControllerRef.current = null
     }
     setIsStreaming(false)
+    setStreamingThreadId(null)
+    streamingThreadIdRef.current = null
   }, [])
 
   const startStream = React.useCallback(
@@ -155,6 +169,8 @@ export function useAIChatStream() {
       const controller = new AbortController()
       abortControllerRef.current = controller
       setIsStreaming(true)
+      setStreamingThreadId(threadId)
+      streamingThreadIdRef.current = threadId
 
       try {
         await executeChatStreamRequest({
@@ -167,12 +183,15 @@ export function useAIChatStream() {
         })
       } catch (err: unknown) {
         if (err instanceof Error && err.name === "AbortError") {
+          handlers.onAbort?.()
           return
         }
         const errMsg = err instanceof Error ? err.message : "Streaming failed"
         handlers.onError?.(errMsg)
       } finally {
         setIsStreaming(false)
+        setStreamingThreadId(null)
+        streamingThreadIdRef.current = null
         abortControllerRef.current = null
       }
     },
@@ -181,6 +200,7 @@ export function useAIChatStream() {
 
   return {
     isStreaming,
+    streamingThreadId,
     startStream,
     stop,
   }

--- a/frontend/src/hooks/useAIChatStream.ts
+++ b/frontend/src/hooks/useAIChatStream.ts
@@ -41,6 +41,35 @@ const EVENT_ACTIONS: Record<string, EventAction> = {
   error: (d, h) => h.onError?.(d.message || "Unknown stream error"),
 }
 
+function parseDataLine(
+  payload: string,
+  eventType: string,
+  handlers: StreamEventHandlers,
+) {
+  try {
+    const parsed = JSON.parse(payload) as ParsedEventData
+    EVENT_ACTIONS[eventType]?.(parsed, handlers)
+  } catch {
+    // Non-JSON payload ignored
+  }
+}
+
+function processSSELine(
+  line: string,
+  currentEvent: string,
+  handlers: StreamEventHandlers,
+): string {
+  const trimmed = line.trim()
+  if (!trimmed) return currentEvent
+  if (trimmed.startsWith("event:")) {
+    return trimmed.slice(6).trim()
+  }
+  if (trimmed.startsWith("data:")) {
+    parseDataLine(trimmed.slice(5).trim(), currentEvent, handlers)
+  }
+  return currentEvent
+}
+
 function parseSSELines(
   lines: string[],
   currentEvent: string,
@@ -48,19 +77,7 @@ function parseSSELines(
 ): string {
   let eventType = currentEvent
   for (const line of lines) {
-    const trimmed = line.trim()
-    if (!trimmed) continue
-
-    if (trimmed.startsWith("event:")) {
-      eventType = trimmed.slice(6).trim()
-    } else if (trimmed.startsWith("data:")) {
-      try {
-        const parsed = JSON.parse(trimmed.slice(5).trim()) as ParsedEventData
-        EVENT_ACTIONS[eventType]?.(parsed, handlers)
-      } catch {
-        // Non-JSON payload ignored
-      }
-    }
+    eventType = processSSELine(line, eventType, handlers)
   }
   return eventType
 }
@@ -136,6 +153,24 @@ async function executeChatStreamRequest({
   await streamResponse(response, handlers)
 }
 
+function abortActiveController(
+  ref: React.MutableRefObject<AbortController | null>,
+) {
+  if (ref.current) {
+    ref.current.abort()
+    ref.current = null
+  }
+}
+
+function handleStreamError(err: unknown, handlers: StreamEventHandlers) {
+  if (err instanceof Error && err.name === "AbortError") {
+    handlers.onAbort?.()
+    return
+  }
+  const errMsg = err instanceof Error ? err.message : "Streaming failed"
+  handlers.onError?.(errMsg)
+}
+
 export function useAIChatStream() {
   const [isStreaming, setIsStreaming] = React.useState(false)
   const [streamingThreadId, setStreamingThreadId] = React.useState<
@@ -148,10 +183,7 @@ export function useAIChatStream() {
     if (targetThreadId && streamingThreadIdRef.current !== targetThreadId) {
       return
     }
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort()
-      abortControllerRef.current = null
-    }
+    abortActiveController(abortControllerRef)
     setIsStreaming(false)
     setStreamingThreadId(null)
     streamingThreadIdRef.current = null
@@ -182,12 +214,7 @@ export function useAIChatStream() {
           signal: controller.signal,
         })
       } catch (err: unknown) {
-        if (err instanceof Error && err.name === "AbortError") {
-          handlers.onAbort?.()
-          return
-        }
-        const errMsg = err instanceof Error ? err.message : "Streaming failed"
-        handlers.onError?.(errMsg)
+        handleStreamError(err, handlers)
       } finally {
         setIsStreaming(false)
         setStreamingThreadId(null)

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -12,7 +12,10 @@ import { handleError } from "@/utils"
 import useCustomToast from "./useCustomToast"
 
 const isLoggedIn = () => {
-  return localStorage.getItem("access_token") !== null
+  return (
+    typeof localStorage !== "undefined" &&
+    localStorage.getItem("access_token") !== null
+  )
 }
 
 const useAuth = () => {

--- a/frontend/src/hooks/useChatTurnSender.ts
+++ b/frontend/src/hooks/useChatTurnSender.ts
@@ -30,11 +30,17 @@ export async function convertFilesToDataUrls(
   }
 }
 
-export function createMessageTurn(
-  text: string,
-  imageUrls: string[] = [],
-  assistantStatus: "queued" | "streaming" = "streaming",
-): {
+export interface CreateMessageTurnOptions {
+  text: string
+  imageUrls?: string[]
+  assistantStatus?: "queued" | "streaming"
+}
+
+export function createMessageTurn({
+  text,
+  imageUrls = [],
+  assistantStatus = "streaming",
+}: CreateMessageTurnOptions): {
   userMsg: ChatUIMessage
   assistantMsg: ChatUIMessage
 } {
@@ -64,53 +70,96 @@ export function createMessageTurn(
   return { userMsg, assistantMsg }
 }
 
-export function updateAssistantPart(
-  messages: ChatUIMessage[],
-  assistantMsgId: string,
+export interface UpdateAssistantPartOptions {
+  messages: ChatUIMessage[]
+  assistantMsgId: string
+  partType: "thought" | "text"
+  content: string
+}
+
+function findLastPartIndex(
+  parts: ChatUIMessage["parts"],
+  partType: string,
+): number {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i].type === partType) {
+      return i
+    }
+  }
+  return -1
+}
+
+function mergePartContent(
+  existing: ChatUIMessage["parts"][number],
   partType: "thought" | "text",
   content: string,
-): ChatUIMessage[] {
+): ChatUIMessage["parts"][number] {
+  if (partType === "thought" && existing.type === "thought") {
+    return { ...existing, content: existing.content + content }
+  }
+  if (partType === "text" && existing.type === "text") {
+    return { ...existing, text: existing.text + content }
+  }
+  return existing
+}
+
+function createNewPart(
+  partType: "thought" | "text",
+  content: string,
+): ChatUIMessage["parts"][number] {
+  if (partType === "thought") {
+    return { type: "thought", content }
+  }
+  return { type: "text", text: content }
+}
+
+function updateMessageParts(
+  parts: ChatUIMessage["parts"],
+  partType: "thought" | "text",
+  content: string,
+): ChatUIMessage["parts"] {
+  const updated = [...parts]
+  const existingIndex = findLastPartIndex(updated, partType)
+  if (existingIndex >= 0) {
+    updated[existingIndex] = mergePartContent(
+      updated[existingIndex],
+      partType,
+      content,
+    )
+  } else {
+    updated.push(createNewPart(partType, content))
+  }
+  return updated
+}
+
+export function updateAssistantPart({
+  messages,
+  assistantMsgId,
+  partType,
+  content,
+}: UpdateAssistantPartOptions): ChatUIMessage[] {
   return messages.map((msg) => {
     if (msg.id !== assistantMsgId) return msg
-    const parts = [...msg.parts]
-    let existingIndex = -1
-    for (let i = parts.length - 1; i >= 0; i--) {
-      if (parts[i].type === partType) {
-        existingIndex = i
-        break
-      }
+    return {
+      ...msg,
+      parts: updateMessageParts(msg.parts, partType, content),
     }
-
-    if (existingIndex >= 0) {
-      const existing = parts[existingIndex]
-      if (partType === "thought" && existing.type === "thought") {
-        parts[existingIndex] = {
-          ...existing,
-          content: existing.content + content,
-        }
-      } else if (partType === "text" && existing.type === "text") {
-        parts[existingIndex] = {
-          ...existing,
-          text: existing.text + content,
-        }
-      }
-    } else {
-      if (partType === "thought") {
-        parts.push({ type: "thought", content })
-      } else {
-        parts.push({ type: "text", text: content })
-      }
-    }
-    return { ...msg, parts }
   })
 }
 
-export function updateAssistantToolStart(
-  messages: ChatUIMessage[],
-  assistantMsgId: string,
-  name: string,
-  input: unknown,
-): ChatUIMessage[] {
+export interface UpdateAssistantToolStartOptions {
+  messages: ChatUIMessage[]
+  assistantMsgId: string
+  name: string
+  input: unknown
+}
+
+export function updateAssistantToolStart({
+  messages,
+  assistantMsgId,
+  name,
+  input,
+}: UpdateAssistantToolStartOptions): ChatUIMessage[] {
   return messages.map((msg) => {
     if (msg.id !== assistantMsgId) return msg
     const parts = [...msg.parts]
@@ -132,44 +181,61 @@ export function updateAssistantToolStart(
   })
 }
 
-export function updateAssistantToolOutput(
-  messages: ChatUIMessage[],
-  assistantMsgId: string,
+function isMatchingRunningTool(part: unknown, toolName: string): boolean {
+  if (!part || typeof part !== "object") return false
+  const p = part as { type?: string; name?: string; state?: string }
+  if (p.name !== toolName) return false
+  if (p.state !== "running") return false
+  return p.type === "tool-call" || p.type === "tool_call"
+}
+
+function createCompletedToolPart(
+  prevPart: unknown,
   name: string,
   output: unknown,
-): ChatUIMessage[] {
+): ChatUIMessage["parts"][number] {
+  const p = prevPart as {
+    toolCallId?: string
+    tool?: ToolCallItem
+    input?: Record<string, unknown>
+  }
+  const updatedTool: ToolCallItem = {
+    id: p.toolCallId || p.tool?.id || `tool_${Date.now()}`,
+    name,
+    state: "completed",
+    input: p.tool?.input || p.input,
+    output: output as Record<string, unknown>,
+  }
+  return {
+    type: "tool-call",
+    toolCallId: updatedTool.id,
+    name,
+    state: "completed",
+    tool: updatedTool,
+    input: updatedTool.input,
+    output: updatedTool.output,
+  }
+}
+
+export interface UpdateAssistantToolOutputOptions {
+  messages: ChatUIMessage[]
+  assistantMsgId: string
+  name: string
+  output: unknown
+}
+
+export function updateAssistantToolOutput({
+  messages,
+  assistantMsgId,
+  name,
+  output,
+}: UpdateAssistantToolOutputOptions): ChatUIMessage[] {
   return messages.map((msg) => {
     if (msg.id !== assistantMsgId) return msg
     const parts = [...msg.parts]
     for (let i = parts.length - 1; i >= 0; i--) {
-      const p = parts[i]
-      if (
-        (p.type === "tool-call" ||
-          (p as { type: string }).type === "tool_call") &&
-        (p as { name?: string }).name === name &&
-        (p as { state?: string }).state === "running"
-      ) {
-        const prevTool = (p as { tool?: ToolCallItem }).tool
-        const updatedTool: ToolCallItem = {
-          id:
-            (p as { toolCallId?: string }).toolCallId ||
-            prevTool?.id ||
-            `tool_${Date.now()}`,
-          name,
-          state: "completed",
-          input:
-            prevTool?.input || (p as { input?: Record<string, unknown> }).input,
-          output: output as Record<string, unknown>,
-        }
-        parts[i] = {
-          type: "tool-call",
-          toolCallId: updatedTool.id,
-          name,
-          state: "completed",
-          tool: updatedTool,
-          input: updatedTool.input,
-          output: updatedTool.output,
-        }
+      if (isMatchingRunningTool(parts[i], name)) {
+        parts[i] = createCompletedToolPart(parts[i], name, output)
         break
       }
     }
@@ -177,158 +243,204 @@ export function updateAssistantToolOutput(
   })
 }
 
-export function appendAssistantArtifact(
-  messages: ChatUIMessage[],
-  assistantMsgId: string,
-  artifactPart: ChatUIMessage["parts"][number],
-): ChatUIMessage[] {
+export interface AppendAssistantArtifactOptions {
+  messages: ChatUIMessage[]
+  assistantMsgId: string
+  artifactPart: ChatUIMessage["parts"][number]
+}
+
+export function appendAssistantArtifact({
+  messages,
+  assistantMsgId,
+  artifactPart,
+}: AppendAssistantArtifactOptions): ChatUIMessage[] {
   return messages.map((msg) => {
     if (msg.id !== assistantMsgId) return msg
     return { ...msg, parts: [...msg.parts, artifactPart] }
   })
 }
 
-export function buildStreamHandlers({
-  assistantMsgId,
-  targetThreadId,
-  setMessagesByThread,
-  queryClient,
-}: {
+export interface HandlerFactoryOptions {
   assistantMsgId: string
   targetThreadId: string
   setMessagesByThread: React.Dispatch<
     React.SetStateAction<Record<string, ChatUIMessage[]>>
   >
+}
+
+function createAbortHandler({
+  assistantMsgId,
+  targetThreadId,
+  setMessagesByThread,
+}: HandlerFactoryOptions) {
+  return () =>
+    setMessagesByThread((prev) => {
+      const msgs = prev[targetThreadId] ?? []
+      return {
+        ...prev,
+        [targetThreadId]: msgs.map((m) => {
+          if (m.id !== assistantMsgId) return m
+          const hasContent = m.parts.length > 0
+          return {
+            ...m,
+            status: "done" as const,
+            parts: hasContent
+              ? m.parts
+              : [{ type: "text" as const, text: "*(Generation stopped)*" }],
+          }
+        }),
+      }
+    })
+}
+
+function createDoneHandler({
+  assistantMsgId,
+  targetThreadId,
+  setMessagesByThread,
+  queryClient,
+}: HandlerFactoryOptions & {
   queryClient: ReturnType<typeof useQueryClient>
 }) {
+  return () => {
+    setMessagesByThread((prev) => {
+      const msgs = prev[targetThreadId] ?? []
+      return {
+        ...prev,
+        [targetThreadId]: msgs.map((m) =>
+          m.id === assistantMsgId ? { ...m, status: "done" as const } : m,
+        ),
+      }
+    })
+    queryClient.invalidateQueries({ queryKey: ["ai-threads"] })
+    queryClient.invalidateQueries({
+      queryKey: ["ai-thread", targetThreadId],
+    })
+  }
+}
+
+function createErrorHandler({
+  assistantMsgId,
+  targetThreadId,
+  setMessagesByThread,
+}: HandlerFactoryOptions) {
+  return (errMsg: string) =>
+    setMessagesByThread((prev) => {
+      const msgs = prev[targetThreadId] ?? []
+      const updated = updateAssistantPart({
+        messages: msgs,
+        assistantMsgId,
+        partType: "text",
+        content: `\n\n*(Error: ${errMsg})*`,
+      })
+      return {
+        ...prev,
+        [targetThreadId]: updated.map((m) =>
+          m.id === assistantMsgId ? { ...m, status: "error" as const } : m,
+        ),
+      }
+    })
+}
+
+function createContentHandlers({
+  assistantMsgId,
+  targetThreadId,
+  setMessagesByThread,
+}: HandlerFactoryOptions) {
   return {
     onThought: (content: string) =>
       setMessagesByThread((prev) => ({
         ...prev,
-        [targetThreadId]: updateAssistantPart(
-          prev[targetThreadId] ?? [],
+        [targetThreadId]: updateAssistantPart({
+          messages: prev[targetThreadId] ?? [],
           assistantMsgId,
-          "thought",
+          partType: "thought",
           content,
-        ),
+        }),
       })),
     onTextDelta: (delta: string) =>
       setMessagesByThread((prev) => ({
         ...prev,
-        [targetThreadId]: updateAssistantPart(
-          prev[targetThreadId] ?? [],
+        [targetThreadId]: updateAssistantPart({
+          messages: prev[targetThreadId] ?? [],
           assistantMsgId,
-          "text",
-          delta,
-        ),
+          partType: "text",
+          content: delta,
+        }),
       })),
     onToolStart: (name: string, input: unknown) =>
       setMessagesByThread((prev) => ({
         ...prev,
-        [targetThreadId]: updateAssistantToolStart(
-          prev[targetThreadId] ?? [],
+        [targetThreadId]: updateAssistantToolStart({
+          messages: prev[targetThreadId] ?? [],
           assistantMsgId,
           name,
           input,
-        ),
+        }),
       })),
     onToolOutput: (name: string, output: unknown) =>
       setMessagesByThread((prev) => ({
         ...prev,
-        [targetThreadId]: updateAssistantToolOutput(
-          prev[targetThreadId] ?? [],
+        [targetThreadId]: updateAssistantToolOutput({
+          messages: prev[targetThreadId] ?? [],
           assistantMsgId,
           name,
           output,
-        ),
+        }),
       })),
     onTrendingArtifact: (artifact: TrendingArtifact) =>
       setMessagesByThread((prev) => ({
         ...prev,
-        [targetThreadId]: appendAssistantArtifact(
-          prev[targetThreadId] ?? [],
+        [targetThreadId]: appendAssistantArtifact({
+          messages: prev[targetThreadId] ?? [],
           assistantMsgId,
-          {
-            type: "trending_artifact",
-            artifact,
-          },
-        ),
+          artifactPart: { type: "trending_artifact", artifact },
+        }),
       })),
     onDraftArtifact: (artifact: DraftArtifact) =>
       setMessagesByThread((prev) => ({
         ...prev,
-        [targetThreadId]: appendAssistantArtifact(
-          prev[targetThreadId] ?? [],
+        [targetThreadId]: appendAssistantArtifact({
+          messages: prev[targetThreadId] ?? [],
           assistantMsgId,
-          {
-            type: "draft_artifact",
-            artifact,
-          },
-        ),
+          artifactPart: { type: "draft_artifact", artifact },
+        }),
       })),
-    onError: (errMsg: string) =>
-      setMessagesByThread((prev) => {
-        const msgs = prev[targetThreadId] ?? []
-        const updated = updateAssistantPart(
-          msgs,
-          assistantMsgId,
-          "text",
-          `\n\n*(Error: ${errMsg})*`,
-        )
-        return {
-          ...prev,
-          [targetThreadId]: updated.map((m) =>
-            m.id === assistantMsgId ? { ...m, status: "error" as const } : m,
-          ),
-        }
-      }),
-    onAbort: () =>
-      setMessagesByThread((prev) => {
-        const msgs = prev[targetThreadId] ?? []
-        return {
-          ...prev,
-          [targetThreadId]: msgs.map((m) => {
-            if (m.id !== assistantMsgId) return m
-            const hasContent = m.parts.length > 0
-            if (!hasContent) {
-              return {
-                ...m,
-                status: "done" as const,
-                parts: [
-                  { type: "text" as const, text: "*(Generation stopped)*" },
-                ],
-              }
-            }
-            return { ...m, status: "done" as const }
-          }),
-        }
-      }),
-    onDone: () => {
-      setMessagesByThread((prev) => {
-        const msgs = prev[targetThreadId] ?? []
-        return {
-          ...prev,
-          [targetThreadId]: msgs.map((m) =>
-            m.id === assistantMsgId ? { ...m, status: "done" as const } : m,
-          ),
-        }
-      })
-      queryClient.invalidateQueries({ queryKey: ["ai-threads"] })
-      queryClient.invalidateQueries({
-        queryKey: ["ai-thread", targetThreadId],
-      })
-    },
   }
 }
 
-export async function resolveTargetThreadId(
-  activeThreadId: string | null,
-  promptText: string,
+export function buildStreamHandlers(
+  options: HandlerFactoryOptions & {
+    queryClient: ReturnType<typeof useQueryClient>
+  },
+) {
+  const contentHandlers = createContentHandlers(options)
+  const onAbort = createAbortHandler(options)
+  const onDone = createDoneHandler(options)
+  const onError = createErrorHandler(options)
+
+  return {
+    ...contentHandlers,
+    onError,
+    onAbort,
+    onDone,
+  }
+}
+
+export interface ResolveTargetThreadOptions {
+  activeThreadId: string | null
+  promptText: string
   createThreadMutation: ReturnType<
     typeof useMutation<ChatThreadPublic, Error, string | undefined>
-  >,
-  setActiveThreadId: (id: string) => void,
-): Promise<string | null> {
+  >
+  setActiveThreadId: (id: string) => void
+}
+
+export async function resolveTargetThreadId({
+  activeThreadId,
+  promptText,
+  createThreadMutation,
+  setActiveThreadId,
+}: ResolveTargetThreadOptions): Promise<string | null> {
   if (activeThreadId) return activeThreadId
   try {
     const newThread = await createThreadMutation.mutateAsync(promptText)
@@ -339,18 +451,24 @@ export async function resolveTargetThreadId(
   }
 }
 
-export function resolvePromptText(
-  trimmedText: string,
-  hasImages: boolean,
-): string {
+export function resolvePromptText({
+  trimmedText,
+  hasImages,
+}: {
+  trimmedText: string
+  hasImages: boolean
+}): string {
   if (trimmedText) return trimmedText
   return hasImages ? "Analyze the attached image(s)" : ""
 }
 
-export function shouldSkipMessageSend(
-  trimmedText: string,
-  hasImages: boolean,
-): boolean {
+export function shouldSkipMessageSend({
+  trimmedText,
+  hasImages,
+}: {
+  trimmedText: string
+  hasImages: boolean
+}): boolean {
   return !trimmedText && !hasImages
 }
 
@@ -372,91 +490,118 @@ export interface UseChatTurnSenderProps {
   processQueue: () => void
 }
 
-export function useChatTurnSender(props: UseChatTurnSenderProps) {
-  const {
-    activeThreadId,
-    selectedModelId,
-    isStreaming,
-    streamingThreadId,
-    setActiveThreadId,
-    setMessagesByThread,
-    setPendingQuestion,
-    clearThreadDraft,
-    createThreadMutation,
-    enqueueTurn,
-    processQueue,
-  } = props
+interface DispatchTurnOptions {
+  targetThreadId: string
+  promptText: string
+  base64Images: string[]
+  selectedModelId: string
+  assistantMsg: ChatUIMessage
+  userMsg: ChatUIMessage
+  setMessagesByThread: React.Dispatch<
+    React.SetStateAction<Record<string, ChatUIMessage[]>>
+  >
+  setPendingQuestion: (q: AskUserToolPart | null) => void
+  enqueueTurn: (turn: QueuedTurn) => void
+  processQueue: () => void
+}
 
+function dispatchQueuedTurn({
+  targetThreadId,
+  promptText,
+  base64Images,
+  selectedModelId,
+  assistantMsg,
+  userMsg,
+  setMessagesByThread,
+  setPendingQuestion,
+  enqueueTurn,
+  processQueue,
+}: DispatchTurnOptions) {
+  setMessagesByThread((prev) => ({
+    ...prev,
+    [targetThreadId]: [...(prev[targetThreadId] ?? []), userMsg, assistantMsg],
+  }))
+  setPendingQuestion(null)
+
+  const queuedTurn: QueuedTurn = {
+    id: `queue_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+    threadId: targetThreadId,
+    promptText,
+    base64Images: base64Images.length > 0 ? base64Images : undefined,
+    selectedModelId,
+    assistantMsgId: assistantMsg.id,
+  }
+
+  enqueueTurn(queuedTurn)
+  processQueue()
+}
+
+interface ExecuteSendOptions extends UseChatTurnSenderProps {
+  text: string
+  attachedImages?: File[]
+  isResolvingThreadRef: React.MutableRefObject<boolean>
+}
+
+async function executeChatTurnSend(options: ExecuteSendOptions) {
+  const trimmedText = options.text.trim()
+  const hasImages = Boolean(
+    options.attachedImages && options.attachedImages.length > 0,
+  )
+  if (shouldSkipMessageSend({ trimmedText, hasImages })) return
+
+  if (options.isResolvingThreadRef.current) return
+  options.isResolvingThreadRef.current = true
+
+  try {
+    const base64Images = await convertFilesToDataUrls(options.attachedImages)
+    const promptText = resolvePromptText({ trimmedText, hasImages })
+    const targetThreadId = await resolveTargetThreadId({
+      activeThreadId: options.activeThreadId,
+      promptText,
+      createThreadMutation: options.createThreadMutation,
+      setActiveThreadId: options.setActiveThreadId,
+    })
+    if (!targetThreadId) return
+
+    options.clearThreadDraft(options.activeThreadId)
+
+    const isBusy = options.isStreaming || options.streamingThreadId !== null
+    const assistantStatus = isBusy ? "queued" : "streaming"
+
+    const { userMsg, assistantMsg } = createMessageTurn({
+      text: promptText,
+      imageUrls: base64Images,
+      assistantStatus,
+    })
+
+    dispatchQueuedTurn({
+      targetThreadId,
+      promptText,
+      base64Images,
+      selectedModelId: options.selectedModelId,
+      assistantMsg,
+      userMsg,
+      setMessagesByThread: options.setMessagesByThread,
+      setPendingQuestion: options.setPendingQuestion,
+      enqueueTurn: options.enqueueTurn,
+      processQueue: options.processQueue,
+    })
+  } finally {
+    options.isResolvingThreadRef.current = false
+  }
+}
+
+export function useChatTurnSender(props: UseChatTurnSenderProps) {
   const isResolvingThreadRef = React.useRef(false)
 
   return React.useCallback(
-    async (text: string, attachedImages?: File[]) => {
-      const trimmedText = text.trim()
-      const hasImages = Boolean(attachedImages && attachedImages.length > 0)
-      if (shouldSkipMessageSend(trimmedText, hasImages)) return
-
-      if (isResolvingThreadRef.current) return
-      isResolvingThreadRef.current = true
-
-      try {
-        const base64Images = await convertFilesToDataUrls(attachedImages)
-        const promptText = resolvePromptText(trimmedText, hasImages)
-        const targetThreadId = await resolveTargetThreadId(
-          activeThreadId,
-          promptText,
-          createThreadMutation,
-          setActiveThreadId,
-        )
-        if (!targetThreadId) return
-
-        clearThreadDraft(activeThreadId)
-
-        const isBusy = isStreaming || streamingThreadId !== null
-        const assistantStatus = isBusy ? "queued" : "streaming"
-
-        const { userMsg, assistantMsg } = createMessageTurn(
-          promptText,
-          base64Images,
-          assistantStatus,
-        )
-
-        setMessagesByThread((prev) => ({
-          ...prev,
-          [targetThreadId]: [
-            ...(prev[targetThreadId] ?? []),
-            userMsg,
-            assistantMsg,
-          ],
-        }))
-        setPendingQuestion(null)
-
-        const queuedTurn: QueuedTurn = {
-          id: `queue_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
-          threadId: targetThreadId,
-          promptText,
-          base64Images: base64Images.length > 0 ? base64Images : undefined,
-          selectedModelId,
-          assistantMsgId: assistantMsg.id,
-        }
-
-        enqueueTurn(queuedTurn)
-        processQueue()
-      } finally {
-        isResolvingThreadRef.current = false
-      }
-    },
-    [
-      activeThreadId,
-      clearThreadDraft,
-      createThreadMutation,
-      enqueueTurn,
-      isStreaming,
-      processQueue,
-      selectedModelId,
-      setActiveThreadId,
-      setMessagesByThread,
-      setPendingQuestion,
-      streamingThreadId,
-    ],
+    (text: string, attachedImages?: File[]) =>
+      executeChatTurnSend({
+        ...props,
+        text,
+        attachedImages,
+        isResolvingThreadRef,
+      }),
+    [props],
   )
 }

--- a/frontend/src/hooks/useChatTurnSender.ts
+++ b/frontend/src/hooks/useChatTurnSender.ts
@@ -1,10 +1,16 @@
 import type { useMutation, useQueryClient } from "@tanstack/react-query"
 import * as React from "react"
 import type { ChatThreadPublic } from "@/client"
-import type { AskUserToolPart, ChatUIMessage } from "@/components/Chat/types"
-import type { useAIChatStream } from "@/hooks/useAIChatStream"
+import type {
+  AskUserToolPart,
+  ChatUIMessage,
+  DraftArtifact,
+  QueuedTurn,
+  ToolCallItem,
+  TrendingArtifact,
+} from "@/components/Chat/types"
 
-function fileToDataUrl(file: File): Promise<string> {
+export function fileToDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = () => resolve(reader.result as string)
@@ -13,7 +19,9 @@ function fileToDataUrl(file: File): Promise<string> {
   })
 }
 
-async function convertFilesToDataUrls(files?: File[]): Promise<string[]> {
+export async function convertFilesToDataUrls(
+  files?: File[],
+): Promise<string[]> {
   if (!files || files.length === 0) return []
   try {
     return await Promise.all(files.map(fileToDataUrl))
@@ -22,9 +30,10 @@ async function convertFilesToDataUrls(files?: File[]): Promise<string[]> {
   }
 }
 
-function createMessageTurn(
+export function createMessageTurn(
   text: string,
   imageUrls: string[] = [],
+  assistantStatus: "queued" | "streaming" = "streaming",
 ): {
   userMsg: ChatUIMessage
   assistantMsg: ChatUIMessage
@@ -38,23 +47,24 @@ function createMessageTurn(
   }
 
   const userMsg: ChatUIMessage = {
-    id: `local_user_${Date.now()}`,
+    id: `local_user_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
     role: "user",
     parts,
     createdAt: new Date().toISOString(),
   }
 
   const assistantMsg: ChatUIMessage = {
-    id: `local_assistant_${Date.now() + 1}`,
+    id: `local_assistant_${Date.now() + 1}_${Math.random().toString(36).slice(2, 6)}`,
     role: "assistant",
     parts: [],
+    status: assistantStatus,
     createdAt: new Date().toISOString(),
   }
 
   return { userMsg, assistantMsg }
 }
 
-function updateAssistantPart(
+export function updateAssistantPart(
   messages: ChatUIMessage[],
   assistantMsgId: string,
   partType: "thought" | "text",
@@ -95,27 +105,214 @@ function updateAssistantPart(
   })
 }
 
-function buildStreamHandlers({
+export function updateAssistantToolStart(
+  messages: ChatUIMessage[],
+  assistantMsgId: string,
+  name: string,
+  input: unknown,
+): ChatUIMessage[] {
+  return messages.map((msg) => {
+    if (msg.id !== assistantMsgId) return msg
+    const parts = [...msg.parts]
+    const toolItem: ToolCallItem = {
+      id: `tool_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+      name,
+      state: "running",
+      input: input as Record<string, unknown>,
+    }
+    parts.push({
+      type: "tool-call",
+      toolCallId: toolItem.id,
+      name,
+      state: "running",
+      tool: toolItem,
+      input: input as Record<string, unknown>,
+    })
+    return { ...msg, parts }
+  })
+}
+
+export function updateAssistantToolOutput(
+  messages: ChatUIMessage[],
+  assistantMsgId: string,
+  name: string,
+  output: unknown,
+): ChatUIMessage[] {
+  return messages.map((msg) => {
+    if (msg.id !== assistantMsgId) return msg
+    const parts = [...msg.parts]
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const p = parts[i]
+      if (
+        (p.type === "tool-call" ||
+          (p as { type: string }).type === "tool_call") &&
+        (p as { name?: string }).name === name &&
+        (p as { state?: string }).state === "running"
+      ) {
+        const prevTool = (p as { tool?: ToolCallItem }).tool
+        const updatedTool: ToolCallItem = {
+          id:
+            (p as { toolCallId?: string }).toolCallId ||
+            prevTool?.id ||
+            `tool_${Date.now()}`,
+          name,
+          state: "completed",
+          input:
+            prevTool?.input || (p as { input?: Record<string, unknown> }).input,
+          output: output as Record<string, unknown>,
+        }
+        parts[i] = {
+          type: "tool-call",
+          toolCallId: updatedTool.id,
+          name,
+          state: "completed",
+          tool: updatedTool,
+          input: updatedTool.input,
+          output: updatedTool.output,
+        }
+        break
+      }
+    }
+    return { ...msg, parts }
+  })
+}
+
+export function appendAssistantArtifact(
+  messages: ChatUIMessage[],
+  assistantMsgId: string,
+  artifactPart: ChatUIMessage["parts"][number],
+): ChatUIMessage[] {
+  return messages.map((msg) => {
+    if (msg.id !== assistantMsgId) return msg
+    return { ...msg, parts: [...msg.parts, artifactPart] }
+  })
+}
+
+export function buildStreamHandlers({
   assistantMsgId,
   targetThreadId,
-  setLocalMessages,
+  setMessagesByThread,
   queryClient,
 }: {
   assistantMsgId: string
   targetThreadId: string
-  setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>
+  setMessagesByThread: React.Dispatch<
+    React.SetStateAction<Record<string, ChatUIMessage[]>>
+  >
   queryClient: ReturnType<typeof useQueryClient>
 }) {
   return {
     onThought: (content: string) =>
-      setLocalMessages((prev) =>
-        updateAssistantPart(prev, assistantMsgId, "thought", content),
-      ),
+      setMessagesByThread((prev) => ({
+        ...prev,
+        [targetThreadId]: updateAssistantPart(
+          prev[targetThreadId] ?? [],
+          assistantMsgId,
+          "thought",
+          content,
+        ),
+      })),
     onTextDelta: (delta: string) =>
-      setLocalMessages((prev) =>
-        updateAssistantPart(prev, assistantMsgId, "text", delta),
-      ),
+      setMessagesByThread((prev) => ({
+        ...prev,
+        [targetThreadId]: updateAssistantPart(
+          prev[targetThreadId] ?? [],
+          assistantMsgId,
+          "text",
+          delta,
+        ),
+      })),
+    onToolStart: (name: string, input: unknown) =>
+      setMessagesByThread((prev) => ({
+        ...prev,
+        [targetThreadId]: updateAssistantToolStart(
+          prev[targetThreadId] ?? [],
+          assistantMsgId,
+          name,
+          input,
+        ),
+      })),
+    onToolOutput: (name: string, output: unknown) =>
+      setMessagesByThread((prev) => ({
+        ...prev,
+        [targetThreadId]: updateAssistantToolOutput(
+          prev[targetThreadId] ?? [],
+          assistantMsgId,
+          name,
+          output,
+        ),
+      })),
+    onTrendingArtifact: (artifact: TrendingArtifact) =>
+      setMessagesByThread((prev) => ({
+        ...prev,
+        [targetThreadId]: appendAssistantArtifact(
+          prev[targetThreadId] ?? [],
+          assistantMsgId,
+          {
+            type: "trending_artifact",
+            artifact,
+          },
+        ),
+      })),
+    onDraftArtifact: (artifact: DraftArtifact) =>
+      setMessagesByThread((prev) => ({
+        ...prev,
+        [targetThreadId]: appendAssistantArtifact(
+          prev[targetThreadId] ?? [],
+          assistantMsgId,
+          {
+            type: "draft_artifact",
+            artifact,
+          },
+        ),
+      })),
+    onError: (errMsg: string) =>
+      setMessagesByThread((prev) => {
+        const msgs = prev[targetThreadId] ?? []
+        const updated = updateAssistantPart(
+          msgs,
+          assistantMsgId,
+          "text",
+          `\n\n*(Error: ${errMsg})*`,
+        )
+        return {
+          ...prev,
+          [targetThreadId]: updated.map((m) =>
+            m.id === assistantMsgId ? { ...m, status: "error" as const } : m,
+          ),
+        }
+      }),
+    onAbort: () =>
+      setMessagesByThread((prev) => {
+        const msgs = prev[targetThreadId] ?? []
+        return {
+          ...prev,
+          [targetThreadId]: msgs.map((m) => {
+            if (m.id !== assistantMsgId) return m
+            const hasContent = m.parts.length > 0
+            if (!hasContent) {
+              return {
+                ...m,
+                status: "done" as const,
+                parts: [
+                  { type: "text" as const, text: "*(Generation stopped)*" },
+                ],
+              }
+            }
+            return { ...m, status: "done" as const }
+          }),
+        }
+      }),
     onDone: () => {
+      setMessagesByThread((prev) => {
+        const msgs = prev[targetThreadId] ?? []
+        return {
+          ...prev,
+          [targetThreadId]: msgs.map((m) =>
+            m.id === assistantMsgId ? { ...m, status: "done" as const } : m,
+          ),
+        }
+      })
       queryClient.invalidateQueries({ queryKey: ["ai-threads"] })
       queryClient.invalidateQueries({
         queryKey: ["ai-thread", targetThreadId],
@@ -124,7 +321,7 @@ function buildStreamHandlers({
   }
 }
 
-async function resolveTargetThreadId(
+export async function resolveTargetThreadId(
   activeThreadId: string | null,
   promptText: string,
   createThreadMutation: ReturnType<
@@ -142,17 +339,18 @@ async function resolveTargetThreadId(
   }
 }
 
-function resolvePromptText(trimmedText: string, hasImages: boolean): string {
+export function resolvePromptText(
+  trimmedText: string,
+  hasImages: boolean,
+): string {
   if (trimmedText) return trimmedText
   return hasImages ? "Analyze the attached image(s)" : ""
 }
 
-function shouldSkipMessageSend(
+export function shouldSkipMessageSend(
   trimmedText: string,
   hasImages: boolean,
-  isStreaming: boolean,
 ): boolean {
-  if (isStreaming) return true
   return !trimmedText && !hasImages
 }
 
@@ -160,62 +358,18 @@ export interface UseChatTurnSenderProps {
   activeThreadId: string | null
   selectedModelId: string
   isStreaming: boolean
+  streamingThreadId: string | null
   setActiveThreadId: (id: string) => void
-  setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>
+  setMessagesByThread: React.Dispatch<
+    React.SetStateAction<Record<string, ChatUIMessage[]>>
+  >
   setPendingQuestion: (q: AskUserToolPart | null) => void
   clearThreadDraft: (id: string | null) => void
   createThreadMutation: ReturnType<
     typeof useMutation<ChatThreadPublic, Error, string | undefined>
   >
-  startStream: ReturnType<typeof useAIChatStream>["startStream"]
-  queryClient: ReturnType<typeof useQueryClient>
-}
-
-function appendOptimisticTurn(
-  promptText: string,
-  base64Images: string[],
-  setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>,
-  setPendingQuestion: (q: AskUserToolPart | null) => void,
-): { assistantMsgId: string } {
-  const { userMsg, assistantMsg } = createMessageTurn(promptText, base64Images)
-  setLocalMessages((prev) => [...prev, userMsg, assistantMsg])
-  setPendingQuestion(null)
-  return { assistantMsgId: assistantMsg.id }
-}
-
-function sendTurnStream({
-  assistantMsgId,
-  targetThreadId,
-  promptText,
-  base64Images,
-  selectedModelId,
-  setLocalMessages,
-  queryClient,
-  startStream,
-}: {
-  assistantMsgId: string
-  targetThreadId: string
-  promptText: string
-  base64Images: string[]
-  selectedModelId: string
-  setLocalMessages: React.Dispatch<React.SetStateAction<ChatUIMessage[]>>
-  queryClient: ReturnType<typeof useQueryClient>
-  startStream: ReturnType<typeof useAIChatStream>["startStream"]
-}) {
-  const handlers = buildStreamHandlers({
-    assistantMsgId,
-    targetThreadId,
-    setLocalMessages,
-    queryClient,
-  })
-  const imagesPayload = base64Images.length > 0 ? base64Images : undefined
-  startStream(
-    targetThreadId,
-    promptText,
-    handlers,
-    selectedModelId,
-    imagesPayload,
-  )
+  enqueueTurn: (turn: QueuedTurn) => void
+  processQueue: () => void
 }
 
 export function useChatTurnSender(props: UseChatTurnSenderProps) {
@@ -223,61 +377,86 @@ export function useChatTurnSender(props: UseChatTurnSenderProps) {
     activeThreadId,
     selectedModelId,
     isStreaming,
+    streamingThreadId,
     setActiveThreadId,
-    setLocalMessages,
+    setMessagesByThread,
     setPendingQuestion,
     clearThreadDraft,
     createThreadMutation,
-    startStream,
-    queryClient,
+    enqueueTurn,
+    processQueue,
   } = props
+
+  const isResolvingThreadRef = React.useRef(false)
 
   return React.useCallback(
     async (text: string, attachedImages?: File[]) => {
       const trimmedText = text.trim()
       const hasImages = Boolean(attachedImages && attachedImages.length > 0)
-      if (shouldSkipMessageSend(trimmedText, hasImages, isStreaming)) return
+      if (shouldSkipMessageSend(trimmedText, hasImages)) return
 
-      const base64Images = await convertFilesToDataUrls(attachedImages)
-      clearThreadDraft(activeThreadId)
-      const promptText = resolvePromptText(trimmedText, hasImages)
-      const { assistantMsgId } = appendOptimisticTurn(
-        promptText,
-        base64Images,
-        setLocalMessages,
-        setPendingQuestion,
-      )
+      if (isResolvingThreadRef.current) return
+      isResolvingThreadRef.current = true
 
-      const targetThreadId = await resolveTargetThreadId(
-        activeThreadId,
-        promptText,
-        createThreadMutation,
-        setActiveThreadId,
-      )
-      if (!targetThreadId) return
+      try {
+        const base64Images = await convertFilesToDataUrls(attachedImages)
+        const promptText = resolvePromptText(trimmedText, hasImages)
+        const targetThreadId = await resolveTargetThreadId(
+          activeThreadId,
+          promptText,
+          createThreadMutation,
+          setActiveThreadId,
+        )
+        if (!targetThreadId) return
 
-      sendTurnStream({
-        assistantMsgId,
-        targetThreadId,
-        promptText,
-        base64Images,
-        selectedModelId,
-        setLocalMessages,
-        queryClient,
-        startStream,
-      })
+        clearThreadDraft(activeThreadId)
+
+        const isBusy = isStreaming || streamingThreadId !== null
+        const assistantStatus = isBusy ? "queued" : "streaming"
+
+        const { userMsg, assistantMsg } = createMessageTurn(
+          promptText,
+          base64Images,
+          assistantStatus,
+        )
+
+        setMessagesByThread((prev) => ({
+          ...prev,
+          [targetThreadId]: [
+            ...(prev[targetThreadId] ?? []),
+            userMsg,
+            assistantMsg,
+          ],
+        }))
+        setPendingQuestion(null)
+
+        const queuedTurn: QueuedTurn = {
+          id: `queue_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          threadId: targetThreadId,
+          promptText,
+          base64Images: base64Images.length > 0 ? base64Images : undefined,
+          selectedModelId,
+          assistantMsgId: assistantMsg.id,
+        }
+
+        enqueueTurn(queuedTurn)
+        processQueue()
+      } finally {
+        isResolvingThreadRef.current = false
+      }
     },
     [
       activeThreadId,
       clearThreadDraft,
-      isStreaming,
       createThreadMutation,
+      enqueueTurn,
+      isStreaming,
+      processQueue,
       selectedModelId,
-      startStream,
-      queryClient,
       setActiveThreadId,
-      setLocalMessages,
+      setMessagesByThread,
       setPendingQuestion,
+      streamingThreadId,
     ],
   )
 }

--- a/frontend/src/routes/_layout/ai.tsx
+++ b/frontend/src/routes/_layout/ai.tsx
@@ -12,7 +12,18 @@ import { PromptForm } from "@/components/Chat/PromptForm"
 import { RenameThreadDialog } from "@/components/Chat/RenameThreadDialog"
 import { useAIChatFeedState } from "@/hooks/useAIChatFeedState"
 
+interface AISearchParams {
+  threadId?: string
+  prompt?: string
+  autoRun?: boolean
+}
+
 export const Route = createFileRoute("/_layout/ai")({
+  validateSearch: (search: Record<string, unknown>): AISearchParams => ({
+    threadId: typeof search.threadId === "string" ? search.threadId : undefined,
+    prompt: typeof search.prompt === "string" ? search.prompt : undefined,
+    autoRun: search.autoRun === true || search.autoRun === "true",
+  }),
   component: AIPage,
   head: () => ({
     meta: [
@@ -29,12 +40,12 @@ function getInitialStoredModel(): string {
   if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
     try {
       const saved = localStorage.getItem(AI_MODEL_STORAGE_KEY)
-      if (saved) return saved
+      if (saved && !saved.startsWith("gemini")) return saved
     } catch {
       // ignore
     }
   }
-  return "gemini-3.6-flash-high"
+  return "gpt-5.4"
 }
 
 function filterAndSortThreads(
@@ -60,7 +71,22 @@ function filterAndSortThreads(
   return result
 }
 
+function getUrlSearchParams(): AISearchParams {
+  if (typeof window === "undefined") return {}
+  try {
+    const params = new URLSearchParams(window.location.search)
+    return {
+      threadId: params.get("threadId") || undefined,
+      prompt: params.get("prompt") || undefined,
+      autoRun: params.get("autoRun") === "true",
+    }
+  } catch {
+    return {}
+  }
+}
+
 function AIPage() {
+  const search = React.useMemo(() => getUrlSearchParams(), [])
   const queryClient = useQueryClient()
   const promptInputRef = React.useRef<HTMLTextAreaElement>(null)
 
@@ -105,13 +131,15 @@ function AIPage() {
         ? localStorage.getItem(AI_MODEL_STORAGE_KEY)
         : null
 
-    if (!saved) {
-      const defaultId = modelsData.default_model || modelsData.data?.[0]?.id
+    if (!saved || saved.startsWith("gemini")) {
+      const defaultId =
+        modelsData.default_model || modelsData.data?.[0]?.id || "gpt-5.4"
       if (defaultId) setSelectedModelId(defaultId)
     } else if (modelsData.data && modelsData.data.length > 0) {
       const exists = modelsData.data.some((m) => m.id === saved)
       if (!exists) {
-        const fallback = modelsData.default_model || modelsData.data[0].id
+        const fallback =
+          modelsData.default_model || modelsData.data[0].id || "gpt-5.4"
         setSelectedModelId(fallback)
       }
     }
@@ -128,16 +156,82 @@ function AIPage() {
     activeThreadId,
     setActiveThreadId,
     localMessages,
-    setLocalMessages,
     pendingQuestion,
     threadDrafts,
     setThreadDraft,
-    isStreaming,
+    streamingThreadId,
+    queuedThreadIds,
+    isThreadStreaming,
+    isThreadQueued,
+    handleThreadDeleted,
     stopStream,
     handleSendMessage,
     handleQuestionAnswer,
     handleNewChat,
-  } = useAIChatFeedState({ threads, selectedModelId })
+  } = useAIChatFeedState({
+    threads,
+    selectedModelId,
+    initialThreadId: search.threadId,
+  })
+
+  const isCurrentThreadStreaming = isThreadStreaming(activeThreadId)
+  const isCurrentThreadQueued = isThreadQueued(activeThreadId)
+  const isCurrentThreadBusy = isCurrentThreadStreaming || isCurrentThreadQueued
+
+  const autoRunExecutedRef = React.useRef(false)
+  React.useEffect(() => {
+    if (search.autoRun && search.prompt && !autoRunExecutedRef.current) {
+      autoRunExecutedRef.current = true
+      try {
+        const url = new URL(window.location.href)
+        url.searchParams.delete("autoRun")
+        url.searchParams.delete("prompt")
+        window.history.replaceState(
+          {},
+          "",
+          url.pathname + (url.search ? url.search : ""),
+        )
+      } catch {
+        // ignore
+      }
+      handleSendMessage(search.prompt)
+    }
+  }, [search.autoRun, search.prompt, handleSendMessage])
+
+  // Keep browser URL in sync with activeThreadId and purge stale autoRun/prompt params
+  React.useEffect(() => {
+    if (typeof window === "undefined") return
+    try {
+      const url = new URL(window.location.href)
+      let changed = false
+      if (url.searchParams.has("autoRun")) {
+        url.searchParams.delete("autoRun")
+        changed = true
+      }
+      if (url.searchParams.has("prompt")) {
+        url.searchParams.delete("prompt")
+        changed = true
+      }
+      if (activeThreadId) {
+        if (url.searchParams.get("threadId") !== activeThreadId) {
+          url.searchParams.set("threadId", activeThreadId)
+          changed = true
+        }
+      } else if (url.searchParams.has("threadId")) {
+        url.searchParams.delete("threadId")
+        changed = true
+      }
+      if (changed) {
+        window.history.replaceState(
+          {},
+          "",
+          url.pathname + (url.search ? url.search : ""),
+        )
+      }
+    } catch {
+      // ignore
+    }
+  }, [activeThreadId])
 
   const updateThreadMutation = useMutation({
     mutationFn: ({
@@ -163,10 +257,10 @@ function AIPage() {
     mutationFn: (id: string) => AiThreadsService.deleteChatThread({ id }),
     onSuccess: (_, deletedId) => {
       queryClient.invalidateQueries({ queryKey: ["ai-threads"] })
+      handleThreadDeleted(deletedId)
       if (activeThreadId === deletedId) {
         const remaining = threads.filter((t) => t.id !== deletedId)
         setActiveThreadId(remaining.length > 0 ? remaining[0].id : null)
-        setLocalMessages([])
       }
       setThreadToDelete(null)
     },
@@ -223,7 +317,7 @@ function AIPage() {
   )
 
   return (
-    <div className="flex w-full min-h-[calc(100vh-3.5rem)] lg:min-h-screen bg-background text-foreground">
+    <div className="flex w-full h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden bg-background text-foreground">
       <RenameThreadDialog
         thread={threadToRename}
         isOpen={Boolean(threadToRename)}
@@ -248,7 +342,7 @@ function AIPage() {
       <div className="relative mx-auto flex min-h-0 w-full flex-1 max-w-2xl border-r-0 md:border-r border-border flex-col h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden">
         <AIChatFeed
           localMessages={localMessages}
-          isStreaming={isStreaming}
+          isStreaming={isCurrentThreadStreaming}
           pendingQuestion={pendingQuestion}
           onSendMessage={handleSendMessage}
           onQuestionAnswer={handleQuestionAnswer}
@@ -260,8 +354,10 @@ function AIPage() {
             inputRef={promptInputRef}
             initialValue={threadDrafts[activeThreadId ?? "new-chat"] ?? ""}
             onValueChange={(val) => setThreadDraft(activeThreadId, val)}
-            placeholder="Ask anything"
-            isBusy={isStreaming}
+            placeholder={
+              isCurrentThreadQueued ? "Waiting in queue..." : "Ask anything"
+            }
+            isBusy={isCurrentThreadBusy}
             selectedModelId={selectedModelId}
             models={modelsData?.data}
             onSelectModel={setSelectedModelId}
@@ -279,6 +375,8 @@ function AIPage() {
         activeThreadId={activeThreadId}
         openMenuThreadId={openMenuThreadId}
         isLoading={isThreadsLoading}
+        streamingThreadId={streamingThreadId}
+        queuedThreadIds={queuedThreadIds}
         filters={{
           searchQuery,
           isSearchOpen,
@@ -302,7 +400,6 @@ function AIPage() {
         actions={{
           onSelect: (threadId) => {
             if (threadId !== activeThreadId) {
-              stopStream()
               setActiveThreadId(threadId)
             }
           },

--- a/frontend/src/routes/_layout/ai.tsx
+++ b/frontend/src/routes/_layout/ai.tsx
@@ -36,16 +36,49 @@ export const Route = createFileRoute("/_layout/ai")({
 
 const AI_MODEL_STORAGE_KEY = "linkx_ai_selected_model"
 
-function getInitialStoredModel(): string {
-  if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
-    try {
-      const saved = localStorage.getItem(AI_MODEL_STORAGE_KEY)
-      if (saved && !saved.startsWith("gemini")) return saved
-    } catch {
-      // ignore
-    }
+function getStoredModel(): string | null {
+  try {
+    return window?.localStorage?.getItem(AI_MODEL_STORAGE_KEY) ?? null
+  } catch {
+    return null
   }
+}
+
+function persistStoredModel(modelId: string): void {
+  try {
+    window?.localStorage?.setItem(AI_MODEL_STORAGE_KEY, modelId)
+  } catch {
+    // ignore
+  }
+}
+
+function getInitialStoredModel(): string {
+  const saved = getStoredModel()
+  if (saved && !saved.startsWith("gemini")) return saved
   return "gpt-5.4"
+}
+
+function resolveFallbackModel(modelsData?: {
+  default_model?: string | null
+  data?: { id: string }[]
+}): string {
+  return modelsData?.default_model || modelsData?.data?.[0]?.id || "gpt-5.4"
+}
+
+function computeReconciledModel(modelsData?: {
+  default_model?: string | null
+  data?: { id: string }[]
+}): string | null {
+  if (!modelsData) return null
+  const saved = getStoredModel()
+  if (!saved || saved.startsWith("gemini")) {
+    return resolveFallbackModel(modelsData)
+  }
+  const available = modelsData.data ?? []
+  if (available.length > 0 && !available.some((m) => m.id === saved)) {
+    return resolveFallbackModel(modelsData)
+  }
+  return null
 }
 
 function filterAndSortThreads(
@@ -85,25 +118,53 @@ function getUrlSearchParams(): AISearchParams {
   }
 }
 
-function AIPage() {
-  const search = React.useMemo(() => getUrlSearchParams(), [])
-  const queryClient = useQueryClient()
-  const promptInputRef = React.useRef<HTMLTextAreaElement>(null)
+function syncBrowserUrl(activeThreadId: string | null) {
+  if (typeof window === "undefined") return
+  try {
+    const url = new URL(window.location.href)
+    let changed = false
+    if (url.searchParams.has("autoRun")) {
+      url.searchParams.delete("autoRun")
+      changed = true
+    }
+    if (url.searchParams.has("prompt")) {
+      url.searchParams.delete("prompt")
+      changed = true
+    }
+    const currentParam = url.searchParams.get("threadId")
+    if (activeThreadId && currentParam !== activeThreadId) {
+      url.searchParams.set("threadId", activeThreadId)
+      changed = true
+    } else if (!activeThreadId && currentParam) {
+      url.searchParams.delete("threadId")
+      changed = true
+    }
+    if (changed) {
+      window.history.replaceState({}, "", url.pathname + url.search)
+    }
+  } catch {
+    // ignore
+  }
+}
 
-  const [threadToRename, setThreadToRename] =
-    React.useState<ChatThreadPublic | null>(null)
-  const [threadToDelete, setThreadToDelete] =
-    React.useState<ChatThreadPublic | null>(null)
-  const [openMenuThreadId, setOpenMenuThreadId] = React.useState<string | null>(
-    null,
-  )
-  const [recentsOpen, setRecentsOpen] = React.useState(true)
-  const [archivedOpen, setArchivedOpen] = React.useState(true)
-  const [isSearchOpen, setIsSearchOpen] = React.useState(false)
-  const [searchQuery, setSearchQuery] = React.useState("")
-  const [sortOrder, setSortOrder] = React.useState<SortOption>("recent")
-  const [isSortMenuOpen, setIsSortMenuOpen] = React.useState(false)
+function useAutoRunPrompt({
+  autoRun,
+  prompt,
+  handleSendMessage,
+}: {
+  autoRun?: boolean
+  prompt?: string
+  handleSendMessage: (text: string) => void
+}) {
+  const executedRef = React.useRef(false)
+  React.useEffect(() => {
+    if (!autoRun || !prompt || executedRef.current) return
+    executedRef.current = true
+    handleSendMessage(prompt)
+  }, [autoRun, prompt, handleSendMessage])
+}
 
+function useAIModelSelection() {
   const { data: modelsData } = useQuery({
     queryKey: ["ai-models"],
     queryFn: () => AiThreadsService.listAiModels(),
@@ -115,123 +176,82 @@ function AIPage() {
 
   const setSelectedModelId = React.useCallback((modelId: string) => {
     setSelectedModelIdState(modelId)
-    if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
-      try {
-        localStorage.setItem(AI_MODEL_STORAGE_KEY, modelId)
-      } catch {
-        // ignore
-      }
-    }
+    persistStoredModel(modelId)
   }, [])
 
   React.useEffect(() => {
-    if (!modelsData) return
-    const saved =
-      typeof window !== "undefined" && typeof localStorage !== "undefined"
-        ? localStorage.getItem(AI_MODEL_STORAGE_KEY)
-        : null
-
-    if (!saved || saved.startsWith("gemini")) {
-      const defaultId =
-        modelsData.default_model || modelsData.data?.[0]?.id || "gpt-5.4"
-      if (defaultId) setSelectedModelId(defaultId)
-    } else if (modelsData.data && modelsData.data.length > 0) {
-      const exists = modelsData.data.some((m) => m.id === saved)
-      if (!exists) {
-        const fallback =
-          modelsData.default_model || modelsData.data[0].id || "gpt-5.4"
-        setSelectedModelId(fallback)
-      }
-    }
+    const nextModel = computeReconciledModel(modelsData)
+    if (nextModel) setSelectedModelId(nextModel)
   }, [modelsData, setSelectedModelId])
 
-  const { data: threadsData, isLoading: isThreadsLoading } = useQuery({
-    queryKey: ["ai-threads"],
-    queryFn: () => AiThreadsService.listChatThreads({ skip: 0, limit: 100 }),
-  })
+  return { selectedModelId, setSelectedModelId, modelsData }
+}
 
-  const threads = threadsData?.data ?? []
+function useThreadSidebarFilters(threads: ChatThreadPublic[]) {
+  const [recentsOpen, setRecentsOpen] = React.useState(true)
+  const [archivedOpen, setArchivedOpen] = React.useState(true)
+  const [isSearchOpen, setIsSearchOpen] = React.useState(false)
+  const [searchQuery, setSearchQuery] = React.useState("")
+  const [sortOrder, setSortOrder] = React.useState<SortOption>("recent")
+  const [isSortMenuOpen, setIsSortMenuOpen] = React.useState(false)
 
-  const {
-    activeThreadId,
-    setActiveThreadId,
-    localMessages,
-    pendingQuestion,
-    threadDrafts,
-    setThreadDraft,
-    streamingThreadId,
-    queuedThreadIds,
-    isThreadStreaming,
-    isThreadQueued,
-    handleThreadDeleted,
-    stopStream,
-    handleSendMessage,
-    handleQuestionAnswer,
-    handleNewChat,
-  } = useAIChatFeedState({
-    threads,
-    selectedModelId,
-    initialThreadId: search.threadId,
-  })
+  const recentThreads = React.useMemo(
+    () =>
+      filterAndSortThreads(
+        threads.filter((t) => !t.is_archived),
+        searchQuery,
+        sortOrder,
+      ),
+    [threads, searchQuery, sortOrder],
+  )
 
-  const isCurrentThreadStreaming = isThreadStreaming(activeThreadId)
-  const isCurrentThreadQueued = isThreadQueued(activeThreadId)
-  const isCurrentThreadBusy = isCurrentThreadStreaming || isCurrentThreadQueued
+  const archivedThreads = React.useMemo(
+    () =>
+      filterAndSortThreads(
+        threads.filter((t) => t.is_archived),
+        searchQuery,
+        sortOrder,
+      ),
+    [threads, searchQuery, sortOrder],
+  )
 
-  const autoRunExecutedRef = React.useRef(false)
-  React.useEffect(() => {
-    if (search.autoRun && search.prompt && !autoRunExecutedRef.current) {
-      autoRunExecutedRef.current = true
-      try {
-        const url = new URL(window.location.href)
-        url.searchParams.delete("autoRun")
-        url.searchParams.delete("prompt")
-        window.history.replaceState(
-          {},
-          "",
-          url.pathname + (url.search ? url.search : ""),
-        )
-      } catch {
-        // ignore
-      }
-      handleSendMessage(search.prompt)
-    }
-  }, [search.autoRun, search.prompt, handleSendMessage])
+  return {
+    recentsOpen,
+    setRecentsOpen,
+    archivedOpen,
+    setArchivedOpen,
+    isSearchOpen,
+    setIsSearchOpen,
+    searchQuery,
+    setSearchQuery,
+    sortOrder,
+    setSortOrder,
+    isSortMenuOpen,
+    setIsSortMenuOpen,
+    recentThreads,
+    archivedThreads,
+  }
+}
 
-  // Keep browser URL in sync with activeThreadId and purge stale autoRun/prompt params
-  React.useEffect(() => {
-    if (typeof window === "undefined") return
-    try {
-      const url = new URL(window.location.href)
-      let changed = false
-      if (url.searchParams.has("autoRun")) {
-        url.searchParams.delete("autoRun")
-        changed = true
-      }
-      if (url.searchParams.has("prompt")) {
-        url.searchParams.delete("prompt")
-        changed = true
-      }
-      if (activeThreadId) {
-        if (url.searchParams.get("threadId") !== activeThreadId) {
-          url.searchParams.set("threadId", activeThreadId)
-          changed = true
-        }
-      } else if (url.searchParams.has("threadId")) {
-        url.searchParams.delete("threadId")
-        changed = true
-      }
-      if (changed) {
-        window.history.replaceState(
-          {},
-          "",
-          url.pathname + (url.search ? url.search : ""),
-        )
-      }
-    } catch {
-      // ignore
-    }
-  }, [activeThreadId])
+interface ThreadMutationsOptions {
+  queryClient: ReturnType<typeof useQueryClient>
+  activeThreadId: string | null
+  setActiveThreadId: (id: string | null) => void
+  threads: ChatThreadPublic[]
+  handleThreadDeleted: (deletedId: string) => void
+}
+
+function useThreadMutations({
+  queryClient,
+  activeThreadId,
+  setActiveThreadId,
+  threads,
+  handleThreadDeleted,
+}: ThreadMutationsOptions) {
+  const [threadToRename, setThreadToRename] =
+    React.useState<ChatThreadPublic | null>(null)
+  const [threadToDelete, setThreadToDelete] =
+    React.useState<ChatThreadPublic | null>(null)
 
   const updateThreadMutation = useMutation({
     mutationFn: ({
@@ -266,22 +286,6 @@ function AIPage() {
     },
   })
 
-  React.useEffect(() => {
-    function handleClickOutside() {
-      setOpenMenuThreadId(null)
-      setIsSortMenuOpen(false)
-    }
-    if (openMenuThreadId || isSortMenuOpen) {
-      document.addEventListener("click", handleClickOutside)
-      return () => document.removeEventListener("click", handleClickOutside)
-    }
-  }, [openMenuThreadId, isSortMenuOpen])
-
-  function onNewChatClick() {
-    handleNewChat()
-    setTimeout(() => promptInputRef.current?.focus(), 50)
-  }
-
   function handleConfirmRename(title: string) {
     if (!threadToRename) return
     updateThreadMutation.mutate({ id: threadToRename.id, title })
@@ -289,128 +293,257 @@ function AIPage() {
   }
 
   function handleToggleArchive(thread: ChatThreadPublic) {
-    setOpenMenuThreadId(null)
     updateThreadMutation.mutate({
       id: thread.id,
       isArchived: !thread.is_archived,
     })
   }
 
-  const recentThreads = React.useMemo(
-    () =>
-      filterAndSortThreads(
-        threads.filter((t) => !t.is_archived),
-        searchQuery,
-        sortOrder,
-      ),
-    [threads, searchQuery, sortOrder],
+  return {
+    threadToRename,
+    setThreadToRename,
+    threadToDelete,
+    setThreadToDelete,
+    updateThreadMutation,
+    deleteThreadMutation,
+    handleConfirmRename,
+    handleToggleArchive,
+  }
+}
+
+interface AIChatCenterColumnProps {
+  activeThreadId: string | null
+  localMessages: ReturnType<typeof useAIChatFeedState>["localMessages"]
+  isCurrentThreadStreaming: boolean
+  isCurrentThreadBusy: boolean
+  isCurrentThreadQueued: boolean
+  pendingQuestion: ReturnType<typeof useAIChatFeedState>["pendingQuestion"]
+  threadDrafts: Record<string, string>
+  setThreadDraft: (id: string | null, val: string) => void
+  promptInputRef: React.RefObject<HTMLTextAreaElement | null>
+  selectedModelId: string
+  modelsData?: { data?: { id: string; name?: string }[] }
+  setSelectedModelId: (id: string) => void
+  handleSendMessage: (text: string, images?: File[]) => Promise<void>
+  handleQuestionAnswer: (id: string, answers: any[]) => void
+  stopStream: () => void
+}
+
+function AIChatCenterColumn({
+  activeThreadId,
+  localMessages,
+  isCurrentThreadStreaming,
+  isCurrentThreadBusy,
+  isCurrentThreadQueued,
+  pendingQuestion,
+  threadDrafts,
+  setThreadDraft,
+  promptInputRef,
+  selectedModelId,
+  modelsData,
+  setSelectedModelId,
+  handleSendMessage,
+  handleQuestionAnswer,
+  stopStream,
+}: AIChatCenterColumnProps) {
+  const currentKey = activeThreadId ?? "new-chat"
+  const draftValue = threadDrafts[currentKey] ?? ""
+  const placeholderText = isCurrentThreadQueued
+    ? "Waiting in queue..."
+    : "Ask anything"
+
+  return (
+    <div className="relative mx-auto flex min-h-0 w-full flex-1 max-w-2xl border-r-0 md:border-r border-border flex-col h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden">
+      <AIChatFeed
+        localMessages={localMessages}
+        isStreaming={isCurrentThreadStreaming}
+        pendingQuestion={pendingQuestion}
+        onSendMessage={handleSendMessage}
+        onQuestionAnswer={handleQuestionAnswer}
+      />
+
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-2 px-4 pb-4 shrink-0">
+        <PromptForm
+          key={currentKey}
+          inputRef={promptInputRef}
+          initialValue={draftValue}
+          onValueChange={(val) => setThreadDraft(activeThreadId, val)}
+          placeholder={placeholderText}
+          isBusy={isCurrentThreadBusy}
+          selectedModelId={selectedModelId}
+          models={modelsData?.data?.map((m) => ({
+            id: m.id,
+            name: m.name || m.id,
+          }))}
+          onSelectModel={setSelectedModelId}
+          onSubmit={handleSendMessage}
+          onStop={stopStream}
+          autoFocus
+        />
+      </div>
+    </div>
+  )
+}
+
+function AIPage() {
+  const search = React.useMemo(() => getUrlSearchParams(), [])
+  const queryClient = useQueryClient()
+  const promptInputRef = React.useRef<HTMLTextAreaElement>(null)
+  const [openMenuThreadId, setOpenMenuThreadId] = React.useState<string | null>(
+    null,
   )
 
-  const archivedThreads = React.useMemo(
-    () =>
-      filterAndSortThreads(
-        threads.filter((t) => t.is_archived),
-        searchQuery,
-        sortOrder,
-      ),
-    [threads, searchQuery, sortOrder],
+  const { selectedModelId, setSelectedModelId, modelsData } =
+    useAIModelSelection()
+
+  const { data: threadsData, isLoading: isThreadsLoading } = useQuery({
+    queryKey: ["ai-threads"],
+    queryFn: () => AiThreadsService.listChatThreads({ skip: 0, limit: 100 }),
+  })
+
+  const threads = threadsData?.data ?? []
+
+  const feedState = useAIChatFeedState({
+    threads,
+    selectedModelId,
+    initialThreadId: search.threadId,
+  })
+
+  const sidebarFilters = useThreadSidebarFilters(threads)
+
+  const mutations = useThreadMutations({
+    queryClient,
+    activeThreadId: feedState.activeThreadId,
+    setActiveThreadId: feedState.setActiveThreadId,
+    threads,
+    handleThreadDeleted: feedState.handleThreadDeleted,
+  })
+
+  const isCurrentThreadStreaming = feedState.isThreadStreaming(
+    feedState.activeThreadId,
   )
+  const isCurrentThreadQueued = feedState.isThreadQueued(
+    feedState.activeThreadId,
+  )
+  const isCurrentThreadBusy = isCurrentThreadStreaming || isCurrentThreadQueued
+
+  useAutoRunPrompt({
+    autoRun: search.autoRun,
+    prompt: search.prompt,
+    handleSendMessage: feedState.handleSendMessage,
+  })
+
+  React.useEffect(() => {
+    syncBrowserUrl(feedState.activeThreadId)
+  }, [feedState.activeThreadId])
+
+  React.useEffect(() => {
+    function handleClickOutside() {
+      setOpenMenuThreadId(null)
+      sidebarFilters.setIsSortMenuOpen(false)
+    }
+    if (openMenuThreadId || sidebarFilters.isSortMenuOpen) {
+      document.addEventListener("click", handleClickOutside)
+      return () => document.removeEventListener("click", handleClickOutside)
+    }
+  }, [
+    openMenuThreadId,
+    sidebarFilters.isSortMenuOpen,
+    sidebarFilters.setIsSortMenuOpen,
+  ])
+
+  function onNewChatClick() {
+    feedState.handleNewChat()
+    setTimeout(() => promptInputRef.current?.focus(), 50)
+  }
 
   return (
     <div className="flex w-full h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden bg-background text-foreground">
       <RenameThreadDialog
-        thread={threadToRename}
-        isOpen={Boolean(threadToRename)}
-        isPending={updateThreadMutation.isPending}
-        onClose={() => setThreadToRename(null)}
-        onConfirm={handleConfirmRename}
+        thread={mutations.threadToRename}
+        isOpen={Boolean(mutations.threadToRename)}
+        isPending={mutations.updateThreadMutation.isPending}
+        onClose={() => mutations.setThreadToRename(null)}
+        onConfirm={mutations.handleConfirmRename}
       />
 
       <DeleteThreadConfirmDialog
-        thread={threadToDelete}
-        isOpen={Boolean(threadToDelete)}
-        isPending={deleteThreadMutation.isPending}
-        onClose={() => setThreadToDelete(null)}
+        thread={mutations.threadToDelete}
+        isOpen={Boolean(mutations.threadToDelete)}
+        isPending={mutations.deleteThreadMutation.isPending}
+        onClose={() => mutations.setThreadToDelete(null)}
         onConfirm={() => {
-          if (threadToDelete) {
-            deleteThreadMutation.mutate(threadToDelete.id)
+          if (mutations.threadToDelete) {
+            mutations.deleteThreadMutation.mutate(mutations.threadToDelete.id)
           }
         }}
       />
 
-      {/* 1. Center Column: Active Chat Feed */}
-      <div className="relative mx-auto flex min-h-0 w-full flex-1 max-w-2xl border-r-0 md:border-r border-border flex-col h-[calc(100vh-3.5rem)] lg:h-screen overflow-hidden">
-        <AIChatFeed
-          localMessages={localMessages}
-          isStreaming={isCurrentThreadStreaming}
-          pendingQuestion={pendingQuestion}
-          onSendMessage={handleSendMessage}
-          onQuestionAnswer={handleQuestionAnswer}
-        />
+      <AIChatCenterColumn
+        activeThreadId={feedState.activeThreadId}
+        localMessages={feedState.localMessages}
+        isCurrentThreadStreaming={isCurrentThreadStreaming}
+        isCurrentThreadBusy={isCurrentThreadBusy}
+        isCurrentThreadQueued={isCurrentThreadQueued}
+        pendingQuestion={feedState.pendingQuestion}
+        threadDrafts={feedState.threadDrafts}
+        setThreadDraft={feedState.setThreadDraft}
+        promptInputRef={promptInputRef}
+        selectedModelId={selectedModelId}
+        modelsData={modelsData}
+        setSelectedModelId={setSelectedModelId}
+        handleSendMessage={feedState.handleSendMessage}
+        handleQuestionAnswer={feedState.handleQuestionAnswer}
+        stopStream={feedState.stopStream}
+      />
 
-        <div className="mx-auto flex w-full max-w-2xl flex-col gap-2 px-4 pb-4 shrink-0">
-          <PromptForm
-            key={activeThreadId ?? "new-chat"}
-            inputRef={promptInputRef}
-            initialValue={threadDrafts[activeThreadId ?? "new-chat"] ?? ""}
-            onValueChange={(val) => setThreadDraft(activeThreadId, val)}
-            placeholder={
-              isCurrentThreadQueued ? "Waiting in queue..." : "Ask anything"
-            }
-            isBusy={isCurrentThreadBusy}
-            selectedModelId={selectedModelId}
-            models={modelsData?.data}
-            onSelectModel={setSelectedModelId}
-            onSubmit={handleSendMessage}
-            onStop={stopStream}
-            autoFocus
-          />
-        </div>
-      </div>
-
-      {/* 2. Right Column: History Sidebar */}
       <AIThreadsSidebar
-        recentThreads={recentThreads}
-        archivedThreads={archivedThreads}
-        activeThreadId={activeThreadId}
+        recentThreads={sidebarFilters.recentThreads}
+        archivedThreads={sidebarFilters.archivedThreads}
+        activeThreadId={feedState.activeThreadId}
         openMenuThreadId={openMenuThreadId}
         isLoading={isThreadsLoading}
-        streamingThreadId={streamingThreadId}
-        queuedThreadIds={queuedThreadIds}
+        streamingThreadId={feedState.streamingThreadId}
+        queuedThreadIds={feedState.queuedThreadIds}
         filters={{
-          searchQuery,
-          isSearchOpen,
-          sortOrder,
-          isSortMenuOpen,
-          recentsOpen,
-          archivedOpen,
+          searchQuery: sidebarFilters.searchQuery,
+          isSearchOpen: sidebarFilters.isSearchOpen,
+          sortOrder: sidebarFilters.sortOrder,
+          isSortMenuOpen: sidebarFilters.isSortMenuOpen,
+          recentsOpen: sidebarFilters.recentsOpen,
+          archivedOpen: sidebarFilters.archivedOpen,
         }}
         filterHandlers={{
-          onToggleSearch: () => setIsSearchOpen((prev) => !prev),
-          onSearchChange: setSearchQuery,
-          onToggleSortMenu: () => setIsSortMenuOpen((prev) => !prev),
+          onToggleSearch: () => sidebarFilters.setIsSearchOpen((prev) => !prev),
+          onSearchChange: sidebarFilters.setSearchQuery,
+          onToggleSortMenu: () =>
+            sidebarFilters.setIsSortMenuOpen((prev) => !prev),
           onSelectSortOrder: (newOrder) => {
-            setSortOrder(newOrder)
-            setIsSortMenuOpen(false)
+            sidebarFilters.setSortOrder(newOrder)
+            sidebarFilters.setIsSortMenuOpen(false)
           },
-          onToggleRecents: () => setRecentsOpen((prev) => !prev),
-          onToggleArchived: () => setArchivedOpen((prev) => !prev),
+          onToggleRecents: () => sidebarFilters.setRecentsOpen((prev) => !prev),
+          onToggleArchived: () =>
+            sidebarFilters.setArchivedOpen((prev) => !prev),
           onNewChat: onNewChatClick,
         }}
         actions={{
           onSelect: (threadId) => {
-            if (threadId !== activeThreadId) {
-              setActiveThreadId(threadId)
+            if (threadId !== feedState.activeThreadId) {
+              feedState.setActiveThreadId(threadId)
             }
           },
           onStartRename: (t) => {
             setOpenMenuThreadId(null)
-            setThreadToRename(t)
+            mutations.setThreadToRename(t)
           },
-          onToggleArchive: handleToggleArchive,
+          onToggleArchive: (t) => {
+            setOpenMenuThreadId(null)
+            mutations.handleToggleArchive(t)
+          },
           onDelete: (t) => {
             setOpenMenuThreadId(null)
-            setThreadToDelete(t)
+            mutations.setThreadToDelete(t)
           },
           onToggleMenu: (id) =>
             setOpenMenuThreadId((prev) => (prev === id ? null : id)),

--- a/frontend/src/test/chat-queue.test.tsx
+++ b/frontend/src/test/chat-queue.test.tsx
@@ -1,0 +1,398 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { AiThreadsService } from "@/client"
+import { Route } from "@/routes/_layout/ai"
+
+vi.mock("@/client", async () => {
+  const actual = await vi.importActual("@/client")
+  return {
+    ...actual,
+    AiThreadsService: {
+      listChatThreads: vi.fn(),
+      getChatThread: vi.fn(),
+      createChatThread: vi.fn(),
+      updateChatThread: vi.fn(),
+      deleteChatThread: vi.fn(),
+      listAiModels: vi.fn().mockResolvedValue({
+        data: [{ id: "gpt-5.4", name: "GPT-5.4" }],
+        default_model: "gpt-5.4",
+      }),
+    },
+  }
+})
+
+function renderWithClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  )
+}
+
+describe("Multi-thread prompt queuing and stream isolation", () => {
+  const mockThreads = [
+    {
+      id: "thread-A",
+      title: "Thread Alpha",
+      origin: "manual",
+      message_count: 1,
+      is_archived: false,
+      created_at: new Date(Date.now() + 10000).toISOString(),
+      updated_at: new Date().toISOString(),
+      owner_id: "user-1",
+    },
+    {
+      id: "thread-B",
+      title: "Thread Beta",
+      origin: "manual",
+      message_count: 1,
+      is_archived: false,
+      created_at: new Date(Date.now() - 10000).toISOString(),
+      updated_at: new Date().toISOString(),
+      owner_id: "user-1",
+    },
+  ]
+
+  const mockDetailA = {
+    ...mockThreads[0],
+    transcript: {
+      messages: [
+        {
+          id: "m-a-1",
+          role: "user",
+          parts: [{ type: "text", text: "Alpha initial prompt" }],
+        },
+      ],
+    },
+  }
+
+  const mockDetailB = {
+    ...mockThreads[1],
+    transcript: {
+      messages: [
+        {
+          id: "m-b-1",
+          role: "user",
+          parts: [{ type: "text", text: "Beta initial prompt" }],
+        },
+      ],
+    },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.replaceState({}, "", "/")
+    vi.mocked(AiThreadsService.listChatThreads).mockResolvedValue({
+      data: mockThreads,
+      count: mockThreads.length,
+    })
+    ;(vi.mocked(AiThreadsService.getChatThread) as any).mockImplementation(
+      async ({ id }: { id: string }) => {
+        if (id === "thread-A") return mockDetailA
+        if (id === "thread-B") return mockDetailB
+        return {
+          id,
+          title: "New Thread",
+          origin: "composer",
+          message_count: 0,
+          is_archived: false,
+          transcript: { messages: [] },
+          owner_id: "user-1",
+        }
+      },
+    )
+    vi.mocked(AiThreadsService.createChatThread).mockResolvedValue({
+      id: "thread-new",
+      title: "New thread title",
+      origin: "composer",
+      message_count: 0,
+      is_archived: false,
+      transcript: { messages: [] },
+      owner_id: "user-1",
+    })
+  })
+
+  it("queues Thread Beta when submitted while Thread Alpha is streaming", async () => {
+    let controllerA: any = null
+    const streamA = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        controllerA = ctrl
+      },
+    })
+
+    let controllerB: any = null
+    const streamB = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        controllerB = ctrl
+      },
+    })
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("thread-A")) {
+        return new Response(streamA, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      }
+      if (url.includes("thread-B")) {
+        return new Response(streamB, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      }
+      return new Response("Not found", { status: 404 })
+    })
+    globalThis.fetch = fetchMock
+
+    const Component = Route.options.component as React.ComponentType
+    renderWithClient(<Component />)
+
+    // Wait for Thread Alpha to load initially
+    await screen.findByText("Thread Alpha")
+    await screen.findByText("Alpha initial prompt")
+
+    // Send a message in Thread Alpha
+    const input = screen.getByPlaceholderText("Ask anything")
+    fireEvent.change(input, { target: { value: "Run generation on Alpha" } })
+    fireEvent.submit(input.closest("form")!)
+
+    // Verify fetch was called for thread-A
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/ai/threads/thread-A/chat"),
+        expect.anything(),
+      )
+    })
+
+    // Verify Thread Alpha shows generating badge in sidebar
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-generating-badge")).toBeInTheDocument()
+    })
+
+    // Now switch to Thread Beta in sidebar WITHOUT aborting Thread Alpha
+    const threadBetaBtn = screen.getByText("Thread Beta")
+    fireEvent.click(threadBetaBtn)
+
+    // Verify Thread Beta messages load
+    await screen.findByText("Beta initial prompt")
+
+    // In Thread Beta, input should NOT be disabled; user can submit
+    const inputBeta = screen.getByPlaceholderText("Ask anything")
+    fireEvent.change(inputBeta, { target: { value: "Run prompt on Beta" } })
+    fireEvent.submit(inputBeta.closest("form")!)
+
+    // Verify Thread Beta displays user message and queued assistant indicator
+    expect(await screen.findByText("Run prompt on Beta")).toBeInTheDocument()
+    expect(
+      await screen.findByText(
+        /Queued • Waiting for active generation to finish.../i,
+      ),
+    ).toBeInTheDocument()
+
+    // Verify Thread Beta has queued badge in sidebar
+    expect(screen.getByTestId("thread-queued-badge")).toBeInTheDocument()
+
+    // Thread B should NOT have called fetch yet because Thread A is still streaming!
+    const betaCallsBefore = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("thread-B"),
+    )
+    expect(betaCallsBefore.length).toBe(0)
+
+    // Now finish Thread Alpha stream
+    const encoder = new TextEncoder()
+    controllerA?.enqueue(
+      encoder.encode(
+        'event: text_delta\ndata: {"content": "Alpha completed successfully"}\n\nevent: done\ndata: {}\n\n',
+      ),
+    )
+    controllerA?.close()
+
+    // Once Thread Alpha completes, the queue automatically triggers Thread Beta's stream!
+    await waitFor(
+      () => {
+        const betaCallsAfter = fetchMock.mock.calls.filter((c) =>
+          String(c[0]).includes("thread-B"),
+        )
+        expect(betaCallsAfter.length).toBe(1)
+      },
+      { timeout: 3000 },
+    )
+
+    // Send chunks to Thread Beta
+    controllerB?.enqueue(
+      encoder.encode(
+        'event: text_delta\ndata: {"content": "Beta response is here!"}\n\nevent: done\ndata: {}\n\n',
+      ),
+    )
+    controllerB?.close()
+
+    // Verify Thread Beta receives response text
+    expect(
+      await screen.findByText("Beta response is here!"),
+    ).toBeInTheDocument()
+  })
+
+  it("can cancel a queued turn in Thread Beta without interrupting active Thread Alpha stream", async () => {
+    let controllerA: any = null
+    const streamA = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        controllerA = ctrl
+      },
+    })
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("thread-A")) {
+        return new Response(streamA, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      }
+      return new Response("Not found", { status: 404 })
+    })
+    globalThis.fetch = fetchMock
+
+    const Component = Route.options.component as React.ComponentType
+    renderWithClient(<Component />)
+
+    // Wait for Thread Alpha to load and start streaming
+    await screen.findByText("Thread Alpha")
+    const input = screen.getByPlaceholderText("Ask anything")
+    fireEvent.change(input, { target: { value: "Prompt on Alpha" } })
+    fireEvent.submit(input.closest("form")!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-generating-badge")).toBeInTheDocument()
+    })
+
+    // Switch to Thread Beta and submit a prompt to queue it
+    const threadBetaBtn = screen.getByText("Thread Beta")
+    fireEvent.click(threadBetaBtn)
+    await screen.findByText("Beta initial prompt")
+
+    const inputBeta = screen.getByPlaceholderText("Ask anything")
+    fireEvent.change(inputBeta, { target: { value: "Queued prompt on Beta" } })
+    fireEvent.submit(inputBeta.closest("form")!)
+
+    expect(await screen.findByText("Queued prompt on Beta")).toBeInTheDocument()
+    expect(
+      await screen.findByText(
+        /Queued • Waiting for active generation to finish.../i,
+      ),
+    ).toBeInTheDocument()
+
+    // PromptForm in Thread Beta now displays Stop button
+    const stopButton = screen.getByRole("button", {
+      name: /stop generating/i,
+    })
+    fireEvent.click(stopButton)
+
+    // Queued indicator is removed from Thread Beta
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          /Queued • Waiting for active generation to finish.../i,
+        ),
+      ).not.toBeInTheDocument()
+    })
+
+    // The user's prompt is restored to the input box so it is not lost
+    expect(screen.getByPlaceholderText("Ask anything")).toHaveValue(
+      "Queued prompt on Beta",
+    )
+
+    // Thread Alpha is STILL running and generating!
+    expect(screen.getByTestId("thread-generating-badge")).toBeInTheDocument()
+
+    // Clean up stream A
+    controllerA?.close()
+  })
+
+  it("deleting a queued thread purges it from the queue and prevents it from streaming when active stream finishes", async () => {
+    let controllerA: any = null
+    const streamA = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        controllerA = ctrl
+      },
+    })
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("thread-A")) {
+        return new Response(streamA, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      }
+      return new Response("Not found", { status: 404 })
+    })
+    globalThis.fetch = fetchMock
+
+    const Component = Route.options.component as React.ComponentType
+    renderWithClient(<Component />)
+
+    // Start Thread Alpha streaming
+    await screen.findByText("Thread Alpha")
+    const input = screen.getByPlaceholderText("Ask anything")
+    fireEvent.change(input, { target: { value: "Prompt on Alpha" } })
+    fireEvent.submit(input.closest("form")!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-generating-badge")).toBeInTheDocument()
+    })
+
+    // Switch to Thread Beta and submit a prompt to queue it
+    const threadBetaBtn = screen.getByText("Thread Beta")
+    fireEvent.click(threadBetaBtn)
+    await screen.findByText("Beta initial prompt")
+
+    const inputBeta = screen.getByPlaceholderText("Ask anything")
+    fireEvent.change(inputBeta, { target: { value: "Queued on Beta" } })
+    fireEvent.submit(inputBeta.closest("form")!)
+
+    expect(await screen.findByText("Queued on Beta")).toBeInTheDocument()
+
+    // Open options menu for Thread Beta and click Delete
+    const kebabButtons = await screen.findAllByRole("button", {
+      name: /thread options/i,
+    })
+    fireEvent.click(kebabButtons[1]) // Thread Beta kebab
+
+    const deleteMenuItem = screen.getByRole("menuitem", { name: /delete/i })
+    fireEvent.click(deleteMenuItem)
+
+    // Confirm deletion inside dialog
+    const confirmDeleteBtn = screen.getByRole("button", {
+      name: /^delete chat$/i,
+    })
+    fireEvent.click(confirmDeleteBtn)
+
+    // Verify backend delete was invoked
+    await waitFor(() => {
+      expect(AiThreadsService.deleteChatThread).toHaveBeenCalledWith({
+        id: "thread-B",
+      })
+    })
+
+    // Now finish Thread Alpha stream
+    const encoder = new TextEncoder()
+    controllerA?.enqueue(
+      encoder.encode(
+        'event: text_delta\ndata: {"content": "Alpha done"}\n\nevent: done\ndata: {}\n\n',
+      ),
+    )
+    controllerA?.close()
+
+    // Wait 200ms to ensure no queued turn for Thread Beta is executed
+    await new Promise((r) => setTimeout(r, 200))
+
+    const betaCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("thread-B"),
+    )
+    expect(betaCalls.length).toBe(0)
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,29 @@ import "@testing-library/jest-dom/vitest"
 import { cleanup } from "@testing-library/react"
 import { afterEach } from "vitest"
 
+const storage: Record<string, string> = {}
+if (
+  typeof globalThis.localStorage === "undefined" ||
+  !globalThis.localStorage.getItem
+) {
+  globalThis.localStorage = {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value
+    },
+    removeItem: (key: string) => {
+      delete storage[key]
+    },
+    clear: () => {
+      for (const k of Object.keys(storage)) {
+        delete storage[k]
+      }
+    },
+    key: (index: number) => Object.keys(storage)[index] ?? null,
+    length: 0,
+  }
+}
+
 afterEach(() => {
   cleanup()
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,11 +40,11 @@ export default defineConfig({
     port: 4000,
     proxy: {
       "/api": {
-        target: "http://localhost:8888",
+        target: process.env.VITE_API_URL || "http://localhost:8000",
         changeOrigin: true,
       },
       "/static": {
-        target: "http://localhost:8888",
+        target: process.env.VITE_API_URL || "http://localhost:8000",
         changeOrigin: true,
       },
     },

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -17,10 +17,11 @@ export default defineConfig({
         __dirname,
         "../node_modules/@tanstack/react-query",
       ),
-      "@radix-ui/react-dialog": path.resolve(
+      "@tanstack/react-router": path.resolve(
         __dirname,
-        "../node_modules/@radix-ui/react-dialog",
+        "../node_modules/@tanstack/react-router",
       ),
+      "@radix-ui": path.resolve(__dirname, "../node_modules/@radix-ui"),
     },
     dedupe: ["react", "react-dom"],
   },

--- a/scripts/check_codescene.py
+++ b/scripts/check_codescene.py
@@ -1,20 +1,88 @@
 #!/usr/bin/env python3
 """Run CodeScene delta analysis via local cs-mcp server to verify Code Health quality gates."""
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess
 import sys
+from typing import Any
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 CS_MCP_BIN = "/opt/homebrew/bin/cs-mcp"
 
 
-def check_codescene(*, base_ref: str = "origin/master") -> int:
-    if not os.path.exists(CS_MCP_BIN):
-        print(f"Error: CodeScene MCP binary not found at {CS_MCP_BIN}")
-        return 1
+def _send_rpc(proc: subprocess.Popen[str], msg: dict[str, Any]) -> None:
+    if not proc.stdin:
+        return
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
 
+
+def _read_json_response(
+    proc: subprocess.Popen[str], target_id: int
+) -> dict[str, Any] | None:
+    if not proc.stdout:
+        return None
+    for line in proc.stdout:
+        trimmed = line.strip()
+        if not trimmed.startswith("{"):
+            continue
+        data: dict[str, Any] = json.loads(trimmed)
+        if data.get("id") == target_id:
+            return data
+    return None
+
+
+def _init_mcp(proc: subprocess.Popen[str]) -> bool:
+    init_msg = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "linkx-check", "version": "1.0"},
+        },
+    }
+    _send_rpc(proc, init_msg)
+    res = _read_json_response(proc, 1)
+    return res is not None
+
+
+def _request_change_set(
+    proc: subprocess.Popen[str], base_ref: str
+) -> dict[str, Any] | None:
+    call_msg = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "analyze_change_set",
+            "arguments": {
+                "base_ref": base_ref,
+                "git_repository_path": REPO_ROOT,
+            },
+        },
+    }
+    _send_rpc(proc, call_msg)
+    return _read_json_response(proc, 2)
+
+
+def _parse_mcp_output(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not payload:
+        return None
+    content_list = payload.get("result", {}).get("content", [])
+    raw_text = content_list[0].get("text", "") if content_list else ""
+    json_start = raw_text.find("{")
+    if json_start < 0:
+        return None
+    res: dict[str, Any] = json.loads(raw_text[json_start:])
+    return res
+
+
+def _run_mcp_analysis(base_ref: str) -> dict[str, Any] | None:
     proc = subprocess.Popen(
         [CS_MCP_BIN],
         stdin=subprocess.PIPE,
@@ -22,86 +90,65 @@ def check_codescene(*, base_ref: str = "origin/master") -> int:
         stderr=subprocess.PIPE,
         text=True,
     )
-
-    def send_rpc(msg: dict) -> None:
-        assert proc.stdin is not None
-        proc.stdin.write(json.dumps(msg) + "\n")
-        proc.stdin.flush()
-
-    # Initialize MCP
-    send_rpc(
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "linkx-check", "version": "1.0"},
-            },
-        }
-    )
-
-    assert proc.stdout is not None
-    for line in proc.stdout:
-        if line.strip().startswith("{"):
-            if json.loads(line.strip()).get("id") == 1:
-                break
-
-    # Call analyze_change_set
-    send_rpc(
-        {
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/call",
-            "params": {
-                "name": "analyze_change_set",
-                "arguments": {
-                    "base_ref": base_ref,
-                    "git_repository_path": REPO_ROOT,
-                },
-            },
-        }
-    )
-
-    result_data = None
-    for line in proc.stdout:
-        if line.strip().startswith("{"):
-            payload = json.loads(line.strip())
-            if payload.get("id") == 2:
-                raw_text = payload["result"]["content"][0]["text"]
-                json_start = raw_text.find("{")
-                result_data = json.loads(raw_text[json_start:])
-                break
-
+    if not _init_mcp(proc):
+        proc.kill()
+        return None
+    payload = _request_change_set(proc, base_ref)
     proc.kill()
+    return _parse_mcp_output(payload)
 
+
+def _log(msg: str = "") -> None:
+    sys.stdout.write(f"{msg}\n")
+
+
+def _print_finding_detail(detail: dict[str, Any], category: str) -> None:
+    desc = detail.get("description", "")
+    _log(f"   • [{category}] {desc}")
+
+
+def _print_file_findings(finding: dict[str, Any]) -> None:
+    category = str(finding.get("category", ""))
+    for detail in finding.get("change-details", []):
+        _print_finding_detail(detail, category)
+
+
+def _print_degraded_file(file_info: dict[str, Any]) -> None:
+    _log(f"📁 {file_info.get('name')}:")
+    for finding in file_info.get("findings", []):
+        _print_file_findings(finding)
+    _log()
+
+
+def _report_degradations(degraded_files: list[dict[str, Any]], gates: str) -> int:
+    _log(f"❌ CodeScene Quality Gates: {gates.upper()}")
+    _log(f"Found {len(degraded_files)} degraded file(s):\n")
+    for f in degraded_files:
+        _print_degraded_file(f)
+    return 1
+
+
+def check_codescene(*, base_ref: str = "origin/master") -> int:
+    if not os.path.exists(CS_MCP_BIN):
+        _log(f"Error: CodeScene MCP binary not found at {CS_MCP_BIN}")
+        return 1
+
+    result_data = _run_mcp_analysis(base_ref)
     if not result_data:
-        print("Error: No analysis data received from CodeScene MCP")
+        _log("Error: No analysis data received from CodeScene MCP")
         return 1
 
     results = result_data.get("results", [])
-    quality_gates = result_data.get("quality_gates")
-    degraded_files = [f for f in results if f.get("verdict") == "degraded"]
+    gates = str(result_data.get("quality_gates", ""))
+    degraded = [f for f in results if f.get("verdict") == "degraded"]
 
-    if not degraded_files and quality_gates != "failed":
-        print(
+    if not degraded and gates != "failed":
+        _log(
             f"✅ CodeScene Code Health Quality Gates PASSED! ({len(results)} files checked)"
         )
         return 0
 
-    print(f"❌ CodeScene Quality Gates: {quality_gates.upper()}")
-    print(f"Found {len(degraded_files)} degraded file(s):\n")
-
-    for f in degraded_files:
-        print(f"📁 {f.get('name')}:")
-        for finding in f.get("findings", []):
-            cat = finding.get("category")
-            for detail in finding.get("change-details", []):
-                print(f"   • [{cat}] {detail.get('description')}")
-        print()
-
-    return 1
+    return _report_degradations(degraded, gates)
 
 
 if __name__ == "__main__":

--- a/scripts/check_codescene.py
+++ b/scripts/check_codescene.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Run CodeScene delta analysis via local cs-mcp server to verify Code Health quality gates."""
+
+import json
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CS_MCP_BIN = "/opt/homebrew/bin/cs-mcp"
+
+
+def check_codescene(*, base_ref: str = "origin/master") -> int:
+    if not os.path.exists(CS_MCP_BIN):
+        print(f"Error: CodeScene MCP binary not found at {CS_MCP_BIN}")
+        return 1
+
+    proc = subprocess.Popen(
+        [CS_MCP_BIN],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    def send_rpc(msg: dict) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(msg) + "\n")
+        proc.stdin.flush()
+
+    # Initialize MCP
+    send_rpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "linkx-check", "version": "1.0"},
+            },
+        }
+    )
+
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        if line.strip().startswith("{"):
+            if json.loads(line.strip()).get("id") == 1:
+                break
+
+    # Call analyze_change_set
+    send_rpc(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "analyze_change_set",
+                "arguments": {
+                    "base_ref": base_ref,
+                    "git_repository_path": REPO_ROOT,
+                },
+            },
+        }
+    )
+
+    result_data = None
+    for line in proc.stdout:
+        if line.strip().startswith("{"):
+            payload = json.loads(line.strip())
+            if payload.get("id") == 2:
+                raw_text = payload["result"]["content"][0]["text"]
+                json_start = raw_text.find("{")
+                result_data = json.loads(raw_text[json_start:])
+                break
+
+    proc.kill()
+
+    if not result_data:
+        print("Error: No analysis data received from CodeScene MCP")
+        return 1
+
+    results = result_data.get("results", [])
+    quality_gates = result_data.get("quality_gates")
+    degraded_files = [f for f in results if f.get("verdict") == "degraded"]
+
+    if not degraded_files and quality_gates != "failed":
+        print(
+            f"✅ CodeScene Code Health Quality Gates PASSED! ({len(results)} files checked)"
+        )
+        return 0
+
+    print(f"❌ CodeScene Quality Gates: {quality_gates.upper()}")
+    print(f"Found {len(degraded_files)} degraded file(s):\n")
+
+    for f in degraded_files:
+        print(f"📁 {f.get('name')}:")
+        for finding in f.get("findings", []):
+            cat = finding.get("category")
+            for detail in finding.get("change-details", []):
+                print(f"   • [{cat}] {detail.get('description')}")
+        print()
+
+    return 1
+
+
+if __name__ == "__main__":
+    ref = sys.argv[1] if len(sys.argv) > 1 else "origin/master"
+    sys.exit(check_codescene(base_ref=ref))


### PR DESCRIPTION
## Summary
This PR delivers the robust chat copilot foundation, resolving the dead-thread multimodal image issue, enabling multi-thread background prompt queuing with stream isolation, and preserving rich draft artifact memory across conversation turns.

### Key Changes
1. **Multimodal Image Payload Normalization & Thread Healer** (`07dd3eb`):
   - Introduced `backend/app/services/ai_image_utils.py` to detect and re-encode unsupported formats (AVIF, HEIC, TIFF, BMP) into OpenAI-compliant JPEGs.
   - Sanitizes both incoming prompts and historical turns so corrupt image data never bricks a thread.
   - Repaired poisoned historical threads in local PostgreSQL.

2. **Copilot Supervisor & Model Resolution Resilience** (`993cfea`):
   - Created `backend/app/services/agentic/agent_supervisor.py` with LangGraph multi-tool orchestration (database queries, scraping, LLM post curation).
   - Added model resolution fallback for unified router compatibility.

3. **Browser Diagnostics & Invisible Banner Heuristics** (`64681d8`):
   - Fixed false-positive rate limit flags in `diagnostics.py` caused by unrendered error banners in SPA templates.

4. **Trending Topics Copilot Redirection** (`1d7f409`):
   - Added `TrendingArtifactCard.tsx` and routed trending actions to the `/ai` copilot with interactive cards.

5. **Multi-Thread Prompt Queue & Stream Isolation** (`9a298f7`):
   - Built frontend queue management allowing users to queue prompts across different threads while another thread is actively streaming.
   - Preserves draft artifacts and post IDs in conversational memory so prompts like *"make this post more controversial"* maintain context of the drafted post.
   - Stream parser safely handles partial thought blocks.

### Verification
- **Backend Linting**: `ruff check` & `mypy app` passed (0 errors across 80 files)
- **Backend Tests**: 570 / 570 tests passed (`uv run pytest tests/ -v`)
- **Frontend Linting & Build**: `bun run lint` (155 files clean) & `bun run build` (0 errors)
- **Frontend Tests**: 71 / 71 tests passed across 16 test suites (`bun run test:unit`)
- **Pre-commit Hooks**: Passed on all 5 atomic commits.