### PR TITLE
fix(security): harden perception tools against SSRF bypasses and port crashes (#125)

### DIFF
--- a/backend/app/services/agentic/tools/perception_tools.py
+++ b/backend/app/services/agentic/tools/perception_tools.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import ipaddress
 import logging
+import re
 from typing import Any
+from urllib.parse import SplitResult, urlsplit
 
 from app.services.agentic.tools.common import get_active_page
 from app.services.browser.actions import human_navigation, random_delay
@@ -12,6 +15,102 @@ from app.services.browser.manager import BrowserManager
 from scripts.scrape_trending_topics import extract_topic_tweets, scrape_trending_topics
 
 logger = logging.getLogger(__name__)
+
+ALLOWED_TOPIC_DOMAINS: frozenset[str] = frozenset({"x.com", "twitter.com"})
+ALLOWED_SCHEMES: frozenset[str] = frozenset({"https", "http"})
+ALLOWED_PORTS: frozenset[int | None] = frozenset({None, 80, 443})
+_DNS_LABEL_REGEX = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
+def _is_ip_address(*, host: str) -> bool:
+    """Check if the provided host string is an IPv4 or IPv6 address."""
+    clean_host = host.strip("[]")
+    try:
+        ipaddress.ip_address(clean_host)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_valid_dns_label(*, label: str) -> bool:
+    """Check if a label complies with RFC 1123 hostname standards."""
+    return bool(_DNS_LABEL_REGEX.match(label))
+
+
+def _has_valid_domain_suffix(*, labels: list[str]) -> bool:
+    """Verify that domain labels end in an allowed domain suffix."""
+    if len(labels) < 2:
+        return False
+    suffix = f"{labels[-2]}.{labels[-1]}"
+    return suffix in ALLOWED_TOPIC_DOMAINS
+
+
+def _is_valid_hostname(*, hostname: str | None) -> bool:
+    """Verify that hostname exists, is not an IP, and has valid DNS labels."""
+    if not hostname:
+        return False
+    clean_host = hostname.lower()
+    if _is_ip_address(host=clean_host):
+        return False
+    labels = clean_host.split(".")
+    if not all(_is_valid_dns_label(label=lbl) for lbl in labels):
+        return False
+    return _has_valid_domain_suffix(labels=labels)
+
+
+def _safe_get_port(*, parsed: SplitResult) -> int | None | str:
+    """Safely extract port without crashing on non-numeric or out-of-range port strings."""
+    try:
+        return parsed.port
+    except ValueError:
+        return "invalid"
+
+
+def _has_valid_scheme_and_port(*, scheme: str, port: Any) -> bool:
+    """Validate that the URL scheme and port are standard and allowed."""
+    if scheme.lower() not in ALLOWED_SCHEMES:
+        return False
+    return port in ALLOWED_PORTS
+
+
+def _has_userinfo(*, username: str | None, password: str | None) -> bool:
+    """Check if URL components contain embedded user credentials."""
+    if username is not None:
+        return True
+    return password is not None
+
+
+def _has_disallowed_characters(*, url: str) -> bool:
+    """Check for backslashes, control characters, or non-ASCII characters."""
+    if "\\" in url:
+        return True
+    return any(ord(c) <= 32 or ord(c) >= 127 for c in url)
+
+
+def _parse_url(*, url: str) -> SplitResult | None:
+    """Safely parse a non-empty string into URL split components."""
+    if not isinstance(url, str):
+        return None
+    trimmed = url.strip()
+    if not trimmed or _has_disallowed_characters(url=trimmed):
+        return None
+    try:
+        return urlsplit(trimmed)
+    except ValueError:
+        return None
+
+
+def is_safe_topic_url(*, url: str) -> bool:
+    """Validate that a topic URL belongs to allowed X/Twitter domains to prevent SSRF."""
+    parsed = _parse_url(url=url)
+    if parsed is None:
+        return False
+    port = _safe_get_port(parsed=parsed)
+    if not _has_valid_scheme_and_port(scheme=parsed.scheme, port=port):
+        return False
+    if _has_userinfo(username=parsed.username, password=parsed.password):
+        return False
+    return _is_valid_hostname(hostname=parsed.hostname)
 
 
 async def scrape_live_explore_trends(
@@ -61,6 +160,51 @@ def _format_extracted_tweets(
     ]
 
 
+def _is_disallowed_redirect(*, current_url: Any) -> bool:
+    """Check if the post-navigation destination URL violates domain safety rules."""
+    if not isinstance(current_url, str) or not current_url:
+        return False
+    return not is_safe_topic_url(url=current_url)
+
+
+async def _navigate_and_extract_timeline(
+    *, page: Any, topic_url: str, max_tweets: int
+) -> dict[str, Any]:
+    """Navigate to topic URL and extract Grok summary and tweets."""
+    try:
+        await human_navigation(page=page, url=topic_url)
+    except Exception:
+        await page.goto(topic_url, wait_until="domcontentloaded", timeout=20000)
+
+    current_url = getattr(page, "url", None)
+    if _is_disallowed_redirect(current_url=current_url):
+        logger.warning(
+            "Navigation redirected to unauthorized destination: %s", current_url
+        )
+        return {
+            "success": False,
+            "error": f"Navigation redirected to unauthorized URL '{current_url}'.",
+            "tweets": [],
+            "grok_summary": "",
+        }
+
+    await random_delay(min_sec=1.0, max_sec=2.0)
+    summary = await extract_grok_summary(page)
+    raw_tweets = await extract_topic_tweets(
+        page=page,
+        topic_url=page.url,
+        selectors={},
+    )
+    return {
+        "success": True,
+        "topic_url": topic_url,
+        "grok_summary": summary,
+        "tweets": _format_extracted_tweets(
+            raw_tweets=raw_tweets or [], max_tweets=max_tweets
+        ),
+    }
+
+
 async def scrape_topic_timeline(
     *,
     topic_url: str,
@@ -68,6 +212,17 @@ async def scrape_topic_timeline(
     max_tweets: int = 5,
 ) -> dict[str, Any]:
     """Navigate directly to a specific topic URL on live X, extract Grok summary & top tweets."""
+    if not is_safe_topic_url(url=topic_url):
+        logger.warning(
+            "Blocked potentially malicious or non-whitelisted topic URL: %s", topic_url
+        )
+        return {
+            "success": False,
+            "error": f"Invalid or unauthorized topic URL '{topic_url}'. Only verified X/Twitter domains are allowed.",
+            "tweets": [],
+            "grok_summary": "",
+        }
+
     manager = BrowserManager(user_id=user_id)
     if not manager.session_exists("x"):
         return {
@@ -80,29 +235,9 @@ async def scrape_topic_timeline(
     try:
         async with manager.get_context("x", headless=True) as context:
             page = await get_active_page(context=context)
-
-            try:
-                await human_navigation(page=page, url=topic_url)
-            except Exception:
-                await page.goto(topic_url, wait_until="domcontentloaded", timeout=20000)
-
-            await random_delay(min_sec=1.0, max_sec=2.0)
-            summary = await extract_grok_summary(page)
-
-            raw_tweets = await extract_topic_tweets(
-                page=page,
-                topic_url=page.url,
-                selectors={},
+            return await _navigate_and_extract_timeline(
+                page=page, topic_url=topic_url, max_tweets=max_tweets
             )
-
-            return {
-                "success": True,
-                "topic_url": topic_url,
-                "grok_summary": summary,
-                "tweets": _format_extracted_tweets(
-                    raw_tweets=raw_tweets or [], max_tweets=max_tweets
-                ),
-            }
     except Exception as e:
         logger.error(f"Error scraping topic timeline {topic_url}: {e}")
         return {

--- a/backend/tests/services/agentic/test_perception_tools.py
+++ b/backend/tests/services/agentic/test_perception_tools.py
@@ -1,0 +1,408 @@
+"""Tests for Perception Agentic Tools and SSRF Prevention."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.agentic.tools.perception_tools import (
+    ALLOWED_TOPIC_DOMAINS,
+    inspect_page_session_state,
+    is_safe_topic_url,
+    scrape_live_explore_trends,
+    scrape_topic_timeline,
+)
+
+
+class TestSafeTopicUrlValidation:
+    """Test URL safety validation and SSRF defenses for topic scraping."""
+
+    @pytest.mark.parametrize(
+        "valid_url",
+        [
+            "https://x.com/search?q=AI",
+            "https://x.com/i/trending/1890000000000000001",
+            "https://twitter.com/explore",
+            "http://x.com/search?q=LinkX",
+            "http://twitter.com/hashtag/tech",
+            "https://mobile.x.com/home",
+            "https://mobile.twitter.com/i/trends",
+            "https://sub.x.com/timeline",
+            "https://deep.sub.twitter.com/path",
+            "https://x.com:443/topic",
+            "http://x.com:80/topic",
+            "  https://x.com/search?q=AI  ",
+            "https://x.com/search?q=AI#fragment",
+        ],
+    )
+    def test_allowed_urls(self, valid_url: str) -> None:
+        assert is_safe_topic_url(url=valid_url) is True
+
+    @pytest.mark.parametrize(
+        "ssrf_ip_url",
+        [
+            "http://127.0.0.1",
+            "http://127.0.0.1:8000",
+            "http://localhost",
+            "http://localhost:8000",
+            "http://0.0.0.0:8000",
+            "http://[::1]:8000",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/admin",
+            "http://192.168.1.1/router",
+            "http://172.16.0.1:5432",
+        ],
+    )
+    def test_blocks_localhost_and_internal_ips(self, ssrf_ip_url: str) -> None:
+        assert is_safe_topic_url(url=ssrf_ip_url) is False
+
+    @pytest.mark.parametrize(
+        "internal_host_url",
+        [
+            "http://redis:6379",
+            "http://db:5432",
+            "http://backend:8000",
+            "http://mailcatcher:1080",
+            "http://adminer:8080",
+            "http://traefik:8090",
+        ],
+    )
+    def test_blocks_internal_container_hosts(self, internal_host_url: str) -> None:
+        assert is_safe_topic_url(url=internal_host_url) is False
+
+    @pytest.mark.parametrize(
+        "spoofed_domain_url",
+        [
+            "https://x.com.attacker.com",
+            "https://twitter.com.evil.org",
+            "https://notx.com",
+            "https://fake-x.com",
+            "https://fake-twitter.com",
+            "https://evil.com/x.com",
+            "https://evil.com#x.com",
+            "https://evil.com?target=x.com",
+            "https://x-com.com",
+            "https://attacker.com",
+        ],
+    )
+    def test_blocks_domain_spoofing(self, spoofed_domain_url: str) -> None:
+        assert is_safe_topic_url(url=spoofed_domain_url) is False
+
+    @pytest.mark.parametrize(
+        "dangerous_scheme_url",
+        [
+            "file:///etc/passwd",
+            "file:///proc/self/environ",
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "ftp://x.com/resource",
+            "gopher://127.0.0.1:6379/_INFO",
+            "ws://x.com/feed",
+            "wss://x.com/feed",
+        ],
+    )
+    def test_blocks_dangerous_schemes(self, dangerous_scheme_url: str) -> None:
+        assert is_safe_topic_url(url=dangerous_scheme_url) is False
+
+    @pytest.mark.parametrize(
+        "non_standard_port_url",
+        [
+            "https://x.com:8080/search",
+            "https://x.com:22",
+            "https://x.com:3000",
+            "https://twitter.com:8443",
+        ],
+    )
+    def test_blocks_non_standard_ports(self, non_standard_port_url: str) -> None:
+        assert is_safe_topic_url(url=non_standard_port_url) is False
+
+    @pytest.mark.parametrize(
+        "credentials_url",
+        [
+            "https://user:password@x.com/path",
+            "https://admin@x.com/path",
+            "https://x.com@attacker.com",
+        ],
+    )
+    def test_blocks_userinfo_credentials(self, credentials_url: str) -> None:
+        assert is_safe_topic_url(url=credentials_url) is False
+
+    @pytest.mark.parametrize(
+        "backslash_url",
+        [
+            "https://attacker.com\\.x.com",
+            "https://x.com:443\\attacker.com",
+            "https://x.com\\attacker.com",
+            "https://x.com/\\attacker.com",
+        ],
+    )
+    def test_blocks_backslash_and_parser_differentials(
+        self, backslash_url: str
+    ) -> None:
+        assert is_safe_topic_url(url=backslash_url) is False
+
+    @pytest.mark.parametrize(
+        "control_char_url",
+        [
+            "https://x.com\n/search",
+            "https://x.com\r/search",
+            "https://x.com\t/search",
+            "https://x.com\x00/search",
+            "https://x.com /search",
+        ],
+    )
+    def test_blocks_crlf_and_control_chars(self, control_char_url: str) -> None:
+        assert is_safe_topic_url(url=control_char_url) is False
+
+    @pytest.mark.parametrize(
+        "invalid_port_url",
+        [
+            "https://x.com:abc",
+            "https://x.com:999999999999999999999999999",
+            "https://x.com:-1",
+            "https://x.com:+80",
+            "https://x.com:0",
+        ],
+    )
+    def test_blocks_invalid_ports_without_crashing(self, invalid_port_url: str) -> None:
+        assert is_safe_topic_url(url=invalid_port_url) is False
+
+    @pytest.mark.parametrize(
+        "malformed_label_url",
+        [
+            "https://.x.com",
+            "https://..x.com",
+            "https://...x.com",
+            "https://-x.com",
+            "https://x-.com",
+            "https://sub.-x.com",
+            "https://attacker.com%23.x.com",
+            "https://attacker.com%3f.x.com",
+            "https://attacker.com%2f.x.com",
+        ],
+    )
+    def test_blocks_malformed_domain_labels(self, malformed_label_url: str) -> None:
+        assert is_safe_topic_url(url=malformed_label_url) is False
+
+    @pytest.mark.parametrize(
+        "malformed_input",
+        [
+            "",
+            "   ",
+            "not-a-url",
+            "://invalid",
+            "http://",
+            "https://",
+            None,
+        ],
+    )
+    def test_blocks_malformed_inputs(self, malformed_input: Any) -> None:
+        assert is_safe_topic_url(url=malformed_input) is False
+
+    def test_allowed_topic_domains_constant(self) -> None:
+        assert "x.com" in ALLOWED_TOPIC_DOMAINS
+        assert "twitter.com" in ALLOWED_TOPIC_DOMAINS
+
+
+class TestScrapeTopicTimelineSSRF:
+    """Test SSRF rejection and safe execution in scrape_topic_timeline."""
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "malicious_url",
+        [
+            "http://localhost:8000/api/v1/users",
+            "http://127.0.0.1:8000/admin",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://redis:6379",
+            "file:///etc/passwd",
+            "https://attacker.com/steal-session",
+            "https://x.com.evil.com/fake-topic",
+        ],
+    )
+    async def test_scrape_topic_timeline_blocks_ssrf(self, malicious_url: str) -> None:
+        with patch(
+            "app.services.agentic.tools.perception_tools.BrowserManager"
+        ) as mock_bm_cls:
+            res = await scrape_topic_timeline(
+                topic_url=malicious_url,
+                user_id="user-ssrf-victim",
+                max_tweets=5,
+            )
+
+            assert res["success"] is False
+            assert "Invalid or unauthorized topic URL" in res["error"]
+            assert res["tweets"] == []
+            assert res["grok_summary"] == ""
+            # Critical: BrowserManager must never be instantiated for blocked URLs
+            mock_bm_cls.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_scrape_topic_timeline_valid_url_no_session(self) -> None:
+        with patch(
+            "app.services.agentic.tools.perception_tools.BrowserManager"
+        ) as mock_bm_cls:
+            mock_bm = MagicMock()
+            mock_bm.session_exists.return_value = False
+            mock_bm_cls.return_value = mock_bm
+
+            res = await scrape_topic_timeline(
+                topic_url="https://x.com/search?q=AI",
+                user_id="user-valid-1",
+            )
+            assert res["success"] is False
+            assert "X session not connected" in res["error"]
+            mock_bm.session_exists.assert_called_once_with("x")
+
+    @pytest.mark.anyio
+    async def test_scrape_topic_timeline_valid_url_success(self) -> None:
+        mock_page = AsyncMock()
+        mock_context = AsyncMock()
+        mock_context.pages = [mock_page]
+
+        mock_tweet = MagicMock()
+        mock_tweet.author_handle = "@researcher"
+        mock_tweet.text = "Deep learning breakthrough in 2026"
+        mock_tweet.likes = 120
+        mock_tweet.retweets = 35
+        mock_tweet.replies = 10
+        mock_tweet.views = 5000
+
+        with (
+            patch(
+                "app.services.agentic.tools.perception_tools.BrowserManager"
+            ) as mock_bm_cls,
+            patch(
+                "app.services.agentic.tools.perception_tools.extract_grok_summary",
+                return_value="Summary of breakthrough",
+            ),
+            patch(
+                "app.services.agentic.tools.perception_tools.extract_topic_tweets",
+                return_value=[mock_tweet],
+            ),
+        ):
+            mock_bm = MagicMock()
+            mock_bm.session_exists.return_value = True
+            mock_bm.get_context.return_value.__aenter__.return_value = mock_context
+            mock_bm_cls.return_value = mock_bm
+
+            res = await scrape_topic_timeline(
+                topic_url="https://x.com/search?q=Breakthrough",
+                user_id="user-valid-2",
+                max_tweets=3,
+            )
+            assert res["success"] is True
+            assert res["topic_url"] == "https://x.com/search?q=Breakthrough"
+            assert res["grok_summary"] == "Summary of breakthrough"
+            assert len(res["tweets"]) == 1
+            assert res["tweets"][0]["author"] == "@researcher"
+            assert res["tweets"][0]["likes"] == 120
+
+    @pytest.mark.anyio
+    async def test_scrape_topic_timeline_exception_handling(self) -> None:
+        with patch(
+            "app.services.agentic.tools.perception_tools.BrowserManager"
+        ) as mock_bm_cls:
+            mock_bm = MagicMock()
+            mock_bm.session_exists.return_value = True
+            mock_bm.get_context.side_effect = RuntimeError("Playwright connection lost")
+            mock_bm_cls.return_value = mock_bm
+
+            res = await scrape_topic_timeline(
+                topic_url="https://x.com/search?q=Test",
+                user_id="user-valid-3",
+            )
+            assert res["success"] is False
+            assert "Playwright connection lost" in res["error"]
+
+    @pytest.mark.anyio
+    async def test_scrape_topic_timeline_blocks_post_navigation_redirect(self) -> None:
+        mock_page = AsyncMock()
+        mock_page.url = "http://169.254.169.254/latest/meta-data/"
+        mock_context = AsyncMock()
+        mock_context.pages = [mock_page]
+
+        with patch(
+            "app.services.agentic.tools.perception_tools.BrowserManager"
+        ) as mock_bm_cls:
+            mock_bm = MagicMock()
+            mock_bm.session_exists.return_value = True
+            mock_bm.get_context.return_value.__aenter__.return_value = mock_context
+            mock_bm_cls.return_value = mock_bm
+
+            res = await scrape_topic_timeline(
+                topic_url="https://x.com/search?q=RedirectTest",
+                user_id="user-redirect-victim",
+            )
+            assert res["success"] is False
+            assert "redirected to unauthorized URL" in res["error"]
+            assert res["tweets"] == []
+
+    @pytest.mark.anyio
+    async def test_scrape_topic_timeline_blocks_invalid_port_without_crashing(
+        self,
+    ) -> None:
+        with patch(
+            "app.services.agentic.tools.perception_tools.BrowserManager"
+        ) as mock_bm_cls:
+            res = await scrape_topic_timeline(
+                topic_url="https://x.com:abc/search",
+                user_id="user-port-test",
+            )
+            assert res["success"] is False
+            assert "Invalid or unauthorized topic URL" in res["error"]
+            mock_bm_cls.assert_not_called()
+
+
+class TestOtherPerceptionTools:
+    """Ensure other perception tools continue functioning properly."""
+
+    @pytest.mark.anyio
+    async def test_scrape_live_explore_trends_success(self) -> None:
+        mock_result = MagicMock()
+        mock_result.status = "success"
+        mock_result.topics_found = 5
+        mock_result.topics_scraped = 3
+        mock_result.errors = []
+
+        with patch(
+            "app.services.agentic.tools.perception_tools.scrape_trending_topics",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            res = await scrape_live_explore_trends(user_id="user-test-1", max_topics=3)
+            assert res["status"] == "success"
+            assert res["topics_found"] == 5
+            assert res["topics_scraped"] == 3
+
+    @pytest.mark.anyio
+    async def test_scrape_live_explore_trends_error(self) -> None:
+        with patch(
+            "app.services.agentic.tools.perception_tools.scrape_trending_topics",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Scraper crash"),
+        ):
+            res = await scrape_live_explore_trends(user_id="user-test-1")
+            assert res["status"] == "error"
+            assert "Scraper crash" in res["errors"][0]
+
+    @pytest.mark.anyio
+    async def test_inspect_page_session_state(self) -> None:
+        with patch(
+            "app.services.agentic.tools.perception_tools.BrowserManager"
+        ) as mock_bm_cls:
+            mock_bm = MagicMock()
+            mock_bm.verify_session = AsyncMock(
+                return_value={
+                    "connected": True,
+                    "authenticated": True,
+                    "page_state": "home",
+                }
+            )
+            mock_bm_cls.return_value = mock_bm
+
+            res = await inspect_page_session_state(user_id="user-test-2", platform="x")
+            assert res["connected"] is True
+            assert res["authenticated"] is True


### PR DESCRIPTION
## Summary
Fixes #125 by preventing Server-Side Request Forgery (SSRF) vulnerabilities in agentic perception tools (`scrape_topic_timeline`).

## Problem
Previously, `scrape_topic_timeline(topic_url=...)` accepted any arbitrary URL from LLMs or users and navigated to it via Playwright without validating scheme, domain, IP target, or ports. This could allow attackers to pivot into local backend services (`localhost`, `127.0.0.1`), Docker internal networks (`redis`, `db`), cloud metadata endpoints (`169.254.169.254`), or private intranets.

## Changes
- **Strict Domain Whitelist**: Restrict navigations exclusively to `x.com` and `twitter.com` (including valid subdomains).
- **Scheme & Port Controls**: Enforce `http` / `https` and allowed ports (80, 443, or omitted default).
- **Host & IP Blocking**: Validate and block loopback, private RFC 1918, link-local, and cloud metadata IPs.
- **Parser Differential & Malformed Label Protection**: Guard against backslash differentials (`attacker.com\.x.com`), userinfo credentials (`user:pass@`), control characters, and malformed DNS labels.
- **Post-Navigation Open Redirect Protection**: Validate `page.url` post-navigation to prevent redirects away from permitted domains.
- **Robust Exception Handling**: Prevent crashes on invalid non-numeric or overflow ports (e.g. `:abc`).
- **Test Suite**: Added 100 comprehensive unit and regression tests covering all edge cases, bypass attempts, and valid URL navigations.

## Quality Gates
- `ruff check` and `ruff format`: Passed
- `mypy`: 81 files checked, 0 errors
- CodeScene Code Health Quality Gates: Passed (module complexity < 3.0)
- Pytest: 100/100 tests passed